### PR TITLE
update to VEP docs reflecting move to Bio::DB::HTS module from faidx_xs

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_cache.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_cache.html
@@ -5,67 +5,67 @@
 </head>
 
 <body>
-    
+
 <div>
-	
+
 	<div style="float:right"><img src="/img/vep_logo.png"/></div>
-	
+
 	<h1 id="top"><span style="color:#006">Variant Effect Predictor</span> <img src="/i/16/database.png"> <span style="color:#666">Caches and databases</span></h1>
-	<hr/>	
-	
+	<hr/>
+
 	<p> The VEP script can use a variety of data sources to retrieve transcript
 	information that is used to predict consequence types. </p>
-    
+
     <p> Using a local cache is the most efficient way to use the VEP; we would
     encourage users to use the cache wherever possible. Caches are easy to
     download and set up using the <a
     href="vep_download.html#installer">installer</a>. Follow the <a
     href="vep_tutorial.html">tutorial</a> for a simple guide.</p>
-	
-	
+
+
 	<h2 id="cache">Using the cache</h2>
-	
+
     <p> Using the cache (<a href="vep_options.html#opt_cache">--cache</a>) is
     the fastest and most efficient way to use the VEP script, as in most cases
     only a single initial network connection is made and most data is read from
     local disk. Use <a href="#offline">offline</a> mode eliminate all network
     connections.</p>
-	
+
     <p> Cache files are compressed using the gzip utility. By default zcat is
     used to decompress the files, although gzcat or gzip itself can be used to
     decompress also - you must have one of these utilities installed in your
     path to use the cache. Use <a
     href="vep_options.html#opt_compress">--compress [command]</a> to change the
     default.</p>
-	
+
 	<hr/>
 	<h2 id="pre">Pre-built caches</h2>
-	
+
 	<p> The easiest solution is to download a pre-built cache for your species;
 	this eliminates the need to connect to the database while the script is
 	running (except when using <a href="#limitations">certain options</a>).
 	Cache files can either be downloaded and unpacked as described here, or
 	automatically downloaded and configured using the <a
 	href="vep_download.html#installer">installer script</a>. <p>
-  
+
   <p> Users interested in RefSeq transcripts may download an alternate cache
   file (eg homo_sapiens_refseq), or a merged file of RefSeq and Ensembl
   transcripts (eg homo_sapiens_merged); remember to specify <a
   href="vep_options.html#opt_refseq">--refseq</a> or <a
   href="vep_options.html#opt_merged">--merged</a> when running the VEP to use
   the relevant cache. </p>
-    
+
     <p> Cache files for popular species: </p>
-    
+
     <ul>
         <li><a href="ftp://ftp.ensembl.org/pub/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/VEP/homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh37.tar.gz">Human <i>(Homo sapiens)</i> - GRCh37</a></li>
         <li><a href="ftp://ftp.ensembl.org/pub/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/VEP/homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz">Human <i>(Homo sapiens)</i> - GRCh38</a></li>
         <li><a href="ftp://ftp.ensembl.org/pub/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/VEP/mus_musculus_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCm38.tar.gz">Mouse <i>(Mus musculus)</i> - GRCm38</a></li>
         <li><a href="ftp://ftp.ensembl.org/pub/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/VEP/danio_rerio_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_Zv9.tar.gz">Zebrafish <i>(Danio rerio)</i> - Zv9</a></li>
     </ul>
-    
+
     <p> Other species: </p>
-    
+
     <ul>
         <li><a href="ftp://ftp.ensembl.org/pub/current_variation/VEP/">Vertebrates</a></li>
         <li><a href="ftp://ftp.ensemblgenomes.org/pub/bacteria/current/vep/">Bacteria</a></li>
@@ -74,14 +74,14 @@
         <li><a href="ftp://ftp.ensemblgenomes.org/pub/plants/current/vep/">Plants</a></li>
         <li><a href="ftp://ftp.ensemblgenomes.org/pub/protists/current/vep/">Protists</a></li>
     </ul>
-    
+
     <p> <b>NB:</b> When using Ensembl Genomes caches, you should use the <a
     href="vep_options.html#opt_cache_version">--cache_version</a> option to
     specify the relevant Ensembl Genomes version number as these differ from the
     concurrent Ensembl/VEP version numbers. </p>
-    
+
     <h4>Instructions for use</h4>
-    
+
 	<ol>
 		<li>
 			Download the archive file for your species</a>
@@ -98,54 +98,54 @@ tar xfz homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]].tar.gz</pre>
 			Run the VEP with the <a href="vep_options.html#opt_cache">--cache</a> option
 		</li>
 	</ol>
-	
+
 	<p> Caches for several species, and indeed different Ensembl releases of the
 	same species, can be stored in the same cache base directory. The files are
 	stored in the following directory hierarchy: $HOME -> .vep -> species ->
 	version -> chromosome </p>
-	
+
 	<p> If a pre-built cache does not exist for your species, please contact the
 	<a href="http://lists.ensembl.org/mailman/listinfo/dev" rel="external">ensembl-dev</a> mailing list and we will
 	endeavour to add your species to the list of downloads. </p>
-	
+
 	<p> It is also possible to build your own <a href="#gtf">cache from a GTF/GFF
 	file</a> and a FASTA file. </p>
