### PR TITLE
Removing intellectual property from the warnings

### DIFF
--- a/docs/htdocs/info/about/legal/index.html
+++ b/docs/htdocs/info/about/legal/index.html
@@ -24,7 +24,7 @@ Some of the data and software included in the distribution
 may be subject to third-party constraints.
 Users of the data and software are solely responsible for
 establishing the nature of and complying with any such
-intellectual property restrictions.
+restrictions.
 </p>
 
 <p>


### PR DESCRIPTION
There are more things to be concerned about than just intellectual property for a user of this data.
