### PR TITLE
remove old link and scripts references

### DIFF
--- a/docs/htdocs/info/docs/api/core/core_tutorial.html
+++ b/docs/htdocs/info/docs/api/core/core_tutorial.html
@@ -1436,15 +1436,5 @@ $genes = $feature_slice-&gt;get_all_Genes();
 </pre>
 
 
-<h2 id="other_scripts">Other Scripts</h2>
-
-<p>
-Other useful scripts can be found in the <a href="ftp://ftp.ensembl.org/pub/misc-scripts/" target="external">misc-scripts directory</a> on the <a href="/info/data/ftp/index.html">Ensembl FTP</a> site:</p>
-
-<ul>
-  <li>print_alternate_loci.pl - prints alternate loci for a given species and reference chromosome</li>
-  <li>print_refseq_transcripts.pl - prints refseq transcripts for a given species and logic name</li>
-</ul>
-
 </body>
 </html>


### PR DESCRIPTION
Removed outdated/not supported 'Other Scripts' section to avoid potential misguidance, see github issue: https://github.com/pycogent/pycogent/issues/78