-	
+
 	<p> It is possible to use any combination of cache and database; when using
 	the cache, the cache will take preference, with the database being used when
 	the relevant data is not found in the cache. </p>
-	
-	
+
+
 	<hr/>
 	<h2 id="gtf">Building a cache from a GTF or GFF file</h2>
-	
+
 	<p> For species that don't have a publicly available cache, or even an
 	Ensembl core database, it is possible to build a VEP cache using the
 	gtf2vep.pl script included alongside the main script. This requires a GTF or GFF
 	file and a FASTA file containing the reference sequence for the same
 	species. </p>
-	
+
 	<p> The first time you run the script, the
 	Bio::DB::Fasta module will create an index for the FASTA file that allows rapid
 	random access to the sequences corresponding to the transcripts described in
 	the GTF/GFF file; this may take a few minutes to create. </p>
-	
+
 	<p> The script is run as follows: </p>
-	
+
 	<pre class="code">perl gtf2vep.pl -i my_species_genes.gtf -f my_species_seq.fa -d [[SPECIESDEFS::ENSEMBL_VERSION]] -s my_species
 perl variant_effect_predictor.pl -offline -i my_species_variants.vcf -s my_species</pre>
-	
+
 	<p> By default the cache is created in $HOME/.vep/[species]/[version]/ - to
 	change this root directory, use <a href="vep_options.html#opt_dir">--dir</a>. </p>
-	
+
 	<p> This process takes around 15-20 minutes for human (including the time
 	taken to index the FASTA file). Note that caches created in this way can
 	only be used in <a href="#offline">offline mode</a>.
-	
-	
+
+
 	<hr/>
 	<h2 id="fasta">Using FASTA files</h2>
-	
+
     <p> By pointing the VEP to a FASTA file (or directory containing several
     files), it is possible to retrieve reference sequence locally when using
     <a href="vep_options.html#opt_cache">--cache</a> or <a
@@ -154,7 +154,7 @@ perl variant_effect_predictor.pl -offline -i my_species_variants.vcf -s my_speci
     check the reference sequence given in input data (<a
     href="vep_options.html#opt_check_ref">--check_ref</a>) without accessing a
     database. </p>
-    
+
     <p> FASTA files can be set up using the <a
     href="vep_download.html#installer">installer</a>; files set up using the
     installer are automatically detected by the VEP when using <a
@@ -162,21 +162,22 @@ perl variant_effect_predictor.pl -offline -i my_species_variants.vcf -s my_speci
     href="vep_options.html#opt_offline">--offline</a>; you should not need to
     use <a href="vep_options.html#opt_fasta">--fasta</a> to manually specify
     them. </p>
-	
+
 	<p> To enable this the VEP uses one of two modules: </p>
 
   <ul>
     <li>
       The <a rel="external"
-      href="https://github.com/Ensembl/faidx_xs">Faidx/htslib</a> Perl XS
-      module. This module uses compiled C code and can access compressed
+      href="https://github.com/Ensembl/Bio-HTS">Bio::DB::HTS</a> Perl XS
+      module with <a href="http://www.htslib.org">HTSlib</a>. This module
+      uses compiled C code and can access compressed
       (bgzipped) or uncompressed FASTA files. It is set up by the VEP <a
       href="vep_download.html#installer">installer</a>.
     </li>
     <li>
       The <a rel="external"
       href="http://search.cpan.org/~cjfields/BioPerl-1.6.901/Bio/DB/Fasta.pm">Bio::DB::Fasta</a>
-      module. This may be used on systems where installation of the Faidx
+      module. This may be used on systems where installation of the Bio::DB::HTS
       module has not been possible. It can access only uncompressed FASTA
       files. It is also set up by the VEP installer
       and comes as part of the BioPerl package.
@@ -189,7 +190,7 @@ perl variant_effect_predictor.pl -offline -i my_species_variants.vcf -s my_speci
 	system. On subsequent runs the index does not need to be rebuilt (if the
 	FASTA file has been modified, the VEP will force a rebuild of the index).
 	</p>
-	
+
 	<p> Ensembl provides suitable reference FASTA files as downloads from its
 	FTP server. See the <a href="/info/data/ftp/index.html">Downloads</a> page
 	for details. You should preferably use the installer as described above to
@@ -198,42 +199,42 @@ perl variant_effect_predictor.pl -offline -i my_species_variants.vcf -s my_speci
 	"primary_assembly" file for your species. You should use the unmasked
 	(without "_rm" or "_sm" in the name) sequences. Note that the VEP requires
 	that the file be either unzipped (Bio::DB::Fasta) or unzipped and then
-  recompressed with bgzip (Faidx) to run; when unzipped these files can be very
+  recompressed with bgzip (Bio::DB::HTS::Faidx) to run; when unzipped these files can be very
 	large (25GB for human). An example set of commands for setting up the data
 	for human follows: </p>
-	
+
 	<pre class="code">wget ftp://ftp.ensembl.org/pub/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
 gzip -d Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
 bgzip Homo_sapiens.GRCh38.dna.primary_assembly.fa
 perl variant_effect_predictor.pl -i input.vcf --offline --hgvs --fasta Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz</pre>
-	
-	
+
+
 	<hr/>
 	<h2 id="convert">Convert with tabix</h2>
