### PR TITLE
Add 3D viewer to VEP results and it includes other minor display upda…

### DIFF
--- a/tools/htdocs/components/61_panels.css
+++ b/tools/htdocs/components/61_panels.css
@@ -27,4 +27,9 @@ div.location-filter-box { background-color:#666666; }
 
 span.count-highlight { background-color:#667aa6; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; color: white; }
 
+div.in-table-button   { margin-top:4px; }
+div.in-table-button a { background-color:[[MAIN_DARK]]; border-radius:6px; -webkit-border-radius:6px; -moz-border-radius:6px; color:white; text-decoration:none; padding:4px; font-size:
+11px; white-space:nowrap; }
+div.in-table-button a:hover { background-color: [[MAIN_V_DARK]]; }
+
 .no-spinner .spinner { display:  none; }

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -167,7 +167,6 @@ sub content {
     'DOMAINS'             => 'Domains',
     'STRAND'              => 'Feature strand',
     'TSL'                 => 'Transcript support level',
-    'STRAND'              => 'Feature strand',
     'SOMATIC'             => 'Somatic status',
     'PICK'                => 'Selected annotation',
     'SOURCE'              => 'Transcript source',
@@ -195,33 +194,42 @@ sub content {
     push @{$seen_ids{'vars'}}, $row->{'Existing_variation'} if defined $row->{'Existing_variation'} && $row->{'Existing_variation'} =~ /\w+/;
     push @{$seen_ids{'genes'}}, $row->{'Gene'} if defined $row->{'Gene'} && $row->{'Gene'} =~ /\w+/;
 
+    my $gene_id     = $row->{'Gene'};
+    my $feature_id  = $row->{'Feature'};
+    my $consequence = $row->{'Consequence'};
+
     # linkify content
     foreach my $header (@$headers) {
       $row->{$header} = $self->linkify($header, $row->{$header}, $species, $job_data);
-      if ($header eq 'PUBMED' && $row->{$header} && $row->{$header} ne '' && $row->{$header} ne '-') {
-        my @pubmed = split(', ',$row->{$header});
-        if (scalar @pubmed > 5) {
-          my $div_id = 'row_'.$row_id.'_pubmed';
-          $row->{$header} = $self->display_items_list($div_id, 'pubmed', 'PubMed IDs', \@pubmed, \@pubmed);
+      if ($row->{$header} && $row->{$header} ne '' && $row->{$header} ne '-') {
+        if ($header eq 'PUBMED') {
+          $row->{$header} = $self->get_items_in_list($row_id, 'pubmed', 'PubMed IDs', $row->{$header}, $species);
         }
-      } elsif ($header eq 'PHENOTYPES' && $row->{$header} && $row->{$header} ne '' && $row->{$header} ne '-'){
-        my @phenotypes = split(', ',$row->{$header});
-        # prettify format
-        @phenotypes = $self->prettify_phenotypes(\@phenotypes, $species);
-        if (scalar @phenotypes > 3 ) {
-          my $div_id = 'row_'.$row_id.'_phenotype';
-          $row->{$header} = $self->display_items_list($div_id, 'phenotype', 'Phenotype associations', \@phenotypes, \@phenotypes);
-        } else {
-          $row->{$header} = join(",<br />", @phenotypes);
+        elsif ($header eq 'PHENOTYPES'){
+          $row->{$header} = $self->get_items_in_list($row_id, 'phenotype', 'Phenotype associations', $row->{$header}, $species, 3);
         }
-      }
+        elsif ($header eq 'DOMAINS') {
+          $row->{$header} = $self->get_items_in_list($row_id, 'domains', 'Protein domains', $row->{$header}, $species);
+          if ($row->{$header} =~ /PDB-ENSP/i) {
+            my $url = $hub->url({
+              type    => 'Tools',
+              action  => 'VEP/PDB',
+              var     => $row->{'ID'},
+              pos     => $row->{'Protein_position'},
+              cons    => $consequence,
+              g       => $gene_id,
+              t       => $feature_id,
+              species => $species
+            });
 
-      if (!$display_column{$header}) {
-        $display_column{$header} = 1 if ($row->{$header} && $row->{$header} ne '' && $row->{$header} ne '-');
+            $row->{$header} .= qq{<div class="in-table-button"><a href="$url">Protein Structure View</a></div>};
+          }
+        }
+
+        $display_column{$header} = 1 if (!$display_column{$header});
       }
       $row_id++;
     }
-    #$row->{$_} = $self->linkify($_, $row->{$_}, $species, $job_data) for @$headers;
   }
   $display_column{'PHENO'} = 0 if (defined $display_column{'PHENOTYPES'});
 
@@ -924,7 +932,7 @@ sub linkify {
         species => $species
       });
 
-      $new_value .= ($new_value ? ', ' : '').$self->zmenu_link($url, $zmenu_url, $var);
+      $new_value .= ($new_value ? ', ' : '').'<span>'.$self->zmenu_link($url, $zmenu_url, $var).'</span>';
     }
   }
 
@@ -1069,6 +1077,33 @@ sub linkify {
 
   return $new_value;
 }
+
+# Get a list of comma separated items and transforms it into a bullet point list
+sub get_items_in_list {
+  my $self    = shift;
+  my $row_id  = shift;
+  my $type    = shift;
+  my $label   = shift;
+  my $data    = shift;
+  my $species = shift;
+  my $min_items_count = shift;
+
+  $min_items_count ||= 5;
+
+  my @items_list = split(', ',$data);
+
+  # prettify format
+  @items_list = $self->prettify_phenotypes(\@items_list, $species) if ($type eq 'phenotype');
+
+  if (scalar @items_list > $min_items_count) {
+    my $div_id = 'row_'.$row_id.'_'.$type;
+    return $self->display_items_list($div_id, $type, $label, \@items_list, \@items_list);
+  }
+  else {
+    return join('<br />',@items_list);
+  }
+}
+
 
 sub reload_link {
   my ($self, $html, $url_params) = @_;

--- a/tools/modules/EnsEMBL/Web/Configuration/Tools.pm
+++ b/tools/modules/EnsEMBL/Web/Configuration/Tools.pm
@@ -157,7 +157,14 @@ sub populate_tree {
         ressummary  EnsEMBL::Web::Component::Tools::VEP::ResultsSummary
         results     EnsEMBL::Web::Component::Tools::VEP::Results
       )],
-      { 'availability' => 1, 'concise' => 'Variant Effect Predictor results', 'no_menu_entry' => "$action/$function" ne 'VEP/Results' }
+      { 'availability' => 1, 'concise' => 'Variant Effect Predictor results', 'no_menu_entry' => "$action/$function" !~ /^VEP\/(Results|PDB)$/i }
+    ));
+
+    $vep_node->append($self->create_subnode('VEP/PDB', "Protein Structure View",
+      [qw(
+        pdb  EnsEMBL::Web::Component::Tools::VEP::PDB
+      )],
+      { 'availability' => 1, 'concise' => 'Protein Structure View', 'no_menu_entry' => "$action/$function" ne 'VEP/PDB' }
     ));
   }
 

