### PR TITLE
Updated compara documentation for e94

### DIFF
--- a/ensembl/htdocs/info/genome/compara/family.html
+++ b/ensembl/htdocs/info/genome/compara/family.html
@@ -16,7 +16,7 @@
 <ol>
 <li>Load proteins from Ensembl and UniProt.</li>
 
-<li>Run HMM search (using <a href="/info/genome/compara/hmm_lib.html">the TreeFam HMM library</a>, excluding the TF6 families) to find the families.</li>
+<li>Run an HMM search on <a href="/info/genome/compara/hmm_lib.html">the TreeFam HMM library</a> to classify the sequences into their families.</li>
 
 <li>Align the families with <a href="http://mafft.cbrc.jp/alignment/software/">Mafft</a>.</li>
 

--- a/ensembl/htdocs/info/genome/compara/homology_method.html
+++ b/ensembl/htdocs/info/genome/compara/homology_method.html
@@ -37,11 +37,19 @@ given internal node of the tree.
 <ol>
 <li>Load a <a href="http://www.ensembl.org/Help/Glossary?id=346">representative translation</a> of each gene from all species used in Ensembl. We currently choose the longest translation annotated by the CCDS project, if any, or the longest protein-coding translation otherwise.</li>
 
-<li>run <a href="http://europepmc.org/abstract/MED/20003500">NCBI Blast+1</a> (refined with SmithWaterman) on every gene against every other (both self and non-self species) in a genome-wise manner. We use the version 2.2.28, with the parameters: <code>-seg no -max_hsps_per_subject 1 -use_sw_tback -num_threads 1</code>.</li>
+<li>Run an HMM search on <a href="/info/genome/compara/hmm_lib.html">the TreeFam HMM library</a> to classify the sequences into their families.</li>
+
+<li>Cluster the genes that did not have any match into additional families:
+<ol>
+<li>run <a href="http://europepmc.org/abstract/MED/20003500">NCBI Blast+1</a> (refined with SmithWaterman) on every orphaned gene against every other (both self and non-self species). We use the version 2.2.28, with the parameters: <code>-seg no -max_hsps_per_subject 1 -use_sw_tback -num_threads 1</code>.</li>
 
 <li>Build a sparse graph of gene relations based on Blast e-values and generate clusters using <a href="https://sourceforge.net/p/treesoft/code/HEAD/tree/">hcluster_sg2</a>. Hcluster_sg has a little insight about the phylogeny of the species (namely: a list of outgroup species), which helps defining pertinent clusters for the ingroup species. We use yeast (Saccharomyces cerevisiae) as an outgroup (via the -C option) and the following command line arguments: <code>-m 750 -w 0 -s 0.34 -O</code>. See below for more details.</li>
+</ol>
+</li>
 
-<li>For each cluster, build a multiple alignment based on the protein sequences using either a combination of multiple aligners, consensified by <a href="http://www.tcoffee.org/Projects/mcoffee/">M-Coffee3</a> or <a href="http://mafft.cbrc.jp/alignment/software/">Mafft4</a> when the cluster is too large, or MCoffee is too long. We use the version 9.03.r1318 of M-Coffee, with the aligner set: mafftgins_msa, muscle_msa, kalign_msa, t_coffee_msa, and the Mafft version 7.113 with the command line options: <code>--auto</code>.</li>
+<li>Large families that would be too complex to analyze are broken down with QuickTree<a href="#fn7" class="fn-link">7</a> to limit them to 400 genes.</li>
+
+<li>For each cluster (family), build a multiple alignment based on the protein sequences using either a combination of multiple aligners, consensified by <a href="http://www.tcoffee.org/Projects/mcoffee/">M-Coffee3</a> or <a href="http://mafft.cbrc.jp/alignment/software/">Mafft4</a> when the cluster is too large, or MCoffee is too long. We use the version 9.03.r1318 of M-Coffee, with the aligner set: mafftgins_msa, muscle_msa, kalign_msa, t_coffee_msa, and the Mafft version 7.113 with the command line options: <code>--auto</code>.</li>
 
 <li>For each aligned cluster, build a phylogenetic tree using <a href="https://github.com/Ensembl/treebest">TreeBeST5</a> using the CDS back-translation of the protein multiple alignment from the original DNA sequences. A rooted tree with internal duplication tags is obtained at this stage, reconciling it against a species tree inferred from the <a href="https://www.ncbi.nlm.nih.gov/taxonomy">NCBI taxonomy</a>. See below for more details.</li>
 
@@ -69,12 +77,12 @@ hcluster_sg<a href="#fn2" class="fn-link">2</a> performs hierarchical clustering
 Hcluster_sg also introduces an additional edge breaking rule: removes an edge between cluster A and B if the number of edges between A and B is smaller than <code>|A|*|B|/10</code>. This heuristic rule removes weak relations which are quite unlikely to be joined at a later step.
 </p>
 
