### PR TITLE
Always update the URL when jumping to region

### DIFF
--- a/genoverse/htdocs/genoverse/Ensembl/Menu.js
+++ b/genoverse/htdocs/genoverse/Ensembl/Menu.js
@@ -57,11 +57,7 @@ Ensembl.Panel.GenoverseMenu = Ensembl.Panel.ZMenu.extend({
           var position = browser.getSelectorPosition();
           
           browser.moveTo(position.start, position.end);
-          
-          if (browser.prev.start !== browser.start || browser.prev.end !== browser.end) {
-            browser.updateURL(position);
-          }
-          
+          browser.updateURL(position);
           browser.cancelSelect();
         } else {
           $('.selector_controls .' + cls, '#' + panel.imageId).trigger('click');


### PR DESCRIPTION
Always update the URL when jumping to region otherwise jumps within the current display window will not be triggered.
