### PR TITLE
beta url retired for trackhub registry

### DIFF
--- a/docs/htdocs/info/website/public_trackhubs.html
+++ b/docs/htdocs/info/website/public_trackhubs.html
@@ -10,7 +10,7 @@
 
 <p>Ensembl provides support for track hubs as a way of sharing large quantities of annotation
 over the internet. A list of public track hubs is available at the <a
-        href="http://beta.trackhubregistry.org/">Trackhub Registry</a> based at
+        href="http://trackhubregistry.org/">Trackhub Registry</a> based at
       EMBL-EBI.</p>
 <p>You can search this list from the Registry
       itself, in which case you can use direct links that allow you to attach the Track hub


### PR DESCRIPTION
the beta url does not exist any more, updated the documentation to link to the public URL