-<!--<p>
+<p>
 As the pipeline has to complete in time for the Ensembl releases, we limit the size of the clusters to 400 genes.
 For larger clusters, we run Mafft<a href="#fn4" class="fn-link">4</a> and QuickTree<a href="#fn7" class="fn-link">7</a>.
 QuickTree is a very fast and efficient to build an unrooted phylogenetic tree. We then find the branch that best splits the cluster into two halves.
 We recursively follow this approach until each sub-cluster is smaller than 400 genes.
-</p>-->
+</p>
 
 <h2 id="treebest">Tree building</h2>
 
@@ -149,10 +157,10 @@ The parameters can be found in <kbd>ensembl-compara/scripts/homology/codeml.ctl.
 
 </li>
 
-<!--<li id="fn7">
+<li id="fn7">
 <a href="http://www.sanger.ac.uk/resources/software/quicktree/">QuickTree</a>: Howe K, Bateman A and Durbin R, "QuickTree: building huge Neighbour-Joining trees of protein sequences." <a href="http://www.ncbi.nlm.nih.gov/pubmed/12424131">Bioinformatics (Oxford, England) 2002;18;11;1546-7</a><br/>
 QuickTree builds an unrooted tree and we recursively split the cluster by finding a branch that roughly holds half of the nodes on each side.
-</li>-->
+</li>
 
 
 </ol>

--- a/ensembl/htdocs/info/genome/compara/homology_method.html
+++ b/ensembl/htdocs/info/genome/compara/homology_method.html
@@ -37,11 +37,11 @@ given internal node of the tree.
 <ol>
 <li>Load a <a href="http://www.ensembl.org/Help/Glossary?id=346">representative translation</a> of each gene from all species used in Ensembl. We currently choose the longest translation annotated by the CCDS project, if any, or the longest protein-coding translation otherwise.</li>
 
-<li>run <a href="http://europepmc.org/abstract/MED/20003500">NCBI Blast+1</a> (refined with SmithWaterman) on every gene against every other (both self and non-self species) in a genome-wise manner. We use the version 2.2.28, with the parameters: -seg no -max_hsps_per_subject 1 -use_sw_tback -num_threads 1.</li>
+<li>run <a href="http://europepmc.org/abstract/MED/20003500">NCBI Blast+1</a> (refined with SmithWaterman) on every gene against every other (both self and non-self species) in a genome-wise manner. We use the version 2.2.28, with the parameters: <code>-seg no -max_hsps_per_subject 1 -use_sw_tback -num_threads 1</code>.</li>
 
-<li>Build a sparse graph of gene relations based on Blast e-values and generate clusters using <a href="https://sourceforge.net/p/treesoft/code/HEAD/tree/">hcluster_sg2</a>. Hcluster_sg has a little insight about the phylogeny of the species (namely: a list of outgroup species), which helps defining pertinent clusters for the ingroup species. We use yeast (Saccharomyces cerevisiae) as an outgroup (via the -C option) and the following command line arguments: -m 750 -w 0 -s 0.34 -O. See below for more details.</li>
+<li>Build a sparse graph of gene relations based on Blast e-values and generate clusters using <a href="https://sourceforge.net/p/treesoft/code/HEAD/tree/">hcluster_sg2</a>. Hcluster_sg has a little insight about the phylogeny of the species (namely: a list of outgroup species), which helps defining pertinent clusters for the ingroup species. We use yeast (Saccharomyces cerevisiae) as an outgroup (via the -C option) and the following command line arguments: <code>-m 750 -w 0 -s 0.34 -O</code>. See below for more details.</li>
 
-<li>For each cluster, build a multiple alignment based on the protein sequences using either a combination of multiple aligners, consensified by <a href="http://www.tcoffee.org/Projects/mcoffee/">M-Coffee3</a> or <a href="http://mafft.cbrc.jp/alignment/software/">Mafft4</a> when the cluster is too large, or MCoffee is too long. We use the version 9.03.r1318 of M-Coffee, with the aligner set: mafftgins_msa, muscle_msa, kalign_msa, t_coffee_msa, and the Mafft version 7.113 with the command line options: --auto.</li>
+<li>For each cluster, build a multiple alignment based on the protein sequences using either a combination of multiple aligners, consensified by <a href="http://www.tcoffee.org/Projects/mcoffee/">M-Coffee3</a> or <a href="http://mafft.cbrc.jp/alignment/software/">Mafft4</a> when the cluster is too large, or MCoffee is too long. We use the version 9.03.r1318 of M-Coffee, with the aligner set: mafftgins_msa, muscle_msa, kalign_msa, t_coffee_msa, and the Mafft version 7.113 with the command line options: <code>--auto</code>.</li>
 
 <li>For each aligned cluster, build a phylogenetic tree using <a href="https://github.com/Ensembl/treebest">TreeBeST5</a> using the CDS back-translation of the protein multiple alignment from the original DNA sequences. A rooted tree with internal duplication tags is obtained at this stage, reconciling it against a species tree inferred from the <a href="https://www.ncbi.nlm.nih.gov/taxonomy">NCBI taxonomy</a>. See below for more details.</li>
 
