### PR TITLE
Update vcf configs

### DIFF
--- a/ensembl/conf/json/capra_hircus_vcf.json
+++ b/ensembl/conf/json/capra_hircus_vcf.json
@@ -1,0 +1,18 @@
+{
+  "collections": [
+    {
+      "id": "nextgen_goat",
+      "species": "capra_hircus",
+      "assembly": "ARS1",
+      "type": "local",
+      "filename_template" : "/capra_hircus/ARS1/variation_genotype/NextGenCapraHircusRemappedARS1.vcf.gz",
+      "chromosomes": [
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
+        "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29"
+      ],
+      "population_prefix": "NextGen:",
+      "sample_prefix": "NextGen:"
+    }
+  ]
+}
+

--- a/ensembl/conf/json/ovis_aries_vcf.json
+++ b/ensembl/conf/json/ovis_aries_vcf.json
@@ -23,6 +23,19 @@
         "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "X"
       ],
       "population_prefix": "NextGen:"
+    },
+    {
+      "id": "sheep_genome_consortium",
+      "species": "ovis_aries",
+      "assembly": "Oar_v3.1",
+      "type": "local",
+      "filename_template" : "/ovis_aries/Oar_v3.1/variation_genotype/###CHR###.filtered_intersect.vcf.gz",
+      "chromosomes": [
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
+        "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "X", "MT"
+      ],
+      "population_prefix": "ISGC:",
+      "sample_prefix": "ISGC:"
     }
   ]
 }


### PR DESCRIPTION
Updated config files with new genotype data for goat and sheep. The data needs to be copied from the production area.