### PR TITLE
Add the SDPI format to the list of the Web VEP input format

### DIFF
--- a/tools/htdocs/components/20_VEPForm.js
+++ b/tools/htdocs/components/20_VEPForm.js
@@ -116,7 +116,7 @@ Ensembl.Panel.VEPForm = Ensembl.Panel.ToolsForm.extend({
       this.elLk.dataField.data('previousValue', value);
       this.elLk.dataField.data('inputFormat', (function(value) {
         var format = panel.detectFormat(value.split(/[\r\n]+/)[0]);
-        if (format === 'id' || format === 'vcf' || format === 'ensembl' || format === 'hgvs') {
+        if (format === 'id' || format === 'vcf' || format === 'ensembl' || format === 'hgvs' || format === 'spdi') {
           return format;
         }
         return false;
@@ -206,6 +206,19 @@ Ensembl.Panel.VEPForm = Ensembl.Panel.ToolsForm.extend({
         url = this.previewInp.baseURL + '/region/' + c + ':' + s + '-' + e + ':' + 1 + '/' + a;
         break;
 
+      case "spdi":
+        var arr = this.previewInp.input.split(/:/);
+        var c = arr[0];
+        var r = (arr[2] == '') ? '-' : arr[2];
+        var a = (arr[3] == '') ? '-' : arr[3];
+
+        // 0 based coordinate format
+        var s = parseInt(arr[1])+1;
+        var e = s + (r.length - 1);
+
+        url = this.previewInp.baseURL + '/region/' + c + ':' + s + '-' + e + ':' + 1 + '/' + a;
+        break;
+
       default:
         this.previewError('Failed for ' + this.previewInp.format + ' format');
         return;
@@ -231,8 +244,16 @@ Ensembl.Panel.VEPForm = Ensembl.Panel.ToolsForm.extend({
    */
     var data = input.split(/\s+/);
 
-    // HGVS: ENST00000285667.3:c.1047_1048insC
+    // SPDI: 1:230710044:A:G
     if (
+      data.length === 1 &&
+      data[0].match(/^(.*?\:){2}([^\:]+|)$/i)
+    ) {
+      return 'spdi';
+    }
+
+    // HGVS: ENST00000285667.3:c.1047_1048insC
+    else if (
       data.length === 1 &&
       data[0].match(/^([^\:]+)\:.*?([cgmrp]?)\.?([\*\-0-9]+.*)$/i)
     ) {

--- a/tools/modules/EnsEMBL/Web/VEPConstants.pm
+++ b/tools/modules/EnsEMBL/Web/VEPConstants.pm
@@ -31,7 +31,7 @@ sub INPUT_FORMATS {
     { 'value' => 'vcf',     'caption' => 'VCF',                 'example' => qq(1  909238  var1  G  C  .  .  .\n3  361463  var2  GA  G  .  .  .\n5  121187650 sv1   .  &lt;DUP&gt;  .  .  SVTYPE=DUP;END=121188519  .) },
     { 'value' => 'id',      'caption' => 'Variant identifiers', 'example' => qq(rs699\nrs144678492\nRCV000004642) },
     { 'value' => 'hgvs',    'caption' => 'HGVS notations',      'example' => qq(ENST00000207771.3:c.344+626A>T\nENST00000471631.1:c.28_33delTCGCGG) },
-    # { 'value' => 'pileup',  'caption' => 'Pileup',              'example' => qq(chr5  881906  T  C) },
+    { 'value' => 'spdi',    'caption' => 'SPDI',                'example' => qq(1:230710044:A:G) },
   ];
 }
 


### PR DESCRIPTION
Additional format for VEP in e96: `SPDI`
This PR gives the possibility to use the SPDI format as input on the Web VEP form.

#### Example of VEP results using 2 SPDI entries as input:
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Tools/VEP/Results?db=core;g=ENSG00000135744;r=1:230702523-230714122;t=ENST00000366667;tl=CMABGKZrMOr075fk-607