@@ -49,7 +49,8 @@ given internal node of the tree.
 
 <li>A <a href="gene_tree_stable_id.md">stable ID</a> is assigned to each GeneTree.</li>
 
-<li>There is an extra optional step which calculates the dN/dS values for the orthology relationships of closely related pairs of species, using <a href="http://abacus.gene.ucl.ac.uk/software/paml.html">codeml6</a> with the parameters found in ensembl-compara/scripts/homology/codeml.ctl.hash.</li>
+<li>There is an extra optional step which calculates the dN/dS values for the orthology relationships of closely related pairs of species, using <a href="http://abacus.gene.ucl.ac.uk/software/paml.html">codeml6</a> with the parameters found
+<a href="https://github.com/Ensembl/ensembl-compara/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/scripts/homology/codeml.ctl.hash">here</a>.</li>
 </ol>
 
 
@@ -59,13 +60,13 @@ given internal node of the tree.
 hcluster_sg<a href="#fn2" class="fn-link">2</a> performs hierarchical clustering under mean distance. It reads an input file that describes the similarity between two sequences, and groups two nearest nodes at each step. When two nodes are joined, the distance between the joined node and all the other nodes are updated by mean distance. This procedure is iterated until one of the three rules is met:
 </p>
 <ol>
-<li style="list-style-type: lower-alpha">Do not merge cluster A and B if the total number of edges between A and B is smaller than |A|*|B|/3, where |A| and |B| are the sizes of A and B, respectively. This rule guarantees each cluster is compact.</li>
-<li style="list-style-type: lower-alpha">Do not join A to any other cluster if |A| &lt; 500. This rule avoids huge clusters which may cause computational burden for multiple alignment and tree building as well.</li>
+<li style="list-style-type: lower-alpha">Do not merge cluster A and B if the total number of edges between A and B is smaller than <code>|A|*|B|/3</code>, where <code>|A|</code> and <code>|B|</code> are the sizes of A and B, respectively. This rule guarantees each cluster is compact.</li>
+<li style="list-style-type: lower-alpha">Do not join A to any other cluster if <code>|A| &lt; 500</code>. This rule avoids huge clusters which may cause computational burden for multiple alignment and tree building as well.</li>
 <li style="list-style-type: lower-alpha">Do not join A and B if both A and B contain plant genes or both A and B contain Fungi genes. This rule tries to find animal gene families. TreeFam clustering is done with outgroups.</li>
 </ol>
 
 <p>
-Hcluster_sg also introduces an additional edge breaking rule: removes an edge between cluster A and B if the number of edges between A and B is smaller than |A|*|B|/10. This heuristic rule removes weak relations which are quite unlikely to be joined at a later step.
+Hcluster_sg also introduces an additional edge breaking rule: removes an edge between cluster A and B if the number of edges between A and B is smaller than <code>|A|*|B|/10</code>. This heuristic rule removes weak relations which are quite unlikely to be joined at a later step.
 </p>
 
 <!--<p>

--- a/ensembl/htdocs/info/genome/compara/homology_method.html
+++ b/ensembl/htdocs/info/genome/compara/homology_method.html
@@ -47,7 +47,7 @@ given internal node of the tree.
 </ol>
 </li>
 
-<li>Large families that would be too complex to analyze are broken down with QuickTree<a href="#fn7" class="fn-link">7</a> to limit them to 400 genes.</li>
+<li>Large families that would be too complex to analyse are broken down with QuickTree<a href="#fn7" class="fn-link">7</a> to limit them to 400 genes.</li>
 
 <li>For each cluster (family), build a multiple alignment based on the protein sequences using either a combination of multiple aligners, consensified by <a href="http://www.tcoffee.org/Projects/mcoffee/">M-Coffee3</a> or <a href="http://mafft.cbrc.jp/alignment/software/">Mafft4</a> when the cluster is too large, or MCoffee is too long. We use the version 9.03.r1318 of M-Coffee, with the aligner set: mafftgins_msa, muscle_msa, kalign_msa, t_coffee_msa, and the Mafft version 7.113 with the command line options: <code>--auto</code>.</li>
 
@@ -88,7 +88,7 @@ We recursively follow this approach until each sub-cluster is smaller than 400 g
 
 <p>The CDS
 back-translated protein alignment (i.e., codon alignment) is used to
-build 5 different trees (within TreeBeST<a href="#fn5" class="fn-link">5</a>):</p>
+build five different trees (within TreeBeST<a href="#fn5" class="fn-link">5</a>):</p>
 <ol class="lc-roman">
 <li>a maximum likelihood (ML) tree built, based on the protein alignment with the WAG model, which takes into the account the species tree</li>
 <li>a ML tree built using phyml, based on the codon alignment with the Hasegawa-Kishino-Yano (HKY) model, also taking into account the species tree</li>


### PR DESCRIPTION
in e94 we changed the method used to define the gene-trees. This pull request addresses that, and fixes a few layout issues too.
Emily has already proofread and corrected the changes.

Matthieu