### PR TITLE
ENSWEB-4752: update links to eHive documentation

### DIFF
--- a/docs/htdocs/info/docs/Doxygen/index.html
+++ b/docs/htdocs/info/docs/Doxygen/index.html
@@ -28,7 +28,7 @@ Click on a module below for API documentation:</p>
 <h2>Other documentation</h2>
 
 <h3>eHive</h3>
-<p><a href="https://rawgit.com/Ensembl/ensembl-hive/HEAD/docs/index.html">Documentation for the eHive process management system</a> is available from the <a href="https://github.com/Ensembl/ensembl-hive" rel="external">eHive project repository</a> on GitHub.</p>
+<p>The eHive process management system has a <a href="https://ensembl-hive.readthedocs.io/" rel="external">comprehensive user manual, including API documentation</a>.</p>
 
 <h3>BioPerl</h3>
 

--- a/docs/htdocs/info/docs/eHive.html
+++ b/docs/htdocs/info/docs/eHive.html
@@ -20,7 +20,7 @@ by those who need to run computational pipelines.
 <h2>Code and documentation</h2>
 
 <p>
-eHive system is hosted on <a href="https://github.com/Ensembl/ensembl-hive">GitHub</a> together with its recently updated documentation (see docs/index.html).
+The eHive system is hosted on <a href="https://github.com/Ensembl/ensembl-hive">GitHub</a> and has a <a href="https://ensembl-hive.readthedocs.io/" rel="external">copmrehensive user manual</a>.
 </p>
 
 <p>

--- a/docs/htdocs/info/docs/webcode/mirror/tools/index.html
+++ b/docs/htdocs/info/docs/webcode/mirror/tools/index.html
@@ -55,7 +55,7 @@ but it is not necessary to have accounts enabled in order to run Ensembl Tools.<
 GitHub, if you don't already have it. You will also need to install the 
 <a href="https://code.google.com/p/rose/">Rose</a> ORM suite, available from CPAN.</p>
 
-<p>To use the eHive dispatcher you will also need to follow the <a href="https://rawgit.com/Ensembl/ensembl-hive/HEAD/docs/install.html">eHive installation instructions</a>.</p>
+<p>To use the eHive dispatcher you will also need to follow the <a href="https://ensembl-hive.readthedocs.io/en/version-2.5/quickstart/install.html" rel="external">eHive installation instructions</a>.</p>
 
 <h3>2. Create data files directory</h3>
 


### PR DESCRIPTION
Updated links to eHive documentation. Comprehensive guiHive documentation is not yet in the user manual, so leaving the pointer to README.md for it.