-    
+
     <p> For users with <a rel="external" href="http://samtools.sourceforge.net/tabix.shtml"
     target="_blank">tabix</a> installed on their systems, the speed of
     retrieving existing co-located variants can be greatly improved by
     converting the cache files using the supplied script, convert_cache.pl. This
     replaces the plain-text, chunked variant dumps with a single tabix-indexed
     file per chromosome. The script is simple to run: </p>
-    
+
     <pre class="code">perl convert_cache.pl -species [species] -version [vep_version]</pre>
-    
+
     <p> To convert all species and all versions, use "all": </p>
-    
+
     <pre class="code">perl convert_cache.pl -species all -version all</pre>
-    
+
     <p> A full description of the options can be seen using <b>--help</b>. When complete, the VEP should
     automatically detect the converted cache and use this in place. Note that
     tabix and bgzip must be installed on your system to use a converted cache.
     </p>
-    
+
 	<hr/>
 	<h2 id="limitations">Limitations of the cache</h2>
-	
+
 	<p> The cache stores the following information: </p>
-	
+
 	<ul>
 		<li>Transcript location, sequence, exons and other attributes</li>
 		<li>Gene, protein and HGNC identifiers for each transcript (where
@@ -242,10 +243,10 @@ perl variant_effect_predictor.pl -i input.vcf --offline --hgvs --fasta Homo_sapi
 		<li>Regulatory regions</li>
 		<li>Predictions and scores for SIFT, PolyPhen</li>
 	</ul>
-	
+
 	<p> It does not store any information pertaining to, and therefore cannot be
 	used for, the following: </p>
-	
+
 	<ul>
 		<li>Frequency filtering of input (<a href="vep_options.html#opt_check_frequency">--check_frequency</a>) on populations not included in the cache. The human cache currently includes frequency data for the combined 1000 Genomes phase 1 population (ALL), the continental level populations (AFR, AMR, ASN, EUR), and the two NHLBI-ESP populations (AA, EA). It does <b>not</b> contain frequencies for national level (e.g. CEU, YRI) populations.</li>
 		<li>HGVS names (<a href="vep_options.html#opt_hgvs">--hgvs</a>) - to retrieve these you must additionally point
@@ -255,79 +256,79 @@ perl variant_effect_predictor.pl -i input.vcf --offline --hgvs --fasta Homo_sapi
 		<li>Using variant identifiers as input (<a href="vep_options.html#opt_format">--format id</a>)</li>
 		<li>Finding overlapping structural variants (<a href="vep_options.html#opt_check_sv">--check_sv</a>)</li>
 	</ul>
-	
+
     <p> Enabling one of these options with <a href="vep_options.html#opt_cache">--cache</a> will cause the script
     to warn you in its status output with something like the following: </p>
-	
+
 	<pre class="code"> 2011-06-16 16:24:51 - INFO: Database will be accessed when using --hgvs </pre>
-    
-    
+
+
 	<hr/>
 	<h2 id="privacy">Data privacy</h2>
-	
+
 	<p> When using the public database servers, the VEP script requests
 	transcript and variation data that overlap the loci in your input file. As
 	such, these coordinates are transmitted over the network to a public server,
 	which may not be suitable for those with sensitive or private data. Users
 	should note that <b>only</b> the coordinates are transmitted to the server;
 	no other information is sent. </p>
-	
+
 	<p> By using a full downloaded cache (preferably in <a
 	href="#offline">offline mode</a>) or a local database, it is possible to
 	avoid completely any network connections to public servers, thus preserving
 	absolutely the privacy of your data. </p>
-	
-	
+
+
 	<hr/>
 	<h2 id="offline">Offline mode</h2>
-	
+
 	<p> It is possible to run the VEP in a offline mode that does not use the
 	database, and does not require a standard installation of the Ensembl API.
     This means users require only perl (version 5.8 or greater) and the either
     zcat, gzcat or gzip utilities. To enable this mode, use the flag
     <a href="vep_options.html#opt_offline">--offline</a>. </p>
-	
+
     <p> The simplest way to set up your system is to use the <a
     href="vep_download.html#installer">installer script</a>, INSTALL.pl. This
     will download the required dependencies to your system, and download and set
     up any cache files that you require.</p>
-	
+
     <p> The <a href="#limitations">limitations</a> described above apply
     absolutely when using offline mode. For example, if you specify <a
     href="vep_options.html#opt_offline">--offline</a> and <a
     href="vep_options.html#opt_check_sv">--check_sv</a>, the script will report
     an error and refuse to run. </p>
-	
+
     <p> All other features, including the ability to use <a
     href="vep_custom.html">custom annotations</a> and <a
     href="vep_plugins.html">plugins</a>, are accessible in offline mode. </p>
-	
-	
+
+
 	<hr/>
 	<h2 id="public">Public database servers</h2>
-	
+
     <p> By default, the script is configured to connect to Ensembl's public
     MySQL instance at ensembldb.ensembl.org. For users in the US (or for any
     user geographically closer to the East coast of the USA than to Ensembl's
     data centre in Cambridge, UK), a mirror server is available at
     useastdb.ensembl.org. To use the mirror, use the flag <a
     href="vep_options.html#opt_host">--host</a> useastdb.ensembl.org </p>
-	
+
     <p> Users of Ensembl Genomes species (e.g. plants, fungi, microbes) should
     use their public MySQL instance; the connection parameters for this can be
     automatically loaded by using the flag <a
     href="vep_options.html#opt_genomes">--genomes</a> </p>
-	
+
 	<p> Users with small data sets (100s of variants) should find using the
 	default connection settings adequate. Those with larger data sets, or those
 	who wish to use the script in a batch manner, should consider one of the
 	alternatives below. </p>
-	
-	
-	
+
+
+
 	<hr/>
 	<h2 id="local">Using a local database</h2>
-	
+
     <p> It is possible to set up a local MySQL mirror with the databases for
     your species of interest installed. For instructions on installing a local
     mirror, see <a href="/info/docs/webcode/mirror/install/ensembl-data.html"
@@ -338,11 +339,11 @@ perl variant_effect_predictor.pl -i input.vcf --offline --hgvs --fasta Homo_sapi
     installed. In order to find co-located variations or to use SIFT or
     PolyPhen, it is also necessary to install the relevant variation database
     (e.g. homo_sapiens_variation_[[SPECIESDEFS::ENSEMBL_VERSION]]_38). </p>
-	
+
 	<p> Note that unless you have custom data to insert in the database, in most
 	cases it will be much more efficient to use a <a href="#pre">pre-built
 	cache</a> in place of a local database. </p>
-	
+
     <p> To connect to your mirror, you can either set the connection parameters
     using <a href="vep_options.html#opt_host">--host</a>, <a
     href="vep_options.html#opt_port">--port</a>, <a
@@ -350,7 +351,7 @@ perl variant_effect_predictor.pl -i input.vcf --offline --hgvs --fasta Homo_sapi
     href="vep_options.html#opt_password">--password</a>, or use a registry file.
     Registry files contain all the connection parameters for your database, as
     well as any species aliases you wish to set up: </p>
-	
+
 	<pre class="code">
 use Bio::EnsEMBL::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Variation::DBSQL::DBAdaptor;
@@ -378,14 +379,14 @@ Bio::EnsEMBL::Variation::DBSQL::DBAdaptor->new(
 
 Bio::EnsEMBL::Registry->add_alias("Homo_sapiens","human");
 	</pre>
-	
+
 	<p> For more information on the registry and registry files, see <a
 	href="/info/docs/api/registry.html" target="_blank">here</a>. </p>
-	
-	
+
+
 	<hr/>
 	<h2 id="build">Building your own cache</h2>
-	
+
 	<p> It is possible to build your own cache using the VEP script. <span
 	style="color:red;">You should <b>NOT</b> use this command when connected to
 	the public MySQL instances</span> - the process takes a long time, meaning
@@ -393,13 +394,13 @@ Bio::EnsEMBL::Registry->add_alias("Homo_sapiens","human");
 	reasonable use policy on the public servers. You should either download one
 	of the pre-built caches, or create a <a href="#local">local</a> copy of your
 	database of interest to build the cache from. </p>
-	
+
 	<p> You may wish to build a full cache if you have a custom Ensembl database
 	with data not found on the public servers, or you may wish to create a
 	minimal cache covering only a certain set of chromosome regions. Cache files
 	are compressed using the gzip utility; this must be installed in your path
 	to write cache files. </p>
-	
+
     <p> To build a cache "on-the-fly", use the <a
     href="vep_options.html#opt_cache">--cache</a> and <a
     href="vep_options.html#opt_write_cache">--write_cache</a> flags when you run
@@ -411,18 +412,18 @@ Bio::EnsEMBL::Registry->add_alias("Homo_sapiens","human");
     your data covers a relatively small proportion of your genome of interest
     (for example, a few genes of interest), it can be OK to use the public MySQL
     servers when building a partial cache. </p>
-	
+
 	<pre class="code">perl variant_effect_predictor.pl -cache -dir /my/cache/dir/ -write_cache -i input.txt</pre>
-	
+
     <p> To build a cache from scratch, use the flag <a
     href="vep_options.html#opt_build">--build all</a> or e.g. <a
     href="vep_options.html#opt_build">--build 1-5,X</a> to build just a subset
     of chromosomes. You do not need to specify any of the usual input options
     when building a cache:</p>
-	
+
 	<pre class="code">perl variant_effect_predictor.pl -host dbhost -user username -pass password -port 3306 -build 21 -dir /my/cache/dir/</pre>
-	
-	
+
+
 	<table class="ss" style="width:75%;">
 		<tr>
 			<th>Normal mode</th>
@@ -435,10 +436,10 @@ Bio::EnsEMBL::Registry->add_alias("Homo_sapiens","human");
 			<td valign="middle"><a href="/img/vep_cache_build.png"><img src="/img/vep_cache_build_thumb.png" /></a></td>
 		</tr>
 	</table>
-	
+
 	<hr/>
 	<h2 id="technical">Technical information</h2>
-	
+
 	<p> <span style="color:red;">ADVANCED</span> The cache consists of
 	compressed files containing listrefs of serialised objects. These objects
 	are initially created from the database as if using the Ensembl API
@@ -447,9 +448,9 @@ Bio::EnsEMBL::Registry->add_alias("Homo_sapiens","human");
 	dumped to disk. This means that they will not behave in exactly the same way
 	as an object retrieved from the database when writing, for example, a plugin
 	that uses the cache. </p>
-	
+
 	<p>The following hash keys are deleted from each transcript object: </p>
-	
+
 	<ul>
 		<li><b>analysis</b></li>
 		<li><b>created_date</b></li>
@@ -472,13 +473,13 @@ Bio::EnsEMBL::Registry->add_alias("Homo_sapiens","human");
 		<pre class="code">$transcript->{_variation_effect_feature_cache}->{mapper}</pre>
 		</li>
 	</ul>
-	
+
 	<p> As mentioned above, a special hash key "_variation_effect_feature_cache"
 	is created on the transcript object and used to cache things used by the VEP
 	in predicting consequences, things which might otherwise have to be fetched
 	from the database. Some of these are stored in place of equivalent keys that
 	are deleted as described above. The following keys and data are stored: </p>
-	
+
 	<ul>
 		<li><b>introns</b> : listref of intron objects for the transcript. The adaptor,
 		analysis, dbID, next, prev and seqname keys are stripped from each
@@ -501,10 +502,10 @@ Bio::EnsEMBL::Registry->add_alias("Homo_sapiens","human");
 		as returned by e.g.
 		<pre class="code">$protein_function_prediction_matrix_adaptor->fetch_by_analysis_translation_md5('sift', md5_hex($transcript-{_variation_effect_feature_cache}->{peptide}))</pre></li>
 	</ul>
-	
+
 	<p> Similarly, some further data is cached directly on the transcript object
 	under the following keys: </p>
-	
+
 	<ul>
 		<li><b>_gene</b> : gene object. This object has all keys but the following
 		deleted: start, end, strand, stable_id</li>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_download.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_download.html
@@ -23,30 +23,30 @@
 </head>
 
 <body>
-    
+
 <style>
 tr:nth-child(odd) {background-color: #f0f0f0;}
 </style>
 <div>
 	<div style="float:right"><img src="/img/vep_logo.png"/></div>
-	
+
 	<h1 id="top"><span style="color:#006">Variant Effect Predictor</span> <img src="/i/16/download.png"> <span style="color:#666">Download and install</span></h1>
 	<hr/>
 	<h2 id="download">Download</h2>
 	<p> The Variant Effect Predictor script can be downloaded as a zip from
 	the Ensembl GitHub site: </p>
-	
+
 	<div class="tinted-box" style="font-size: 16px; padding: 10px; margin: 10px;width: 300px; text-align:center;">
 		<a href="https://github.com/Ensembl/ensembl-tools/archive/release/[[SPECIESDEFS::ENSEMBL_VERSION]].zip"><img src="/i/16/download.png"> Download latest version ([[SPECIESDEFS::ENSEMBL_VERSION]])</a>
 	</div>
-	
+
 	<p>It is included as part of the ensembl-tools module of the Ensembl
 	API - you can find it in the ensembl-tools-release-[[SPECIESDEFS::ENSEMBL_VERSION]]/scripts/variant_effect_predictor/
 	directory.</p>
-		
+
 	<h4 id="versions"> Previous versions: <a href="#versions" onclick="show_hide('versions');"
 	id="a_versions">Show</a> </h4>
-	
+
 	<div id="div_versions" style="display:none;">
 	<ul>
     <li><a href="https://github.com/Ensembl/ensembl-tools/archive/release/82.zip">Download version 82</a> (Ensembl 82) </li>
@@ -75,7 +75,7 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
   <h2 id="new">What's new</h2>
 
   <h4> New in version 83 <i>(December 2015)</i> </h4>
-  
+
   <ul>
     <li>
       Speed:
@@ -88,33 +88,33 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <li>Add <a href="http://exac.broadinstitute.org/" rel="external">ExAC project</a> frequencies with <a href="vep_options.html#opt_maf_exac">--maf_exac</a></li>
     <li><a href="/Help/Glossary?id=521">APPRIS</a> isoform annotations now available with <a href="vep_options.html#opt_appris">--appris</a> and used by <a href="vep_options.html#opt_pick">--pick</a> and others to prioritise VEP annotations</li>
   </ul>
-  
-  
+
+
   <h4 id="history"> Previous version history: <a href="#history"
   onclick="show_hide('history');" id="a_history">Show</a> </h4>
-  
-  <div id="div_history" style="display: none;"> 
+
+  <div id="div_history" style="display: none;">
 
 	<h2 id="new">What's new</h2>
 
   <h4> New in version 82 <i>(September 2015)</i> </h4>
-  
+
   <ul>
-    <li><a href="#installer">Faster FASTA file access</a> using Faidx/htslib and bgzipped FASTA files</li>
+    <li><a href="#installer">Faster FASTA file access</a> using Bio::DB::HTS/htslib and bgzipped FASTA files</li>
     <li><a href="vep_options.html#opt_gene_phenotype">Flag genes</a> with phenotype associations</li>
     <li>Some plugins now available for use via the <a href="/Tools/VEP">web</a> and <a rel="external" href="http://rest.ensembl.org/#VEP">REST</a> interfaces</li>
   </ul>
 
 	<h4> New in version 81 <i>(July 2015)</i> </h4>
-	
+
 	<ul>
     <li>Plugin registry means plugins can be installed from the <a href="#installer">VEP installer</a></li>
     <li>GFF format now supported by VEP's <a href="vep_cache.html#gtf">cache converter</a></li>
     <li>Fixes and improvements for sequence retrieval from FASTA files</li>
 	</ul>
-	
+
 	<h4> New in version 80 <i>(May 2015)</i> </h4>
-	
+
 	<ul>
     <li><a href="../vep_formats.html#output">Flag added</a> indicating if an overlapping known variant is associated with a phenotype, disease or trait</li>
     <li>HGVS notations are now 3'-shifted by default (use <a href="vep_options.html#opt_shift_hgvs">--shift_hgvs</a> to force enable/disable)</li>
@@ -122,9 +122,9 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <li>Get the variant class using <a href="vep_options.html#opt_variant_class">--variant_class</a></li>
     <li>CCDS status added to categories used by <a href="vep_options.html#opt_pick">--pick</a> flag (and <a href="vep_other.html#pick">others</a>)</li>
 	</ul>
-	
+
 	<h4> New in version 79 <i>(March 2015)</i> </h4>
-	
+
 	<ul>
     <li>Focus on performance and stability: ~100% faster than version 78 and a new test suite</li>
     <li>New guide to <a href="vep_other.html#faster">getting VEP running faster</a></li>
@@ -132,7 +132,7 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <li><a href="../vep_formats.html#vcfout">VCF output</a> has changed slightly to match output from other tools</li>
     <li>Impact modifier added for each consequence type</li>
 	</ul>
-	
+
   <h4> New in version 78 <i>(December 2014)</i> </h4>
 
   <ul>
@@ -141,18 +141,18 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <li>Get <a href="/Help/Glossary?id=492">transcript support level</a>
     using <a href="vep_options.html#opt_tsl">--tsl</a></li>
   </ul>
-  
+
 	<h4> New in version 77 <i>(October 2014)</i> </h4>
-	
+
 	<ul>
     <li>Get the <a href="http://www.sequenceontology.org/" rel="external">SO</a>
     feature type of regulatory features using <a
     href="vep_options.html#opt_regulatory">--regulatory</a> and <a
     href="vep_options.html#opt_biotype">--biotype</a></li>
 	</ul>
-	
+
 	<h4> New in version 76 <i>(August 2014)</i> </h4>
-	
+
 	<ul>
     <li>VEP now supports caches from multiple assemblies (<a
     href="vep_options.html#opt_assembly">--assembly</a>) on the same software
@@ -178,9 +178,9 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     href="http://rest.ensembl.org/#Variation" rel="external">VEP REST API</a>
     has come out of beta!</li>
 	</ul>
-	
+
 	<h4> New in version 75 <i>(February 2014)</i> </h4>
-	
+
 	<ul>
     <li>let VEP pick one consequence per variant for you using <a
     href="vep_options.html#opt_pick">--pick</a>; includes all
@@ -193,16 +193,16 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <li>Added <a href="vep_options.html#opt_cache_version">--cache_version</a>
     option, primarily to aid Ensembl Genomes users.</li>
 	</ul>
-	
+
 	<h4> New in version 74 <i>(December 2013)</i> </h4>
-	
+
 	<ul>
 		<li>retrieve the <a href="http://genetics.bwh.harvard.edu/pph2/dokuwiki/overview#prediction" rel="external">humDiv PolyPhen prediction</a> instead of humVar using <a href="vep_options.html#opt_humdiv">--humdiv</a></li>
 		<li>source for gene symbol available with <a href="vep_options.html#opt_symbol">--symbol</a></li>
 	</ul>
-	
+
 	<h4> New in version 73 <i>(August 2013)</i> </h4>
-	
+
 	<ul>
 		<li>NHLBI-ESP frequencies available in cache (<a href="vep_options.html#opt_maf_esp">--maf_esp</a>)</li>
 		<li>Pubmed IDs for cited existing variants available in cache (<a href="vep_options.html#opt_pubmed">--pubmed</a>)</li>
@@ -214,16 +214,16 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 		<li>use <a href="vep_options.html#opt_total_length">--total_length</a> to give the total length of cDNA, CDS and protein sequences</li>
         <li>add data from VCF INFO fields when using <a href="vep_custom.html">custom annotations</a></li>
 	</ul>
-	
+
 	<h4> New in version 72 <i>(June 2013)</i> </h4>
-	
+
 	<ul>
 		<li>Speed and stability improvements when using forking</li>
 		<li>Filter VEP results using <a href="vep_filter.html">filter_vep.pl</a></li>
 	</ul>
-	
+
 	<h4> New in version 71 <i>(April 2013)</i> </h4>
-	
+
 	<ul>
 		<li>SIFT predictions now available for Chicken, Cow, Dog, Human, Mouse,
 		Pig, Rat and Zebrafish</li>
@@ -236,25 +236,25 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 		<li><p><b>NOTE:</b> VEP version numbers have now (from release 71)
 		changed to match Ensembl release numbers.</p></li>
 	</ul>
-	
+
 	<h4> New in version 2.8 <i>(December 2012)</i> </h4>
-	
+
 	<ul>
 		<li>Easily filter out common human variants with <a href="vep_options.html#opt_filter_common">--filter_common</a></li>
 		<li>1000 Genomes continental population frequencies now stored in cache
 		files</li>
 	</ul>
-	
+
 	<h4> New in version 2.7 <i>(October 2012)</i> </h4>
-	
+
 	<ul>
 		<li>build VEP cache files offline from GTF and FASTA files</li>
 		<li>support for using FASTA files for sequence lookup in HGVS notations
 		in offline/cache modes</li>
 	</ul>
-	
+
 	<h4> New in version 2.6 <i>(July 2012)</i> </h4>
-	
+
 	<ul>
 		<li>support for <a href="../vep_formats.html#sv">structural variant</a> consequences</li>
 		<li>Sequence Ontology (SO) consequence terms now default</li>
@@ -262,9 +262,9 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 		<li>1000 Genomes global MAF available in cache files</li>
 		<li>improved memory usage</li>
 	</ul>
-	
+
 	<h4> New in version 2.5 <i>(May 2012)</i> </h4>
-	
+
 	<ul>
 		<li>SIFT and PolyPhen predictions now available for RefSeq transcripts</li>
 		<li>retrieve cell type-specific regulatory consequences</li>
@@ -273,9 +273,9 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 		<li>find overlapping structural variants</li>
 		<li>Condel support removed from main script and moved to a plugin</li>
 	</ul>
-	
+
 	<h4> New in version 2.4 <i>(February 2012)</i> </h4>
-	
+
 	<ul>
 		<li>offline mode and new installer script make it easy to use the VEP
 		without the usual dependencies</li>
@@ -286,18 +286,18 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 		<li>enhanced support for LRGs</li>
 		<li>plugins now work on variants called as intergenic</li>
 	</ul>
-	
+
 	<h4> New in version 2.3 <i>(December 2011)</i> </h4>
-	
+
 	<ul>
 		<li>add custom annotations from tabix-indexed files (BED, GFF, GTF, VCF,
 		bigWig)</li>
 		<li>add new functionality to the VEP with user-written plugins</li>
 		<li>filter input on consequence type</li>
 	</ul>
-	
+
 	<h4> New in version 2.2 <i>(September 2011)</i> </h4>
-	
+
 	<ul>
 		<li>SIFT, PolyPhen and Condel predictions and regulatory features now
 		accessible from the <a href="vep_cache.html">cache</a></li>
@@ -315,9 +315,9 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 		<li>VEP script moved to <a href="https://github.com/Ensembl/ensembl-tools/tree/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/scripts/variant_effect_predictor" rel="external">ensembl-tools repo</a></li>
 		<li>Added <a href="vep_options.html#opt_canonical">--canonical</a>, <a href="vep_options.html#opt_per_gene">--per_gene</a> and <a href="vep_options.html#opt_no_intergenic">--no_intergenic</a> options</li>
 	</ul>
-	
+
 	<h4> New in version 2.1 <i>(June 2011)</i> </h4>
-	
+
 	<ul>
 		<li>ability to use local file <a href="vep_cache.html#cache">cache</a> in place of or
 		alongside connecting to an Ensembl database</li>
@@ -329,9 +329,9 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 		<li>modification to output file - Transcript column is now Feature, and is
 		followed by a Feature_type column</li>
 	</ul>
-	
+
 	<h4> New in version 2.0 <i>(April 2011)</i> </h4>
-	
+
 	<ul>
 		<li>support for SIFT, PolyPhen and Condel missense predictions in human</li>
 		<li>per-allele and compound consequence types</li>
@@ -353,46 +353,46 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 		<li>whole-genome mode now more stable</li>
 		<li>finding existing co-located variations now ~5x faster</li>
 	</ul>
-    
+
     </div>
-    
+
     <hr/>
 	<h2 id="requirements">Requirements</h2>
-	
+
 	<p>
 	Version [[SPECIESDEFS::ENSEMBL_VERSION]] of the script requires at least version
   [[SPECIESDEFS::ENSEMBL_VERSION]] of the Ensembl Core
 	and Variation APIs and their relevant dependencies to be installed to use
 	the script. A minimal subset of these can be installed using the supplied <a
 	href="#installer">installer script</a>. </p>
-	
+
 	<p> To perform a full install of the API, see the <a
 	rel="external" href="/info/docs/api/index.html">instructions</a> for details. To analyse regulatory
 	features, the Ensembl Regulation API should also be installed. </p>
-	
+
 	<p> To use the <a href="vep_cache.html#cache">cache</a>, the gzip utility is
 	required (gzip is installed as standard on most Unix and Mac systems). </p>
-	
+
 	<p> To use the VEP in Windows, see the <a
 	href="#windows">instructions for Windows users</a> </p>
-	
-	
+
+
 	<hr/>
-	
-	
-	
+
+
+
 	<h2 id="installer">Installation</h2>
-	
+
 	<p> The VEP installer script makes it easy to set up your environment for
     using the VEP. It will download and configure a minimal set of the Ensembl
     API for use by the VEP, and can also download and configure <a
     href="vep_cache.html#cache">cache</a> and <a
     href="vep_cache.html#fasta">FASTA</a> files for use by the VEP, as well
     as <a href="vep_plugins.html">plugins</a>. </p>
-	
+
 	<p> To use the VEP in Windows, see the <a
 	href="#windows">instructions for Windows users</a> </p>
-	
+
 	<p> Users who already have the latest version of the API installed do not
 	need to run the script, although may find it useful for getting an
 	up-to-date API install (with post-release patches applied), and for
@@ -400,45 +400,45 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 	VEP, and will not affect any other Ensembl API installations. </p>
 
   <p> The script will also attempt to install a Perl::XS module,
-  <a rel="external" href="https://github.com/Ensembl/faidx_xs">Faidx</a>, for
+  <a rel="external" href="https://github.com/Ensembl/Bio-HTS">Bio::DB::HTS</a>, for
   rapid access to bgzipped FASTA files. If this fails, you may add the
   --NO_HTSLIB flag when running the installer; VEP will fall back to using
   Bio::DB::Fasta for this functionality (<a
   href="vep_cache.html#fasta">more details</a>).</p>
-	
+
   <p> The installer script is also useful for users whose systems do not have
   all the modules required by the VEP, specifically DBI and DBI::mysql. After
   configuration using the installer, users can then use the VEP in <a
   href="vep_cache.html#offline">offline mode</a> with a cache, eliminating
   dependency on an Ensembl database (with <a
   href="vep_cache.html#limitations">limitations</a>). </p>
-	
+
 	<h2 id="run_install">Running the installer</h2>
-	
+
 	<p> The installer script is run on the command line as follows: </p>
-	
+
 	<pre class="code"> perl INSTALL.pl [options] </pre>
-	
+
 	<p> Users then follow on-screen prompts. Please heed any warnings, as when
 	the script says it will delete/overwrite something, it really will!</p>
-	
+
 	<p> Most users should not need to add any options, but configuration of the
 	installer is possible with the following flags: </p>
-	
+
 	<table class="ss">
 		<tr>
 			<th>Flag</th>
 			<th>Alternate</th>
 			<th>Description</th>
 		</tr>
-		
+
 		<tr>
 		<tr>
 			<td><pre>--AUTO</pre></td>
 			<td><pre>-a</pre></td>
       <td>
-        Run installer without user prompts. Use "a" (API + Faidx/htslib),
-        "l" (Faidx/htslib only), "c" (cache), "f" (FASTA), "p" (plugins) to specify
+        Run installer without user prompts. Use "a" (API + Bio::DB::HTS/htslib),
+        "l" (Bio::DB::HTS/htslib only), "c" (cache), "f" (FASTA), "p" (plugins) to specify
         parts to install e.g. -a ac for API and cache
 			</td>
 		</tr>
@@ -531,41 +531,41 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <tr>
       <td><pre>--NO_HTSLIB</pre></td>
       <td><pre>-l</pre></td>
-      <td>Don't attempt to install Faidx/htslib</td>
+      <td>Don't attempt to install Bio::DB::HTS/htslib</td>
     </tr>
 	</table>
-	
-	
-	
-	
+
+
+
+
 	<hr/>
-    
-    
+
+
 	<h2 id="windows">Using the VEP in Windows</h2>
-	
+
 	<p> The VEP was developed as a command-line tool, and as a Perl script its
 	natural environment is a Linux system. However, there are several ways you can
 	use the VEP script on a Windows machine: </p>
-	
+
 	<h4 id="virtual"> Virtual machines </h4>
-	
+
 	<p> Using a virtual machine you can run a virtual Linux system in a window on
 	your machine. There are two ways to do this: </p>
-	
+
 	<ol>
 		<li> Download the Ensembl virtual machine image <a
 		href="/info/data/virtual_machine.html">[instructions]</a> </li>
 		<li> Use a virtual machine in the Amazon Elastic Cloud Service (ECS) <a
 		rel="external" href="http://aws.amazon.com/">[Amazon]</a> </li>
 	</ol>
-	
+
 	<h4 id="cygwin"> Cygwin </h4>
-	
+
 	<p> Cygwin is a collection of tools which provide a Linux environment
 	embedded in Windows. It is very simple to install and set up, and requires
 	the fewest compute resources to create a suitable Linux environment for the
 	VEP. Instructions: </p>
-	
+
 	<ol>
 		<li> Download the <a rel="external" href="http://cygwin.com/setup.exe">Cygwin setup program</a> </li>
 		<li> Run the setup program, and click through with the default options
@@ -583,13 +583,13 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     href="#download">download link</a> </li>
 		<li> Run the VEP <a href="#installer">installer</a> </li>
 	</ol>
-	
+
 	<h4 id="activestate"> ActiveState Perl </h4>
-	
+
 	<p> ActiveState provide a version of Perl available for Windows. This can be
 	used to run the VEP on the Windows MS-DOS command line interface.
 	Instructions: </p>
-	
+
 	<ol>
 		<li> Download and install <a
 		rel="external" href="http://www.activestate.com/activeperl/downloads">ActiveState
@@ -620,11 +620,11 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
 		variant_effect_predictor.pl script. Add the command line flag
 		'--compress "gzip -dc"' when running the VEP </li>
 	</ol>
-	
+
   <p><b>NB:</b> Under ActiveState Perl on Windows there is a known issue when
   using cache files including SIFT and/or PolyPhen scores. Users should use
   either a virtual machine or Cygwin as described above. </p>
-	
+
 	</div>
 </div>
 


### PR DESCRIPTION
Changes have been made to the VEP to use Faidx (FASTA indexing from HTSlib) from Bio::DB::HTS rather than its own module, as detailed in the merged pull request at https://github.com/Ensembl/ensembl-tools/pull/12. These documentation changes accompany this.