### PR TITLE
Fix typo

### DIFF
--- a/tools_hive/modules/EnsEMBL/Web/RunnableDB.pm
+++ b/tools_hive/modules/EnsEMBL/Web/RunnableDB.pm
@@ -142,7 +142,7 @@ sub save_results {
 
       if (!$count || $count < 1) {
         if (ref($self) =~ /VEP/) {
-          $self->tools_warning({ 'message' => 'Too may variants to be displayed on the location page', 'type' => 'VEPWarning' });
+          $self->tools_warning({ 'message' => 'Too many variants to be displayed on the location page', 'type' => 'VEPWarning' });
         } else {
           throw exception ('HiveException', "Ticket database: Results could not be saved to ticket database.");
         }


### PR DESCRIPTION
There's a typo in one of the VEP warning messages