### PR TITLE
EG doesnt use password for anything except userdata dbs. Causing issue at this stage when only host, user and port are passed to this script.

### DIFF
--- a/tools_hive/modules/EnsEMBL/Web/RunnableDB/IDMapper.pm
+++ b/tools_hive/modules/EnsEMBL/Web/RunnableDB/IDMapper.pm
@@ -58,7 +58,7 @@ sub run {
     '--host'      => $self->param('host'),
     '--user'      => $self->param('user'),
     '--port'      => $self->param('port'),
-    '--pass'      => $self->param('pass')
+    $self->param('pass') ? ('--pass'      => $self->param('pass')) : ()
   })->execute({
     'log_file'    => $log_file,
     'output_file' => $self->param('__output_file')


### PR DESCRIPTION
The bug in this script is resulting in the buildup of the following command:

perl ...........metazoa/ensembl-tools/scripts/id_history_converter/IDmapper.pl --port 4160  --pass  --user ensro --host mysql-eg-staging-1.ebi.ac.uk --species Aedes_aegypti ......

Thus 'pass' key is being assigned value '--user'.