--- a/tools/modules/EnsEMBL/Web/Object/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Object/VEP.pm
@@ -142,8 +142,7 @@ sub handle_download {
     print $content;
 
   # if downloading the result file in any specified format
-  } else {
-
+  } else { 
     my $format    = $hub->param('format')   || 'vcf';
     my $location  = $hub->param('location') || '';
     my $filter    = $hub->param('filter')   || '';
@@ -254,7 +253,7 @@ sub get_form_details {
 
       domains => {
         'label'   => 'Protein domains',
-        'helptip' => 'Report overlapping protein domains from Pfam, Prosite and InterPro',
+        'helptip' => 'Report overlapping protein domains from Pfam, Prosite and InterPro. Link to a protein 3D viewer when the variants overlap a PDB protein model.',
       },
 
       numbers => {

--- a/widgets/htdocs/components/95_PDB.css
+++ b/widgets/htdocs/components/95_PDB.css
@@ -120,11 +120,6 @@ table.pdb_markup h3 {
   vertical-align:top;
 }
 
-a.viewer_btn_link {
-  display:none;
-  color: [[WHITE]] !important;
-}
-
 
 .viewer_helper_btn:before { content: url(/i/16/help.png); }
 .viewer_reset_btn:before  { content: url(/i/16/rev/reload.png); }

--- a/widgets/htdocs/components/95_PDB.js
+++ b/widgets/htdocs/components/95_PDB.js
@@ -72,11 +72,12 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
     this.ensp_var_cons = {};
     this.ensp_length   = {};
 
-    this.max_feature_per_gp   = 150;
-    this.mapping_min_percent  = 50
-    this.mapping_min_length   = 10;
-    this.max_pdb_entries      = 10;
-    this.spinner_waiting_time = 20;
+    this.max_feature_per_gp         = 150;
+    this.mapping_min_percent        = 50;
+    this.mapping_min_percent_length = 50;
+    this.mapping_min_length         = 10;
+    this.max_pdb_entries            = 10;
+    this.spinner_waiting_time       = 20;
 
     this.pdb_id;
     this.pdb_start;
@@ -101,7 +102,7 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
 
       // Transcript portal
       if ($("#ensp_id").length) {
-        panel.ensp_id = $("#ensp_id").html();
+        panel.ensp_id = $("#ensp_id").val();
         panel.ensp_list.push(panel.ensp_id);
         // Get ENSP length
         $.when(panel.get_ens_protein_length()).then(function() {
@@ -111,17 +112,39 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
       }
       // Variation portal
       else {
-        // Get variant ID, the list of ENSP overlapping the variant with the variant coordinates and the variant consequence
-        $.when(panel.get_var_ensp_data()).then(function() {
-          if (panel.ensp_list.length) {
-            // Get the length of all the ENSP
-            $.when(panel.get_ens_protein_length()).then(function() {
+        // Already given the variant position and the ENSP protein
+        if ($('#variant_use_param').length) {
+          // Fetch variant ID
+          panel.var_id = $("#var_id").html();
+          // Retrieve ENSP ID from the provided ENST ID
+          $.when(panel.get_ensp_from_enst($('#variant_enst').val())).then(function() {
+            if (panel.ensp_list.length) {
+              // Var ENSP coordinates
+              var var_pos = $('#variant_pos').val();
+              if (var_pos.indexOf('-') == -1) {
+                var_pos += '-'+var_pos; 
+              }
+              panel.ensp_var_pos[panel.ensp_id] = var_pos;
+              // Var ENSP consequence
+              panel.ensp_var_cons[panel.ensp_id] = $('#variant_cons').val();
+              $('#var_cons').html('('+panel.ensp_var_cons[panel.ensp_id]+')');
               // Get the PDB list of each ENSP
               panel.get_all_pdb_list();
-            });
-          }
-        });
-
+            }
+          });
+        }
+        // Get variant ID, the list of ENSP overlapping the variant with the variant coordinates and the variant consequence
+        else {
+          $.when(panel.get_var_ensp_data()).then(function() {
+            if (panel.ensp_list.length) {
+              // Get the length of all the ENSP
+              $.when(panel.get_ens_protein_length()).then(function() {
+                // Get the PDB list of each ENSP
+                panel.get_all_pdb_list();
+              });
+            }
+          });
+        }
         // Setup variant position (and display it) regarding the selected ENSP
         $('#ensp_list').change(function () {
           panel.ensp_id = $(this).val();
@@ -232,12 +255,9 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
       console.log("    # PDB coords of "+pdb_id+" (on ENSP): "+panel.pdb_start+'-'+panel.pdb_end);
 
       // Display selected ENSP ID and PDB model ID in page
-      $('#mapping_top_ensp').html('<small style="color:#DDF">Ensembl: </small><span>'+panel.ensp_id+'</span>');
-      $('#mapping_top_ensp').attr("href", '/'+panel.species+'/Transcript/Summary?t='+panel.ensp_id);
-      $('#mapping_top_ensp').show();
-      $('#mapping_top_pdb').html('<small style="color:#DFD">PDBe: </small><span>'+pdb_id.toUpperCase()+'</span>');
-      $('#mapping_top_pdb').attr("href", panel.pdbe_url_root+'/entry/pdb/'+pdb_id);
-      $('#mapping_top_pdb').show();
+      $('#mapping_top_ensp').html('Ensembl protein: <a href="'+panel.species+'/Transcript/Summary?t='+panel.ensp_id+'">'+panel.ensp_id+'</a>');
+      $('#mapping_top_pdb').html('PDBe model: <a href="'+panel.pdbe_url_root+'/entry/pdb/'+pdb_id+'" rel="external">'+pdb_id.toUpperCase()+'</a>');
+      $('#mappings_top').show();
 
       $('#mapping_ensp').html(panel.ensp_id);
       $('#mapping_pdb').html(pdb_id.toUpperCase());
@@ -252,7 +272,7 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
         // Position on PDB author coordinates
         var var_pdb_author_coords = panel.ensp_to_pdb_coords(var_pos_ensp[0],var_pos_ensp[1],1);
 
-        $('#'+panel.var_id+'_cb').attr('data-value', var_pdb_coords[0]+','+var_pdb_coords[1]);
+        $('#focus_variant_cb').attr('data-value', var_pdb_coords[0]+','+var_pdb_coords[1]);
 
         // Special display for the stop_gained variants
         var var_cons = panel.ensp_var_cons[panel.ensp_id];
@@ -262,9 +282,9 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
           var altered_sequence = '<tr>'+
                                  '  <td style="border-color:darkred">Altered/missing sequence</td>'+
                                  '  <td>from '+var_pdb_author_coords[0]+'</td><td>from '+var_pos_ensp[1]+'</td>'+
-                                 '  <td><span class="pdb_feature_entry float_left view_enabled" id="'+
-                                      panel.var_id+'_alt_cb" data-value="'+var_pos_after_stop+','+panel.pdb_end+'" data-group="variant_group" data-name="'+
-                                      panel.var_id+'_alt" data-colour="darkred"></span></td>'+
+                                 '  <td><span class="pdb_feature_entry float_left view_enabled" id="focus_variant_alt_cb" data-value="'+
+                                      var_pos_after_stop+','+panel.pdb_end+'" data-group="variant_group" data-name="focus_variant_alt" data-colour="darkred"></span>'+
+                                 '  </td>'+
                                  '</tr>';
           // Remove a potentially previous altered sequence entry if we switch to a different PDB model
           $('#var_details_div > table > tbody').find("tr:gt(0)").remove();
@@ -675,7 +695,7 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
     var ensp_list_cleaned = [];
     // Get the list of mapped PDB entries for each ENSP (from Ensembl 'protein_features' DB table, throught the REST API)
     $.each(panel.ensp_list, function(i,ensp) {
-      if ((panel.var_id && panel.ensp_var_pos[ensp]) || !panel.var_id) {    
+      if ((panel.var_id && panel.ensp_var_pos[ensp]) || !panel.var_id) { 
         pdb_list_calls.push(panel.get_pdb_by_ensp(ensp));
         ensp_list_cleaned.push(ensp);
       }
@@ -693,13 +713,12 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
       $.each(panel.ensp_list, function(i,ensp) {
         // Extract list of PDB IDs and fetch extra PDB information (through the PDBe REST API)
         if (panel.protein_features[ensp]['pdb'] && panel.protein_features[ensp]['pdb'].length !=0) {
-          var var_pos = panel.ensp_var_pos[ensp];          
+          var var_pos = panel.ensp_var_pos[ensp];
 
           // Loop over the PDB models for a given ENSP
           $.each(panel.protein_features[ensp]['pdb'],function (index, result) {
             var pdb_acc = result.id.split('.');
             var pdb_id = pdb_acc[0];
-
             if ($.inArray(pdb_id,pdb_unique_list) == -1) {
               // If variant page, check that the PDB model(s) overlap the variant
               var var_in_pdb = 0;
@@ -811,11 +830,13 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
         // Store the mapping information in an associative array
         if (panel.protein_sources[type] || type == null) {
           // Case of PDB entries
-          if (type == null) {
+          if (type == null || type == 'sifts') {
             // Calculate the percentage of coverage
             var percent_coverage = (hit_mapping_length / panel.ensp_length[ensp])*100;
             // Filter out short PDB mappings or PDB mappings with different length
-            if (hit_mapping_length < panel.mapping_min_length || percent_coverage < panel.mapping_min_percent || ensp_mapping_length != hit_mapping_length) {
+            if (hit_mapping_length < panel.mapping_min_length 
+                || (hit_mapping_length < panel.mapping_min_percent_length && percent_coverage < panel.mapping_min_percent)
+                || ensp_mapping_length != hit_mapping_length) {
               return true;
             }
             type = 'pdb';
@@ -1107,6 +1128,7 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
         var ensp_option = { 'value' : ensp, 'text' : ensp };
         if (ensp == panel.ensp_id) {
           ensp_option['selected'] = 'selected';
+          $('#var_cons').html('('+panel.ensp_var_cons[panel.ensp_id]+')');
           // Display the list of PDB entries in the selection dropdown
           panel.display_pdb_list(ensp);
         }
@@ -1325,7 +1347,34 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
     });
   },
 
-  
+  // Get the ENSP ID from ENST ID (useful in some usage of this script, e.g. VEP)
+  get_ensp_from_enst: function(enst) {
+    var panel = this;
+
+    return $.ajax({
+      url: panel.rest_lookup_url+enst+"?expand=1",
+      method: "GET",
+      contentType: "application/json; charset=utf-8"
+    })
+    .done(function (data) {
+      // ENSP ID
+      var ensp = data.Translation.id;
+      panel.ensp_id = ensp;
+      panel.ensp_list = [panel.ensp_id];
+console.log("TEST: "+ensp);
+      // Store ENSP protein length as well
+      panel.ensp_length[ensp] = data.Translation.length;
+
+      console.log(">>>>> STEP 02: Get corresponding ENSP from ENST (get_ensp_from_enst) - done");
+    })
+    .fail(function (xhRequest, ErrorText, thrownError) {
+      console.log('ErrorText: ' + ErrorText + "\n");
+      console.log('thrownError: ' + thrownError + "\n");
+      panel.removeSpinner();
+      panel.showMsg();
+    });
+  },
+ 
   // Get the ENSP length - unfortunately this has to be done on a different REST endpoint
   get_ens_protein_length: function() {
     var panel = this;
@@ -1555,8 +1604,10 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
   parse_sift_results: function(data) {
     var panel = this; 
 
+    // Sort by position and by sift score (tolerated -> deleterious) in order to highlight
+    // the most critical prediction when several variants/predictions overlap an same amino acid
     data.sort(function(a,b) {
-      return a.start - b.start;
+      return a.start - b.start || b.sift - a.sift;
     });
 
     var sift_details = '';
@@ -1630,8 +1681,10 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
   parse_polyphen_results: function(data) {
     var panel = this;
 
+    // Sort by position and by polyphen score (benign -> pathogenic) in order to highlight
+    // the most critical prediction when several variants/predictions overlap an same amino acid
     data.sort(function(a,b) {
-      return a.start - b.start;
+      return a.start - b.start || a.polyphen - b.polyphen;
     });
 
     var polyphen_details = '';

--- a/widgets/modules/EnsEMBL/Web/Component/PDB.pm
+++ b/widgets/modules/EnsEMBL/Web/Component/PDB.pm
@@ -1,0 +1,308 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Component::PDB;
+
+use strict;
+
+use base qw(EnsEMBL::Web::Component::Shared);
+
+
+sub get_rest_urls {
+  my $self = shift;
+  my $hub  = $self->hub; 
+
+  my $ensembl_rest_url = $hub->species_defs->ENSEMBL_REST_URL;
+  my $pdbe_rest_url    = $hub->species_defs->PDBE_REST_URL;
+ 
+  return qq{
+    <input class="panel_type" value="PDB" type="hidden" />
+    <input type="hidden" name="ensembl_rest_url" class="js_param" value="$ensembl_rest_url">
+    <input type="hidden" name="pdbe_rest_url" class="js_param" value="$pdbe_rest_url">
+  };
+}
+
+sub get_ids_header {
+  my $self   = shift;
+  my $var_id = shift;
+  
+  my $var_id_display = ($var_id) ? qq{<h2 class="float_left">Variant <span id="var_id">$var_id</span> <small><span id="var_cons"></span></small></h2>} : '';
+  my $var_separator  = ($var_id) ? qq{<span class="left-margin right-margin">|</span>} : '';
+
+  return qq{
+  <div>
+    $var_id_display
+    <h2 class="float_left" id="mappings_top" style="display:none">
+      $var_separator
+      <span id="mapping_top_ensp"></span>
+      <span class="left-margin right-margin">|</span>
+      <span id="mapping_top_pdb"></span>
+    </h2>
+    <div style="clear:both"></div>
+  </div>
+
+  <div id="pdb_msg"></div>
+  };
+}
+
+sub get_ensp_pdb_dropdowns {
+  my $self   = shift;
+  my $display_ensp_sel = shift;
+
+  my $ensp_sel  = ($display_ensp_sel) ? qq{<label id="ensp_list_label">Select Ensembl protein:</label><select id="ensp_list"></select>} : '';
+  my $pdb_label = ($display_ensp_sel) ? 'PDBe model' : 'Select PDBe model'; 
+
+  return qq{
+  <div id="ensp_pdb" class="navbar" style="display:none">
+    <div style="float:left">
+      <form>
+        $ensp_sel
+        <label id="pdb_list_label" class="left-margin" style="display:none">$pdb_label:</label>
+        <select id="pdb_list" style="display:none"></select>
+      </form>
+    </div>
+    <div id="right_form" style="float:left;margin-left:15px"></div>
+    <div style="clear:both"></div>
+  </div>
+  };
+}
+
+
+sub get_main_content {
+  my $self = shift;
+  my $focus_var_id = shift; 
+
+  my $viewer_html = $self->get_viewer_canvas();
+  my $menu_html   = $self->get_menu_selection($focus_var_id);
+ 
+  return qq{
+  <div style="margin-bottom:300px">
+    $viewer_html
+    $menu_html
+  </div>
+  }
+}
+
+
+sub get_viewer_canvas {
+  my $self = shift;
+
+  return qq{
+    <div style="float:left;position:relative;height:600px;width:800px">
+      <div class="view_spinner" style="display:none"></div>
+      <div id="litemol_canvas" style="height:600px;width:800px">
+        <!-- Canvas for PDB LiteMol-->
+      </div>
+    </div>
+  }
+}
+
+sub get_menu_selection {
+  my $self = shift;
+  my $focus_var_id = shift;
+
+  my $help_buttons  = $self->get_help_buttons();
+  my $ensp_pdb_menu = $self->get_menu_ensp_pdb_mapping();
+  my $exons_menu    = $self->get_menu_exons();
+  my $proteins_menu = $self->get_menu_proteins();
+  my $variants_menu = $self->get_menu_variants($focus_var_id);
+
+  return qq{
+    <div id="litemol_buttons" style="float:left;margin-left:20px;display:none">
+      $help_buttons
+      $ensp_pdb_menu
+      $exons_menu
+      $proteins_menu
+      $variants_menu
+    </div>
+  };
+}
+
+sub get_help_buttons {
+  my $self = shift;
+
+  return qq { 
+      <div>
+        <div rel="viewer_help" class="float_left view_toggle viewer_btn viewer_helper_btn closed" title="Click to toggle the 3D Viewer Help">
+          <span>3D Viewer Help</span>
+        </div>
+        <div class="float_left viewer_btn viewer_reset_btn left-margin">
+          <span>Reset viewer</span>
+        </div>
+        <div style="clear:both"></div>
+      </div>
+
+      <div id="viewer_help_div" style="display:none">
+        <table>
+          <thead>
+            <tr>
+              <th>Action</th><th>Mouse</th><th>Touchscreen</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Rotate</td><td>Left click + drag</td><td>One finger touch</td></tr>
+            <tr><td>Zoom</td><td>Right click + drag</td><td>Pinch</td></tr>
+            <tr><td>Move</td><td>Middle click + drag</td><td>Two finger touch</td></tr>
+            <tr><td>Slab</td><td>Mouse wheel</td><td>Three finger touch</td></tr>
+          </tbody>
+        </table>
+      </div>
+  };
+
+}
+
+sub get_menu_ensp_pdb_mapping {
+  my $self = shift;
+
+  return qq{
+      <table class="ss pdb_markup">
+        <thead>
+          <tr><th class="pdb_category"><span id="mapping_ensp"></span> - <span id="mapping_pdb"></span> mapping</th></tr>
+        </thead>
+        <tbody>
+
+          <tr>
+            <td id="mapping_block">
+              <div>
+                <div>
+                  <h3 class="float_left">Ensembl-PDBe mapping</h3>
+                  <div class="float_right view_toggle view_toggle_btn open" rel="mapping_details"></div>
+                  <div class="float_right pdb_feature_group view_enabled" title="Click to highlight / hide ENSP-PDB mapping coverage on the 3D viewer" id="mapping_group"></div>
+                  <div style="clear:both"></div>
+                </div>
+                <div class="mapping_details">
+                  <div id="mapping_details_div" class="pdb_features_container toggleable" style="padding-top:5px">
+                    <table class="pdb_features">
+                      <thead>
+                        <tr><th>Label</th><th class="location _ht" title="Position in the selected PDB model"><span>PDB</span></th><th class="location _ht" title="Position in the selected Ensembl protein"><span>ENSP</span></th><th></th></tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td style="border-color:#DDD">Coverage</td><td id="mapping_pdb_pos"></td><td id="mapping_ensp_pos"></td>
+                          <td>
+                            <span class="pdb_feature_entry view_enabled float_left" id="mapping_cb" data-value="" data-group="mapping_group" data-name="Mapping" data-colour="#DDD"></span>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+  };
+}
+
+sub get_menu_exons {
+  my $self = shift;
+
+  return qq{
+    <table class="ss pdb_markup">
+      <thead>
+         <tr><th class="pdb_category">Exons</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td id="exon_block"></td>
+          </tr>
+        </tbody>
+      </table>
+  };
+}
+
+sub get_menu_proteins {
+  my $self = shift;
+  return qq{
+      <table class="ss pdb_markup">
+        <thead>
+          <tr><th class="pdb_category">Protein information</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td id="protein_block"></td>
+          </tr>
+        </tbody>
+      </table>
+  };
+}
+
+
+sub get_menu_variants {
+  my $self = shift;
+  my $focus_var_id = shift;
+
+
+  if ($focus_var_id) {
+    return qq{
+      <table class="ss pdb_markup">
+        <thead>
+          <tr><th class="pdb_category">Variants</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td id="variant_block">
+              <div>
+                <div>
+                  <h3 class="float_left">Variant $focus_var_id</h3>
+                  <div class="float_right view_toggle view_toggle_btn open" rel="var_details"></div>
+                  <div class="float_right pdb_feature_group view_enabled" title="Click to highlight / hide variant on the 3D viewer" id="variant_group"></div>
+                  <div style="clear:both"></div>
+                </div>
+                <div class="var_details">
+                  <div id="var_details_div" class="pdb_features_container toggleable" style="padding-top:5px">
+                    <table class="pdb_features">
+                      <thead>
+                        <tr><th>ID</th><th class="location _ht" title="Position in the selected PDB model"><span>PDB</span></th><th class="location _ht" title="Position in the selected Ensembl protein"><span>ENSP</span></th><th></th></tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td style="border-color:red">$focus_var_id</td><td id="var_pos_pdb"></td><td id="var_pos_ensp"></td>
+                          <td>
+                            <span class="pdb_feature_entry pdb_var_entry view_enabled float_left" id="focus_variant_cb" data-value="" data-group="variant_group" data-name="$focus_var_id" data-colour="red" data-highlight="1"></span>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    };
+  }
+  else {
+    return qq{
+      <table class="ss pdb_markup">
+        <thead>
+          <tr><th class="pdb_category">Variants</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td id="variant_block"></td>
+          </tr>
+        </tbody>
+      </table>
+    };
+  }
+}
+1;

--- a/widgets/modules/EnsEMBL/Web/Component/Transcript/PDB.pm
+++ b/widgets/modules/EnsEMBL/Web/Component/Transcript/PDB.pm
@@ -24,7 +24,7 @@ use strict;
 use HTML::Entities qw(encode_entities);
 use URI::Escape;
 
-use base qw(EnsEMBL::Web::Component::Transcript);
+use base qw(EnsEMBL::Web::Component::Transcript EnsEMBL::Web::Component::PDB);
 
 sub _init {
   my $self = shift;
@@ -39,156 +39,27 @@ sub content {
   my $object      = $self->object;
   my $html;
   if ($object->Obj->isa('Bio::EnsEMBL::Transcript')) {
-    #my $stable_id      = $hub->param('g'); 
     my $species     = $hub->species;
     my $translation = $object->translation_object;
     return unless $translation;
   
     my $translation_id = $translation->stable_id;
-    my $ensembl_rest_url = $hub->species_defs->ENSEMBL_REST_URL;
-    my $pdbe_rest_url    = $hub->species_defs->PDBE_REST_URL;
 
-    $html .= qq{
-  <input class="panel_type" value="PDB" type="hidden" />
-  <input type="hidden" name="ensembl_rest_url" class="js_param" value="$ensembl_rest_url">
-  <input type="hidden" name="pdbe_rest_url" class="js_param" value="$pdbe_rest_url">
- 
-  <div> 
-    <h2 class="float_left">3D representation of the Ensembl protein</h2>
-    <a id="mapping_top_ensp" class="float_left viewer_btn viewer_btn_link left-margin _ht" title="Selected Ensembl protein"><span id="ensp_id">$translation_id</span></a>
-    <a id="mapping_top_pdb" class="float_left viewer_btn viewer_btn_link left-margin _ht" target=_blank" style="background-color:#669966" title="Selected PDB model"></a>
-    <div style="clear:both"></div>
-  </div>
-   
-  <div id="pdb_msg"></div>
+    # Add REST API URLs as hidden param
+    $html .= $self->get_rest_urls();
 
-  <div id="ensp_pdb" class="navbar" style="display:none">
-    <div style="float:left">
-      <form>
-        <label id="pdb_list_label" class="left-margin" style="display:none">Select PDBe model:</label>
-        <select id="pdb_list" style="display:none;margin-left:5px"></select>
-      </form>
-    </div>
-    <div id="right_form" style="float:left;margin-left:15px"></div>
-    <div style="clear:both"></div>
-  </div>
+    # Add the ENSP ID
+    $html .= qq{<input type="hidden" id="ensp_id" value="$translation_id"/>};
 
-  <div style="margin-bottom:300px">
+    # Add IDs header
+    $html .= $self->get_ids_header();
 
-    <div style="float:left;position:relative;height:600px;width:800px">
-      <div class="view_spinner" style="display:none"></div>
-      <div id="litemol_canvas" style="height:600px;width:800px">
-        <!-- Canvas for PDB LiteMol-->
-      </div>
-    </div>
+    # Add selection dropdowns
+    $html .= $self->get_ensp_pdb_dropdowns();
 
-    <div id="litemol_buttons" style="float:left;margin-left:20px;display:none">
-
-      <div>
-        <div rel="viewer_help" class="float_left view_toggle viewer_btn viewer_helper_btn closed" title="Click to toggle the 3D Viewer Help">
-          <span>3D Viewer Help</span>
-        </div>
-        <div class="float_left viewer_btn viewer_reset_btn left-margin">
-          <span>Reset viewer</span>
-        </div>
-        <div style="clear:both"></div>
-      </div>
-
-      <div id="viewer_help_div" style="display:none">
-          <table>
-            <thead>
-              <tr>
-                <th>Action</th><th>Mouse</th><th>Touchscreen</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr><td>Rotate</td><td>Left click + drag</td><td>One finger touch</td></tr>
-              <tr><td>Zoom</td><td>Right click + drag</td><td>Pinch</td></tr>
-              <tr><td>Move</td><td>Middle click + drag</td><td>Two finger touch</td></tr>
-              <tr><td>Slab</td><td>Mouse wheel</td><td>Three finger touch</td></tr>
-            </tbody>
-        </table>
-      </div>
-
-      <table class="ss pdb_markup">
-        <thead>
-          <tr><th class="pdb_category"><span id="mapping_ensp"></span> - <span id="mapping_pdb"></span> mapping</th></tr>
-        </thead>
-        <tbody>
-
-          <tr>
-            <td id="mapping_block">
-              <div>
-                <div>
-                  <h3 class="float_left" style="margin-bottom:0px">Ensembl-PDBe mapping</h3>
-                  <div class="float_right view_toggle view_toggle_btn open" rel="mapping_details"></div>
-                  <div class="float_right pdb_feature_group view_enabled" title="Click to highlight / hide ENSP-PDB mapping coverage on the 3D viewer" id="mapping_group"></div>
-                  <div style="clear:both"></div>
-                </div>
-                <div class="mapping_details">
-                  <div id="mapping_details_div" class="pdb_features_container toggleable" style="padding-top:5px">
-                    <table class="pdb_features">
-                      <thead>
-                        <tr><th>Label</th><th class="location _ht" title="Position in the selected PDB model"><span>PDB</span></th><th class="location _ht" title="Position in the selected     En     sembl protein"><span>ENSP</span></th><th></th></tr>
-                      </thead>
-                      <tbody>
-                        <tr>
-                          <td style="border-color:#DDD">Coverage</td><td id="mapping_pdb_pos"></td><td id="mapping_ensp_pos"></td>
-                          <td>
-                            <span class="pdb_feature_entry view_enabled float_left" id="mapping_cb" data-value="" data-group="mapping_group" data-name="Mapping" data-colour="#DDD"></span>
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-                </div>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-      <table class="ss pdb_markup">
-        <thead>
-          <tr><th class="pdb_category">Exons</th></tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td id="exon_block"></td>
-          </tr>
-        </tbody>
-      </table>
-
-      <table class="ss pdb_markup">
-        <thead>
-          <tr><th class="pdb_category">Protein information</th></tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td id="protein_block"></td>
-          </tr>
-        </tbody>
-      </table>
-
-      <table class="ss pdb_markup">
-        <thead>
-          <tr><th class="pdb_category">Variants</th></tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td id="variant_block"></td>
-          </tr>
-        </tbody>
-      </table>
-    </div> 
-   
-    <div style="clear:both"></div>
-
-  </div>
-};
-
-  }    
-
+    # Litmol viewer + right hand side menu
+    $html .= $self->get_main_content();
+  }
   return $html;
 }
 

--- a/widgets/modules/EnsEMBL/Web/Document/Element/BodyJavascript.pm
+++ b/widgets/modules/EnsEMBL/Web/Document/Element/BodyJavascript.pm
@@ -48,7 +48,7 @@ sub content {
     }
   }
 
-  if ($self->hub->action && $self->hub->action eq 'PDB') {
+  if ($self->hub->action && ($self->hub->action eq 'PDB' || ($self->hub->action eq 'VEP' && $self->hub->function && $self->hub->function eq 'PDB'))) {
     # adding js only for PDB views
     $main_js .=  qq{
       <script language="JavaScript" type="text/javascript" src="$SiteDefs::PDBE_EBI_URL/libs/d3.min.js"></script>

--- a/widgets/modules/EnsEMBL/Web/Document/Element/Stylesheet.pm
+++ b/widgets/modules/EnsEMBL/Web/Document/Element/Stylesheet.pm
@@ -49,7 +49,7 @@ sub content {
       <link rel="stylesheet" type="text/css" href="$static_server/widgets/95_Pathway.css"> 
     };
   }
-  elsif ($self->hub->action && $self->hub->action eq 'PDB') {
+  elsif ($self->hub->action && ($self->hub->action eq 'PDB' || ($self->hub->action eq 'VEP' && $self->hub->function && $self->hub->function eq 'PDB'))) {
     $main_css .=  qq{
       <link rel="stylesheet" type="text/css" href="$SiteDefs::PDBE_EBI_URL/v1.0/css/pdb.component.library.min-1.0.0.css" />
     };


### PR DESCRIPTION
…tes and improvements for the others 3D viewer pages (Transcript and Variation).

#### This PR is an improvement of the closed PR #192.

Here are the main changes:
- Add buttons, module and configuration for the new 3D viewer page from the VEP results
- Create a new module `Component/PDB.pm` to share the HTML content of the 3 views using the PDB viewer (Variation, Transcript and VEP).
- Some changes in the 3D viewer display
- Some changes in the 3D viewer JS code (to integrate the VEP results and also some general optimisation).

### Example of 3D viewer button in the VEP results table
Column `Domains`:
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Tools/VEP/Results?tl=HHzqSVdPXIKhTiMh-526

### Example of 3D viewer from VEP results:
- [rs334](http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Tools/VEP/PDB?cons=missense_variant;db=core;g=ENSG00000244734;pos=7;r=11:5225464-5229395;t=ENST00000335295;tl=HHzqSVdPXIKhTiMh-526;var=rs334)
- [stop_gained](http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Tools/VEP/PDB?cons=stop_gained;db=core;g=ENSG00000135744;pos=400;r=1:230702523-230714122;t=ENST00000366667;tl=BVlsqvDkzJHrWxsT-527;var=1_230704264_C/A)