### PR TITLE
configure VCF file for vervet

### DIFF
--- a/ensembl/conf/json/chlorocebus_sabaeus_vcf.json
+++ b/ensembl/conf/json/chlorocebus_sabaeus_vcf.json
@@ -1,0 +1,14 @@
+{
+  "collections": [
+    {
+      "id": "vervet_EVA_PRJEB22989",
+      "source_name": "PRJEB22989",
+      "species": "chlorocebus_sabaeus",
+      "assembly": "ChlSab1.1",
+      "type": "remote",
+      "use_as_source" : 1,
+      "strict_name_match" : 0,
+      "filename_template" : "ftp://ftp.ebi.ac.uk/pub/databases/eva/PRJEB22988/Svardal_et_al_2017_vervet_monkey_SNPs_imputed_phased.vcf.gz"
+    }
+  ]
+}


### PR DESCRIPTION
We are adding variation data for vervet by reading most of the data from VCF. This makes use of the VCF backend code which has been added by Will.