### PR TITLE
Point to the right URL for track hub docs

### DIFF
--- a/docs/htdocs/info/website/adding_trackhubs.html
+++ b/docs/htdocs/info/website/adding_trackhubs.html
@@ -72,7 +72,7 @@ identical in our genome browser.</p>
 of this data service:</p>
 <ul>
 <li><a href="http://genome.ucsc.edu/goldenPath/help/hgTrackHubHelp.html" rel="external">Using UCSC Genome Browser Track Hubs</a></li>
-<li><a href="http://hgwdev-tdreszer.cse.ucsc.edu/goldenPath/help/trackDb/trackDbHub.html" rel="external">Hub Track Database Definition</a></li>
+<li><a href="http://genome.ucsc.edu/goldenPath/help/trackDb/trackDbHub.html" rel="external">Hub Track Database Definition</a></li>
 </ul>
 
 </body>


### PR DESCRIPTION
Highlighted by Ann Zweig we were pointing to the wrong docs. 