### PR TITLE
Switching to original apache 2 license text

### DIFF
--- a/docs/htdocs/info/about/legal/code_licence.html
+++ b/docs/htdocs/info/about/legal/code_licence.html
@@ -187,7 +187,7 @@ accepting any such warranty or additional liability.</p>
 <h2>APPENDIX: How to apply the Apache License to your work.</h2>
 
 <p>To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
+      boilerplate notice, with the fields enclosed by brackets "{}"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -195,8 +195,23 @@ accepting any such warranty or additional liability.</p>
       same "printed page" as the copyright notice for easier
       identification within third-party archives.</p>
 
-<div class="plain-box">
-<p>Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+<p>Copyright {yyyy} {name of copyright owner}</p>
+
+<p>Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.</p>
+
+<p>You may obtain a copy of the License at</p>
+
+<p class="center">http://www.apache.org/licenses/LICENSE-2.0</p>
+
+<p>Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.</p>
+
+<h1>Ensembl License</h1>
+<p>Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute</p>
 <p>Copyright [2016-2017] EMBL-European Bioinformatics Institute</p>
 
 <p>Licensed under the Apache License, Version 2.0 (the "License");
@@ -211,7 +226,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.</p>
-</div>
 
 <h1>Additional Licenses</h1>
 


### PR DESCRIPTION
**Please wait before accepting in**

Switching back to the original apache license text but also added a new section for Ensembl.
