### PR TITLE
Improving the installation documentation as it was wrong post move to git.

### DIFF
--- a/docs/htdocs/info/docs/api/api_installation.html
+++ b/docs/htdocs/info/docs/api/api_installation.html
@@ -25,7 +25,7 @@ installation of the BioPerl package is included in these instructions.
 Ensembl has produced a video tutorial about how to install the API. 
 Its content is based on this document so you can follow both resources when performing an installation. 
 All commands in this video can be found from the following 
-<a href="ftp://ftp.ebi.ac.uk/pub/databases/ensembl/Helpdesk/API_video_script.txt">document on our FTP site</a>.
+<a href="ftp://ftp.ebi.ac.uk/pub/databases/ensembl/Helpdesk/API_video_script.txt" rel="external">document on our FTP site</a>.
 </p>
 
 <p>[[MOVIE::481]]</p>
@@ -35,60 +35,39 @@ All commands in this video can be found from the following
 <p>
 There are two ways of installing the Perl API. You can <a href="/info/docs/api/api_git.html">clone it from GitHub using Git</a> 
 if you have that available, or you can download the files in gzipped TAR format from our 
-<a href="ftp://ftp.ensembl.org/pub/ensembl-api.tar.gz" rel="external">FTP site</a>, or as a zip file from GitHub as detailed below:
+<a href="ftp://ftp.ensembl.org/pub/ensembl-api.tar.gz" rel="external">FTP site</a>. You will also need <a href='http://bioperl.org/DIST/old_releases/bioperl-1.2.3.tar.gz' rel="external">BioPerl 1.2.3</a>.
 </p>
-
-
-<ol>
-<li>
-<p>
-Create an installation directory:
-</p>
-
-<pre>
-$ cd
-$ mkdir src
-$ cd src
-</pre>
-</li>
-
-<li>
-<p>
-Download the API packages you need:
-</p>
-
-<ul>
-  <li><a href="https://github.com/Ensembl/ensembl/archive/release/[[SPECIESDEFS::ENSEMBL_VERSION]].zip">ensembl</a></li>
-  <li><a href="https://github.com/Ensembl/ensembl-compara/archive/release/[[SPECIESDEFS::ENSEMBL_VERSION]].zip">ensembl-compara</a></li>
-  <li><a href="https://github.com/Ensembl/ensembl-variation/archive/release/[[SPECIESDEFS::ENSEMBL_VERSION]].zip">ensembl-variation</a></li>
-  <li><a href="https://github.com/Ensembl/ensembl-funcgen/archive/release/[[SPECIESDEFS::ENSEMBL_VERSION]].zip">ensembl-funcgen</a></li>
-</ul>
-
 <p>
 <strong>N.B.</strong> We recommend waiting until a few days after a
 release before downloading the new API (or re-downloading after a few
 days), as there may be post-release bug fixes added to the code.
 </p>
-</li>
 
+<ol>
 <li>
 <p>
-Download <a rel="external" href="http://bioperl.org/DIST/old_releases/bioperl-1.2.3.tar.gz">BioPerl 1.2.3</a>
+Create an installation directory and download the distributions:
 </p>
+<pre>
+$ cd
+$ mkdir src
+$ cd src
+$ wget ftp://ftp.ensembl.org/pub/ensembl-api.tar.gz
+$ wget http://bioperl.org/DIST/old_releases/bioperl-1.2.3.tar.gz
+</pre>
 </li>
 
 <li>
 <p>
 Unpack the downloaded files. In the Unix command line, type:
 </p>
-
 <pre>
-$ tar xvfz filename.tar.gz
+$ tar zxvf ensembl-api.tar.gz
+$ tar zxvf bioperl-1.2.3.tar.gz
 </pre>
 
 <p>
-(substituting the name of each file). In Windows, you will need an
-unzipping utility such as <a rel="external" href="http://www.7-zip.org/">7-Zip</a>.
+In Windows, you will need an unzipping utility such as <a rel="external" href="http://www.7-zip.org/">7-Zip</a>.
 </p>
 </li>
 
