### PR TITLE
RNA Sequence Support for BLAST

### DIFF
--- a/ensembl/conf/SiteDefs.pm
+++ b/ensembl/conf/SiteDefs.pm
@@ -25,7 +25,7 @@ sub update_conf {
   $SiteDefs::ENSEMBL_SECONDARY_SPECIES  = 'Mus_musculus'; # Secondary species
 
   $SiteDefs::ARCHIVE_BASE_DOMAIN        = 'archive.ensembl.org';
-  $SiteDefs::ENSEMBL_REST_URL           = 'http://rest.ensembl.org';  # URL for the REST API
+  $SiteDefs::ENSEMBL_REST_URL           = '//rest.ensembl.org';  # URL for the REST API
   $SiteDefs::ENSEMBL_REST_DOC_URL       = 'https://github.com/Ensembl/ensembl-rest/wiki';
 
   $SiteDefs::GXA                        = 1; #enabling gene expression atlas

--- a/ensembl/conf/SiteDefs.pm
+++ b/ensembl/conf/SiteDefs.pm
@@ -25,7 +25,7 @@ sub update_conf {
   $SiteDefs::ENSEMBL_SECONDARY_SPECIES  = 'Mus_musculus'; # Secondary species
 
   $SiteDefs::ARCHIVE_BASE_DOMAIN        = 'archive.ensembl.org';
-  $SiteDefs::ENSEMBL_REST_URL           = '//rest.ensembl.org';  # URL for the REST API
+  $SiteDefs::ENSEMBL_REST_URL           = 'https://rest.ensembl.org';  # URL for the REST API
   $SiteDefs::ENSEMBL_REST_DOC_URL       = 'https://github.com/Ensembl/ensembl-rest/wiki';
 
   $SiteDefs::GXA                        = 1; #enabling gene expression atlas


### PR DESCRIPTION
This pull request is for ENSWEB-4464. 'U' has been added to check DNA sequence type. The 'U' is replaced by 'T' to prevent BLAST jobs from failing. Flags are used to display a message about this to the user. The sandbox links is: http://ves-hx-78.ebi.ac.uk:8310/Multi/Tools/Blast.