### PR TITLE
BioPerl GZ archive updated

### DIFF
--- a/docs/htdocs/info/docs/api/api_installation.html
+++ b/docs/htdocs/info/docs/api/api_installation.html
@@ -53,7 +53,7 @@ $ cd
 $ mkdir src
 $ cd src
 $ wget ftp://ftp.ensembl.org/pub/ensembl-api.tar.gz
-$ wget http://bioperl.org/DIST/BioPerl-1.6.1.tar.gz 
+$ wget https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/BioPerl-1.6.1.tar.gz 
 </pre>
 </li>
 


### PR DESCRIPTION
BioPerl website has been re-organized, fetch the GZ archive from CPAN instead.