### PR TITLE
Hide some of the VEP columns by default

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -242,7 +242,12 @@ sub content {
       $row_id++;
     }
   }
-  $display_column{'PHENO'} = 0 if (defined $display_column{'PHENOTYPES'});
+
+  # Force to hide some columns by default
+  foreach my $col ('IMPACT','SYMBOL_SOURCE','INTRON','DISTANCE','FLAGS','HGNC_ID','PHENO') {
+    $display_column{$col} = 0;
+  }
+
 
   # extras
   my %table_sorts = (


### PR DESCRIPTION
This is a way to reduce the size of the VEP results table, by hidding the less popular columns (which are returned by default by VEP).