### PR TITLE
Cleaning up MySQL client list

### DIFF
--- a/ensembl/htdocs/info/data/mysql.html
+++ b/ensembl/htdocs/info/data/mysql.html
@@ -50,10 +50,18 @@ rel="external">ensembl-dev mailing list archives</a>.
 <h3>MySQL client</h3>
 
 <p>
-Alternatively, you can use a
-MySQL <a href="http://dev.mysql.com/downloads/mysql/">client
-program</a> to query the database directly. However this does require
-knowledge of the complex <a href="/info/docs/api/">database
+Alternatively, you can use a MySQL client program to query the database directly such as:
+</p>
+
+<ul>
+  <li><a href="http://dev.mysql.com/downloads/mysql/">MySQL command line client</a> (available from the MySQL server distribution)</li>
+  <li><a href="http://dev.mysql.com/downloads/workbench/">MySQL workbench</a></li>
+  <li><a href="http://dev.mysql.com/downloads/shell/">MySQL shell</a></li>
+  <li><a href="https://www.sequelpro.com/">SequelPro</a> (macOS only)</li>
+</ul>
+
+<p>
+However this does require knowledge of the complex <a href="/info/docs/api/">database
 schemas</a> used by Ensembl, so we only recommend it if you are unable
 to install our API (e.g. if you have no access to Perl). Also note
 that direct MySQL queries on the database are not suited to retrieve


### PR DESCRIPTION
As suggested by Wojciech Bazant we have clarified the MySQL client you can use to query Ensembl databases. We also expanded the list of clients available