### PR TITLE
fix add cadd files parameter grch38

### DIFF
--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -40,9 +40,8 @@
   },
 
   CADD => {
-    "available" => 1,
     "params" => [
-      "[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD.tsv.gz,[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD_InDels.tsv.gz"
+      "[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD_GRCh38_whole_genome_SNVs.tsv.gz"
     ]
   },
 

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -39,6 +39,13 @@
     ]
   },
 
+  CADD => {
+    "available" => 1,
+    "params" => [
+      "[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD.tsv.gz,[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD_InDels.tsv.gz"
+    ]
+  },
+
   Phenotypes => {
     "params" => [
       "dir=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/Phenotypes_data_files/",


### PR DESCRIPTION

Added missing parameter for CADD files for e96 GRCh38 web.

Example of sandbox with results showing for CADD, columns CADD PHRED, CADD RAW:
http://ves-hx2-76.ebi.ac.uk:6080/Homo_sapiens/Tools/VEP/Results?db=core;tl=SboxrAwK3AT2CPEt-655