### PR TITLE
Add a new option in the VEP input form to change the buffer_size

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -675,6 +675,36 @@ sub _build_predictions {
 }
 
 
+sub _build_advanced {
+  my ($self, $form) = @_;
+
+  my $hub     = $self->hub;
+  my $object  = $self->object;
+  my $species = $object->species_list;
+  my $fd      = $object->get_form_details;
+
+  my @fieldsets;
+
+  ## ADVANCED OPTIONS
+  my $current_section = 'Advanced options';
+  my $fieldset        = $form->add_fieldset({'legend' => $current_section, 'no_required_notes' => 1});
+
+  $fieldset->add_field({
+    'type'    => 'dropdown',
+    'name'    => 'buffer_size',
+    'label'   => $fd->{buffer_size}->{label},
+    'helptip' => $fd->{buffer_size}->{helptip},
+    'notes'   => '<b>NB:</b> When the <b>Regulatory data</b> option is selected, due to the large amount of regulatory data available, the <b>maximum</b> buffer size is automatically set to <b>500</b>. However you can still select a value lower than 500.',
+    'value'   => '5000',
+    'values'  => $fd->{buffer_size}->{values}
+  });
+
+  $self->_end_section(\@fieldsets, $fieldset, $current_section);
+
+  return @fieldsets;
+}
+
+
 sub _end_section {
   my ($self, $fieldsets, $fieldset, $section) = @_;
 

--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -68,6 +68,9 @@ sub prepare_to_dispatch {
     $vep_configs->{$_} = $value if $value && $value ne 'no';
   }
 
+  # buffer size
+  $vep_configs->{buffer_size} = $job_data->{buffer_size};
+
   # regulatory
   if($sp_details->{'regulatory'} && $vep_configs->{'regulatory'}) {
 
@@ -78,7 +81,7 @@ sub prepare_to_dispatch {
     }
 
     $vep_configs->{'regulatory'} = 'yes';
-    $vep_configs->{'buffer_size'} = 500;
+    $vep_configs->{'buffer_size'} = 500 if ($vep_configs->{buffer_size} > 500);
   }
 
   # check existing
@@ -115,7 +118,7 @@ sub prepare_to_dispatch {
   if ($vep_configs->{'most_severe'} || $vep_configs->{'summary'}) {
     delete $vep_configs->{$_} for(qw(coding_only protein symbol sift polyphen ccds canonical numbers domains biotype tsl appris));
   }
-  
+
   # plugins
   $vep_configs->{plugin} = $self->_configure_plugins($job_data);
 

--- a/tools/modules/EnsEMBL/Web/Object/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Object/VEP.pm
@@ -373,6 +373,20 @@ sub get_form_details {
           { 'value' => 'most_severe', 'caption' => 'Show most severe consequence per variant' },
         ]
       },
+
+      # Advanced options
+      buffer_size => {
+        'label'   => 'Buffer size',
+        'helptip' => 'Number of variants that are read in to memory simultaneously (default value: 5000).',
+        'values' => [
+          { 'value' => '5000', 'caption' => '5000' },
+          { 'value' => '2500', 'caption' => '2500' },
+          { 'value' => '1000', 'caption' => '1000' },
+          { 'value' => '500',  'caption' => '500'  },
+          { 'value' => '250',  'caption' => '250'  },
+          { 'value' => '100',  'caption' => '100'  }
+        ]
+      }
     };
 
 

--- a/tools/modules/EnsEMBL/Web/VEPConstants.pm
+++ b/tools/modules/EnsEMBL/Web/VEPConstants.pm
@@ -57,6 +57,10 @@ sub CONFIG_SECTIONS {
     'id'            => 'filters',
     'title'         => 'Filtering options',
     'caption'       => 'Pre-filter results by frequency or consequence type'
+  }, {
+    'id'            => 'advanced',
+    'title'         => 'Advanced options',
+    'caption'       => 'Settings to optimise VEP'
   # }, {
   #  'id'        => 'plugins',
   #  'title'     => 'Plugins',


### PR DESCRIPTION
This change allows the user to change the buffer_size used in web VEP.
There were several cases where the VEP job failed because of memory issue. This option will prevent the webteam to manually to change the input buffer on the server: we could point the users to this new form and ask them to choose a lower value for the buffer of their jobs.

Here is an example on my sandbox (**Advanced options**):
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Tools/VEP?db=core