### PR TITLE
Get the species trees from the compara db

### DIFF
--- a/widgets/htdocs/widgets/95_SpeciesTree.js
+++ b/widgets/htdocs/widgets/95_SpeciesTree.js
@@ -101,22 +101,12 @@ Ensembl.SpeciesTree.tnt_theme_tree_simple_species_tree = function(species_detail
           .attr("class", "header")
           .text("View tree for");
 
-      filter_menu.append("div")
-          .attr("class", "mammalia")
-          .text("Mammals")
+      for(var j in species_details['filters']) {
+        filter_menu.append("div")
+            .attr("class", j)
+            .text(species_details['filters'][j]);
+      }
 
-      filter_menu.append("div")
-          .attr("class", "sauria")
-          .text("Sauropsids");         
-
-      filter_menu.append("div")
-          .attr("class", "amniota")
-          .text("Amniotes");
-
-      filter_menu.append("div")
-          .attr("class", "neopterygii")
-          .text("Fish");
-          
       filter_menu.append("div")
           .attr("class", "all_species current ")
           .text("All species");         
@@ -306,10 +296,9 @@ Ensembl.SpeciesTree.tnt_theme_tree_simple_species_tree = function(species_detail
           root_node.sort(function(node1, node2) { return species_info[node1.node_name()]['taxon_id'] - species_info[node2.node_name()]['taxon_id']; }); //sorting the tree obj based on taxonid
           
           //populating the species_details obj with all possible trees
-          species_details[j.replace(/_tree/g,'')+'_mammalia_tree_obj']    = root_node.find_node_by_name('Mammalia').data();
-          species_details[j.replace(/_tree/g,'')+'_sauria_tree_obj']      = root_node.find_node_by_name('Sauria').data();
-          species_details[j.replace(/_tree/g,'')+'_amniota_tree_obj']     = root_node.find_node_by_name('Amniota').data();
-          species_details[j.replace(/_tree/g,'')+'_neopterygii_tree_obj'] = root_node.find_node_by_name('Neopterygii').data();
+          for(var k in species_details['filters']) {
+              species_details[j.replace(/_tree/g,'')+'_' + k + '_tree_obj']    = root_node.find_node_by_name(k).data();
+          }
           
           species_details[tree_key] = root_node.data();          
         }

--- a/widgets/htdocs/widgets/95_SpeciesTree.js
+++ b/widgets/htdocs/widgets/95_SpeciesTree.js
@@ -63,42 +63,31 @@ Ensembl.SpeciesTree.tnt_theme_tree_simple_species_tree = function(species_detail
           .attr("class", "header")
           .text("Choose tree");
 
+      function update_tree_div(tree_name) {
+          if(!d3.select(".tree_item." + tree_name).attr("class").match(/current/g)) {
+              d3.selectAll(".tree_item").classed("current", false);
+              d3.select(".tree_item." + tree_name).classed("current", true);
+              var species_type = d3.select(".filter_menu").select(".current").attr("class").replace(/\scurrent/g,'');
+              var tree_type    = tree_name + (species_type.match(/all_species/g) ? "" : "_" + species_type) + "_tree_obj";
+              tree_vis.data(species_details[tree_type]);
+              tree_vis.update();
+              update_tree_label();
+          }
+          d3.select(".tree_menu").style("display", "none");
+      };
+
       tree_menu.append("div")
-          .attr("class", "ncbi")
+          .attr("class", "tree_item ncbi")
           .text("NCBI Taxonomy Tree")
           .on("click", function() {
-              if(d3.select(".ncbi").attr("class").match(/current/g)) {
-                d3.select(".tree_menu").style("display", "none");
-                return;
-              } else {
-                d3.select(".ncbi").classed("current", true);
-                d3.select(".ensembl").classed("current", false);
-                var species_type = d3.select(".filter_menu").select(".current").attr("class").replace(/\scurrent/g,'');
-                var tree_type    = species_type.match(/all_species/g) ? "ncbi_tree_obj" : "ncbi_" + species_type + "_tree_obj";
-                tree_vis.data(species_details[tree_type]);
-                tree_vis.update();
-                update_tree_label();
-                d3.select(".tree_menu").style("display", "none");
-              }
+              return update_tree_div("ncbi");
           });
 
       tree_menu.append("div")
-          .attr("class", "ensembl current")
+          .attr("class", "tree_item ensembl current")
           .text("Ensembl Tree")
           .on("click", function() {
-              if(d3.select(".ensembl").attr("class").match(/current/g)) {
-                d3.select(".tree_menu").style("display", "none");
-                return; 
-              } else {
-                d3.select(".ensembl").classed("current", true);
-                d3.select(".ncbi").classed("current", false); 
-                var species_type = d3.select(".filter_menu").select(".current").attr("class").replace(/\scurrent/g,'');
-                var tree_type    = species_type.match(/all_species/g) ? "newick_tree_obj" : "newick_" + species_type + "_tree_obj";                
-                tree_vis.data(species_details[tree_type]);
-                tree_vis.update();
-                update_tree_label();
-                d3.select(".tree_menu").style("display", "none");
-              }
+              return update_tree_div("ensembl");
           });
 
       d3.select("#species_tree").append("div").attr("class", "iexport_menu resize_menu");
@@ -172,7 +161,7 @@ Ensembl.SpeciesTree.tnt_theme_tree_simple_species_tree = function(species_detail
                   } else {          
                     d3.select(".filter_menu").selectAll("div").classed("current", false);   //remove current from the corresponding div
                     d3.select(this).classed("current", true);                
-                    var tree = d3.select(".tree_menu").select(".current").attr("class").match(/ensembl/g) ? tree = filter_class.match(/all_species/g) ? 'newick_tree_obj' : 'newick_'+ filter_class + "_tree_obj"
+                    var tree = d3.select(".tree_menu").select(".current").attr("class").match(/ensembl/g) ? tree = filter_class.match(/all_species/g) ? 'ensembl_tree_obj' : 'ensembl_'+ filter_class + "_tree_obj"
                                : filter_class.match(/all_species/g) ? 'ncbi_tree_obj' : 'ncbi_'+ filter_class + "_tree_obj";
                     tree_vis.data(species_details[tree]);
                     tree_vis.update();
@@ -328,7 +317,7 @@ Ensembl.SpeciesTree.tnt_theme_tree_simple_species_tree = function(species_detail
       
 
     var hash = {};
-    tnt.tree.node(species_details['newick_tree_obj']).apply(function (node){ 
+    tnt.tree.node(species_details['ensembl_tree_obj']).apply(function (node){
         if(hash[node.node_name()] == undefined ) { 
             hash[node.node_name()] = 1;
             node.property("unique_name", node.node_name());
@@ -343,7 +332,7 @@ Ensembl.SpeciesTree.tnt_theme_tree_simple_species_tree = function(species_detail
       });
 
 	    tree_vis
-	      .data(species_details['newick_tree_obj'])
+	      .data(species_details['ensembl_tree_obj'])
         .id("unique_name")
         .label(joined_label)
         .node_display(tree_vis.node_display().size(4))

--- a/widgets/htdocs/widgets/95_SpeciesTree.js
+++ b/widgets/htdocs/widgets/95_SpeciesTree.js
@@ -161,8 +161,8 @@ Ensembl.SpeciesTree.tnt_theme_tree_simple_species_tree = function(species_detail
                   } else {          
                     d3.select(".filter_menu").selectAll("div").classed("current", false);   //remove current from the corresponding div
                     d3.select(this).classed("current", true);                
-                    var tree = d3.select(".tree_menu").select(".current").attr("class").match(/ensembl/g) ? tree = filter_class.match(/all_species/g) ? 'ensembl_tree_obj' : 'ensembl_'+ filter_class + "_tree_obj"
-                               : filter_class.match(/all_species/g) ? 'ncbi_tree_obj' : 'ncbi_'+ filter_class + "_tree_obj";
+                    var tree_type = d3.select(".tree_menu").select(".current").attr("class").replace(/current/g,'').replace(/tree_item/g,'').replace(/ /g,'');
+                    var tree = tree_type + (filter_class.match(/all_species/g) ? '' : ('_' + filter_class)) + "_tree_obj";
                     tree_vis.data(species_details[tree]);
                     tree_vis.update();
                     update_tree_label();

--- a/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
+++ b/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
@@ -54,7 +54,7 @@ sub render {
 
   # Hardcoded the newick tree details for now until compara has an API and db ready for this (ncbi tree is already available via API)
   my $ensembl_species_tree      = $species_tree_adaptor->fetch_by_method_link_species_set_id_label($mlss->dbID, 'ensembl')->root;
-  $tree_details->{'newick_tree'} = $ensembl_species_tree->newick_format('ryo', $format);
+  $tree_details->{'ensembl_tree'} = $ensembl_species_tree->newick_format('ryo', $format);
  
   for my $species (@{$ncbi_species_tree->get_all_nodes()}) {
      my $ncbi_taxon = $ncbiTaxonAdaptor->fetch_node_by_name($species->name);

--- a/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
+++ b/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
@@ -74,7 +74,7 @@ sub render {
      $sp->{timetree} = $ncbi_taxon->get_tagvalue('ensembl timetree mya');
      $sp->{ensembl_name} = $ncbi_taxon->ensembl_alias_name();
 
-     my $genomeDB =$genomeDBAdaptor->fetch_by_taxon_id($ncbi_taxon->taxon_id());
+     my $genomeDB = $species->genome_db();
      if (defined $genomeDB) {
          $sp->{assembly} = $genomeDB->assembly;
          $sp->{production_name} = ucfirst($genomeDB->name);

--- a/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
+++ b/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
@@ -52,6 +52,15 @@ sub render {
   my $ncbi_species_tree         = $species_tree_adaptor->fetch_by_method_link_species_set_id_label($mlss->dbID, 'ncbi')->root;
   $tree_details->{'ncbi_tree'}  = $ncbi_species_tree->newick_format('ryo', $format); #full tree
 
+  # The filters, e.g. 'Mammalia' => 'mammals (all kinds)'
+  # Filters are defined as MLSS tags like 'filter:Mammalia'
+  $tree_details->{'filters'} = {};
+  foreach my $tag ($mlss->get_all_tags()) {
+      if ($tag =~ m/^filter:(.*)$/) {
+          $tree_details->{'filters'}->{ucfirst $1} = $mlss->get_value_for_tag($tag);
+      }
+  }
+
   # Hardcoded the newick tree details for now until compara has an API and db ready for this (ncbi tree is already available via API)
   my $ensembl_species_tree      = $species_tree_adaptor->fetch_by_method_link_species_set_id_label($mlss->dbID, 'ensembl')->root;
   $tree_details->{'ensembl_tree'} = $ensembl_species_tree->newick_format('ryo', $format);

--- a/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
+++ b/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
@@ -43,14 +43,18 @@ sub render {
   my $compara_db        = $self->hub->database('compara');
   my $genomeDBAdaptor   = $compara_db->get_GenomeDBAdaptor();
   my $ncbiTaxonAdaptor  = $compara_db->get_NCBITaxonAdaptor();
+  my $species_tree_adaptor = $compara_db->get_SpeciesTreeAdaptor();
+  my $mlss_adaptor      = $compara_db->get_MethodLinkSpeciesSetAdaptor();
   my $format            = '%{^n}:%{d}';
   
+  my $mlss              = $mlss_adaptor->fetch_by_method_link_type_species_set_name('SPECIES_TREE', 'collection-ensembl');
   # Getting the different NCBI trees 
-  my $ncbi_species_tree         = Bio::EnsEMBL::Compara::Utils::SpeciesTree->create_species_tree(-compara_dba =>$compara_db); 
+  my $ncbi_species_tree         = $species_tree_adaptor->fetch_by_method_link_species_set_id_label($mlss->dbID, 'ncbi')->root;
   $tree_details->{'ncbi_tree'}  = $ncbi_species_tree->newick_format('ryo', $format); #full tree
 
   # Hardcoded the newick tree details for now until compara has an API and db ready for this (ncbi tree is already available via API)
-  $tree_details->{'newick_tree'} = "(((Caenorhabditis elegans:1,Drosophila melanogaster:1)Ecdysozoa:1,((((((((((((((((((((Pan troglodytes:1,Homo sapiens:1)Homininae:1,Gorilla gorilla gorilla:1)Homininae:1,Pongo abelii:1)Hominidae:1,Nomascus leucogenys:1)Hominoidea:1,((Papio anubis:1,Macaca mulatta:1)Cercopithecinae:1,Chlorocebus sabaeus:1)Cercopithecinae:1)Catarrhini:1,Callithrix jacchus:1)Simiiformes:1,Tarsius syrichta:1)Haplorrhini:1,(Microcebus murinus:1,Otolemur garnettii:1)Strepsirrhini:1)Primates:1,Tupaia belangeri:1)Euarchontoglires:1,((Oryctolagus cuniculus:1,Ochotona princeps:1)Lagomorpha:1,((((Rattus norvegicus:1,Mus musculus:1)Murinae:1,Dipodomys ordii:1)Sciurognathi:1,Ictidomys tridecemlineatus:1)Sciurognathi:1,Cavia porcellus:1)Rodentia:1)Glires:1)Euarchontoglires:1,((Erinaceus europaeus:1,Sorex araneus:1)Insectivora:1,(((Pteropus vampyrus:1,Myotis lucifugus:1)Chiroptera:1,((((Mustela putorius furo:1,Ailuropoda melanoleuca:1)Caniformia:1,Canis lupus familiaris:1)Caniformia:1,Felis catus:1)Carnivora:1,Equus caballus:1)Laurasiatheria:1)Laurasiatheria:1,((((Bos taurus:1,Ovis aries:1)Bovidae:1,Tursiops truncatus:1)Cetartiodactyla:1,Vicugna pacos:1)Cetartiodactyla:1,Sus scrofa:1)Cetartiodactyla:1)Laurasiatheria:1)Laurasiatheria:1)Boreoeutheria:1,(((Loxodonta africana:1,Procavia capensis:1)Afrotheria:1,Echinops telfairi:1)Afrotheria:1,(Dasypus novemcinctus:1,Choloepus hoffmanni:1)Xenarthra:1)Eutheria:1)Eutheria:1,((Macropus eugenii:1,Sarcophilus harrisii:1)Marsupialia:1,Monodelphis domestica:1)Marsupialia:1)Theria:1,Ornithorhynchus anatinus:1)Mammalia:1,((((Taeniopygia guttata:1,Ficedula albicollis:1)Passeriformes:1,((Meleagris gallopavo:1,Gallus gallus:1)Phasianidae:1,Anas platyrhynchos:1)Galloanserae:1)Neognathae:1,Pelodiscus sinensis:1)Testudines + Archosauria group:1,Anolis carolinensis:1)Sauria:1)Amniota:1,Xenopus tropicalis:1)Tetrapoda:1,Latimeria chalumnae:1)Sarcopterygii:1,((((((((Xiphophorus maculatus:1,Poecilia formosa:1)Poeciliinae:1,Oryzias latipes:1)Atherinomorphae:1,Gasterosteus aculeatus:1)Percomorphaceae:1,Oreochromis niloticus:1)Percomorphaceae:1,(Takifugu rubripes:1,Tetraodon nigroviridis:1)Tetraodontidae:1)Percomorphaceae:1,Gadus morhua:1)Acanthomorphata:1,(Danio rerio:1,Astyanax mexicanus:1)Otophysa:1)Clupeocephala:1,Lepisosteus oculatus:1)Neopterygii:1)Euteleostomi:1,Petromyzon marinus:1)Vertebrata:1,(Ciona savignyi:1,Ciona intestinalis:1)Ciona:1)Chordata:1)Bilateria:1,Saccharomyces cerevisiae:1):0;";
+  my $ensembl_species_tree      = $species_tree_adaptor->fetch_by_method_link_species_set_id_label($mlss->dbID, 'ensembl')->root;
+  $tree_details->{'newick_tree'} = $ensembl_species_tree->newick_format('ryo', $format);
  
   for my $species (@{$ncbi_species_tree->get_all_nodes()}) {
      my $ncbi_taxon = $ncbiTaxonAdaptor->fetch_node_by_name($species->name);


### PR DESCRIPTION
Summary of changes:
 - there can be more than 2 trees. The Perl code will fetch all the trees that the compara db is exposing
 - species filters and the default tree are defined in the compara db
