### PR TITLE
Modifications to Variation API tutorial

### DIFF
--- a/docs/htdocs/info/docs/api/variation/variation_tutorial.html
+++ b/docs/htdocs/info/docs/api/variation/variation_tutorial.html
@@ -884,7 +884,7 @@ The variant sets can also be retrieved from the structural variants.
 <pre class="code sh_perl">
 # Get the StructuralVariation object
 my $sv_adaptor  = $registry-&gt;get_adaptor( 'human', 'variation', 'structuralvariation' );
-my $sv = $sv_adaptor-&gt;fetch_by_name('esv2663683');
+my $sv = $sv_adaptor-&gt;fetch_by_name('esv3626563');
 
 # Get the structural variation features
 my $svfs = $sv-&gt;get_all_StructuralVariationFeatures();

--- a/docs/htdocs/info/docs/api/variation/variation_tutorial.html
+++ b/docs/htdocs/info/docs/api/variation/variation_tutorial.html
@@ -949,7 +949,7 @@ $registry-&gt;load_registry_from_db(
 
 my $variation_adaptor = $registry-&gt;get_adaptor('mus_musculus', 'variation', 'variation');
 
-my $variation = $variation_adaptor-&gt;fetch_by_name('rs4224828');
+my $variation = $variation_adaptor-&gt;fetch_by_name('rs4224826');
 my $alleles = $variation-&gt;get_all_Alleles();
 
 foreach my $allele (@{$alleles}) {

--- a/docs/htdocs/info/docs/api/variation/variation_tutorial.html
+++ b/docs/htdocs/info/docs/api/variation/variation_tutorial.html
@@ -1521,11 +1521,17 @@ my $slice_adaptor = $registry-&gt;get_adaptor( 'Human', 'Core', 'Slice' );
 # Slice object
 my $slice = $slice_adaptor-&gt;fetch_by_region('chromosome', 3, 125439614, 125462946, 1);
 
+# Variation feature adaptor
+my $vfa = $registry-&gt;get_adaptor('human', 'variation', 'variationfeature');
+
 # Fetch the variation feature objects overlapping the Slice
-my @var_features = @{$slice-&gt;get_all_VariationFeatures()};
+my @var_features = @{$vfa-&gt;fetch_all_by_Slice($slice)};
+
+# Structural variation feature adaptor 
+my $svfa = $registry-&gt;get_adaptor("human","variation","structuralvariationfeature");
 
 # Fetch the structural variation feature objects overlapping the Slice
-my @sv_features = @{$slice-&gt;get_all_StructuralVariationFeatures()};
+my @sv_features = @{$svfa-&gt;fetch_all_by_Slice($slice)};
 
 print "Number of variations: ", scalar @var_features, "\n";
 print "Number of structural variations: ", scalar @sv_features, "\n";
@@ -1552,6 +1558,9 @@ print "Number of structural variations: ", scalar @sv_features, "\n";
 <p>It is also possible to fetch all the variation features overlapping a structural variation feature, using a Slice through a structural variation feature object.</p>
 
 <pre class="code sh_perl">
+# Variation feature adaptor
+my $vf_adaptor = $registry-&gt;get_adaptor('human', 'variation', 'variationfeature');
+
 # Structural variation adaptor
 my $sv_adaptor = $registry-&gt;get_adaptor( 'human', 'variation', 'structuralvariation' );
 # Structural variation object
@@ -1563,7 +1572,7 @@ foreach my $svf (@{$sv-&gt;get_all_StructuralVariationFeatures()}){
   my $slice = $svf-&gt;feature_Slice();
 
   # Fetch the variation feature objects overlapping the Slice
-  my @var_features = @{$slice-&gt;get_all_VariationFeatures()};
+  my @var_features = @{$vf_adaptor-&gt;fetch_all_by_Slice($slice)};
   print "Number of variations: ", scalar (@var_features), "\n";
 }
 </pre>
@@ -1588,6 +1597,9 @@ foreach my $svf (@{$sv-&gt;get_all_StructuralVariationFeatures()}){
 
 <p>And you can do the same with the variation features, for example.</p>
 <pre class="code sh_perl">
+# Structural variation feature adaptor
+my $svf_adaptor = $registry-&gt;get_adaptor("human","variation","structuralvariationfeature");
+
 # Variation adaptor
 my $var_adaptor = $registry-&gt;get_adaptor( 'human', 'variation', 'variation' );
 # Variation object
@@ -1599,7 +1611,7 @@ foreach my $vf (@{$var-&gt;get_all_VariationFeatures()}){
   my $slice = $vf-&gt;feature_Slice();
 
   # Fetch the structural variation feature objects overlapping the Slice
-  my @svf_features = @{$slice-&gt;get_all_StructuralVariationFeatures()};
+  my @svf_features = @{$svf_adaptor-&gt;fetch_all_by_Slice($slice)};
   print "Number of structural variations: ", scalar (@svf_features), "\n";
 }
 </pre>

--- a/docs/htdocs/info/docs/api/variation/variation_tutorial.html
+++ b/docs/htdocs/info/docs/api/variation/variation_tutorial.html
@@ -1365,8 +1365,11 @@ my $sa = $reg-&gt;get_adaptor("human", "core", "slice");
 
 my $slice = $sa-&gt;fetch_by_region('chromosome', 5, 1, 1000000);
 
-# get all structural variation features on the slice
-my $svfs = $slice-&gt;get_all_StructuralVariationFeatures();
+# Get adaptor to StructuralVariationFeature
+my $svfa = $reg-&gt;get_adaptor("human","variation","structuralvariationfeature");
+
+# Get all structural variation features on the slice
+my $svfs = $svfa-&gt;fetch_all_by_Slice($slice);
 
 # StructuralVariationFeature objects
 foreach my $svf (@$svfs) {

--- a/docs/htdocs/info/docs/api/variation/variation_tutorial.html
+++ b/docs/htdocs/info/docs/api/variation/variation_tutorial.html
@@ -343,9 +343,10 @@ my $new_vf = Bio::EnsEMBL::Variation::VariationFeature-&gt;new(
 
 # get the consequence types
 my $cons = $new_vf-&gt;get_all_TranscriptVariations();
+print "Number of TranscriptVariations: " . scalar(@{$cons}) . "\n";
 
-foreach my $con(@{$new_vf-&gt;get_all_TranscriptVariations}) {
-  foreach my $string(@{$con-&gt;consequence_type}) {
+foreach my $con (@{$cons}) {
+  foreach my $string (@{$con-&gt;consequence_type}) {
     print
       "Variation ", $new_vf-&gt;variation_name,
       " at position ", $new_vf-&gt;seq_region_start,


### PR DESCRIPTION
Changes to replace deprecated methods that will be removed in release 88.
Change examples to variants that return results
@ens-lgil Please can you review.