@@ -145,6 +124,17 @@ set PERL5LIB=C:\src\bioperl-1.2.3;C:\src\ensembl\modules;C:\src\ensembl-compara\
 </pre>
 </li>
 
+<li>
+	<p>In Perl (we do not recommend creating hard-coded dependencies in Perl scripts):</p>
+	<pre>
+use lib "$ENV{HOME}/src/bioperl-1.2.3";
+use lib "$ENV{HOME}/src/ensembl/modules";
+use lib "$ENV{HOME}/src/ensembl-compara/modules";
+use lib "$ENV{HOME}/src/ensembl-variation/modules";
+use lib "$ENV{HOME}/src/ensembl-funcgen/modules";
+	</pre>
+</li>
+
 </ul>
 
 </li>
@@ -157,37 +147,11 @@ set PERL5LIB=C:\src\bioperl-1.2.3;C:\src\ensembl\modules;C:\src\ensembl-compara\
 Sometimes installations can go wrong. You should follow our <a href='/info/docs/api/debug_installation_guide.html'>debugging installation guide</a> to help diagnose and resolve installation issues.
 </p>
 
-<h2 id="win">Additional Tips for Windows users</h2>
+<h2>Tips for Windows and Mac Users</h2>
 
-<ul>
-<li>You will of course need Perl installed to use the API! This is available free of charge from
-<a rel="external" href="http://www.activestate.com/activeperl">ActiveState</a>.</li>
-<li>You will also need to install the DBD::MySQL package using PPM (Perl Package Manager),
-a command-line tool which is bundled with ActivePerl.</li>
-<li>If the existing mysql-driver ("libmysql.dll") doesn't work, replace it - e.g. with the one distributed with "php-5-2-3-win32-installer.msi"</li>
-</ul>
-
-<h2 id='mac'>Additional Tips for Mac users</h2>
-<ul>
-<li>Please install the latest <a rel="external" href='http://dev.mysql.com/downloads/'>client libraries or server</a></li>
-<li>XCode and gcc must be installed. Follow this <a rel="external" href='http://stackoverflow.com/questions/9353444/how-to-use-install-gcc-on-mac-os-x-10-8-xcode-4-4'>guide</a> about how to install this on OSX 10.8</li>
-<li>You will need to install <tt>DBD::mysql</tt> using CPAN</li>
-<li>Users have reported issues with a missing library called <tt>libmysqlclient.18.dylib</tt>. If you followed the normal server installtion this is available under <tt>/usr/local/mysql/lib/</tt>. You must either:
-<ul>
-  <li>Add the MySQL library location to your <tt>DYLD_LIBRARY_PATH</tt> environment variable</li>
-  <li>Use <tt>install_name_tool</tt> to force OSX to find your library</li>
-  <li>Symbolically link the library into <tt>/usr/lib</tt></li>
-  <li>Search <a rel="external" href='https://www.google.co.uk/search?q=libmysqlclient.18.dylib'>Google</a> for more information</li>
-</ul>
-</li>
-</ul>
-
-<h2>Additional Modules</h2>
-
-<p>Additional modules for accessing GO data may be found here:</p>
-<ul>
-<li><a rel="external" href="http://search.cpan.org/~cmungall/go-db-perl-0.01/">http://search.cpan.org/~cmungall/go-db-perl-0.01/</a></li>
-</ul>
+<p>
+	Ensembl can be installed on both Windows and Mac machines however installation is not as straightforward as installing on Linux. We recommend you consult our two blog posts detailing how you can install Ensembl on <a href='http://www.ensembl.info/blog/2014/02/10/ensembl-api-on-windows/' rel="external">Windows</a> and on <a href='http://www.ensembl.info/blog/2013/09/09/installing-perl-dbdmysql-and-ensembl-on-osx/' rel="external">OSX</a>. The fastest way to get up and running with Ensembl on these operating systems is to use our <a href='/info/data/virtual_machine.html'>virtual machine</a>.
+</p>
 
 </body>
 </html>


### PR DESCRIPTION
The guide did not take into account shifting directory names from GitHub and
mentioned some out of date techniques to install Ensembl on other oeprating
systems. The guide is much easier to follow and references our blog posts
now.
