### PR TITLE
Updated example data for web VEP and fixed typo in docs

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_download.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_download.html
@@ -115,7 +115,7 @@ cd ensembl-vep-release-[[SPECIESDEFS::ENSEMBL_VERSION]]/</pre>
 
   <ul>
     <li>The VEP parser is now more permissive for the GFF files (ID attribute only required for genes and transcripts)</li>
-    <li>Add new option <a href="vep_options.html#opt_show_aref_allele">--show_aref_allele</a> to include the allele reference in the VEP default output and the tab output formats</li>
+    <li>Add new option <a href="vep_options.html#opt_show_ref_allele">--show_ref_allele</a> to include the allele reference in the VEP default output and the tab output formats</li>
     <li>Add a warning message when the VEP annotations INFO field hasn't been found/recognised in the VCF input file</li>
     <li>VEP Docker image:
       <ul>

--- a/tools/modules/EnsEMBL/Web/VEPConstants.pm
+++ b/tools/modules/EnsEMBL/Web/VEPConstants.pm
@@ -29,7 +29,7 @@ sub INPUT_FORMATS {
   return [
     { 'value' => 'ensembl', 'caption' => 'Ensembl default',     'example' => qq(1  909238  909238  G/C  +\n3  361464  361464  A/-  +\n5  121187650  121188519  DUP) },
     { 'value' => 'vcf',     'caption' => 'VCF',                 'example' => qq(1  909238  var1  G  C  .  .  .\n3  361463  var2  GA  G  .  .  .\n5  121187650 sv1   .  &lt;DUP&gt;  .  .  SVTYPE=DUP;END=121188519  .) },
-    { 'value' => 'id',      'caption' => 'Variant identifiers', 'example' => qq(rs699\nrs144678492\nCOSM354157) },
+    { 'value' => 'id',      'caption' => 'Variant identifiers', 'example' => qq(rs699\nrs144678492\nRCV000004642) },
     { 'value' => 'hgvs',    'caption' => 'HGVS notations',      'example' => qq(ENST00000207771.3:c.344+626A>T\nENST00000471631.1:c.28_33delTCGCGG) },
     # { 'value' => 'pileup',  'caption' => 'Pileup',              'example' => qq(chr5  881906  T  C) },
   ];


### PR DESCRIPTION
2 small fixes here:

1) A change to the example data on web VEP (The current ID example for GRCh37 is giving mangled data, so we want to hide it)

2) A typo in the 'What's new' part of the web documentation.