### PR TITLE
reduce buffer_size if run with regulatory option

### DIFF
--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -76,6 +76,7 @@ sub prepare_to_dispatch {
     }
 
     $vep_configs->{'regulatory'} = 'yes';
+    $vep_configs->{'buffer_size'} = 500;
   }
 
   # check existing


### PR DESCRIPTION
@sanjay-boddu 
This is a PR which attempts to solve the problem with the 2 tickets running out of memory.

The PR will reduce the buffer size only if VEP is run with regulation option. You can see that on my [sandbox](http://ves-hx2-76.ebi.ac.uk:5040/Homo_sapiens/Tools/VEP/Results?db=core;tl=Ep0MmLprbfgsNNTe-269) it is added to the command line. (I wonder if Get regulatory region consequences: should be default to NO, @sarahhunt ?). 