### PR TITLE
add checkbox for transcript_version option

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -327,6 +327,15 @@ sub _build_identifiers {
   });
 
   $fieldset->add_field({
+    'type'        => 'checkbox',
+    'name'        => 'transcript_version',
+    'label'       => $fd->{transcript_version}->{label},
+    'helptip'     => $fd->{transcript_version}->{helptip},
+    'value'       => 'yes',
+    'checked'     => 1
+  });
+
+  $fieldset->add_field({
     'field_class' => '_stt_core _stt_merged _stt_gencode_basic',
     'type'        => 'checkbox',
     'name'        => 'ccds',

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -953,7 +953,7 @@ sub linkify {
   }
 
   # transcript
-  elsif($field eq 'Feature' && $value =~ /^ENS.{0,3}T\d+\.\d+$/) {
+  elsif($field eq 'Feature' && $value =~ /^ENS.{0,3}T\d+[\.\d+]*$/) {
 
     my $url = $hub->url({
       type    => 'Transcript',

--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -43,8 +43,6 @@ sub prepare_to_dispatch {
   $vep_configs->{'merged'}  = 'yes' if $sp_details->{'refseq'} && ($job_data->{'core_type'} // '') eq 'merged';
   $vep_configs->{'gencode_basic'} = 'yes' if ($job_data->{'core_type'} // '') eq 'gencode_basic';
 
-  $vep_configs->{'transcript_version'} = 'yes';
-
   # filters
   my $frequency_filtering = $job_data->{'frequency'};
 
@@ -110,7 +108,7 @@ sub prepare_to_dispatch {
   $vep_configs->{'stats_file'}  = 'stats.txt';
 
   # extra and identifiers
-  $job_data->{$_} and $vep_configs->{$_} = $job_data->{$_} for qw(numbers canonical domains biotype symbol ccds protein uniprot hgvs coding_only all_refseq tsl appris failed distance);
+  $job_data->{$_} and $vep_configs->{$_} = $job_data->{$_} for qw(numbers canonical domains biotype symbol transcript_version ccds protein uniprot hgvs coding_only all_refseq tsl appris failed distance);
 
   $vep_configs->{distance} = 0 if($job_data->{distance} eq '0' || $job_data->{distance} eq "");
 

--- a/tools/modules/EnsEMBL/Web/Object/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Object/VEP.pm
@@ -185,6 +185,11 @@ sub get_form_details {
         'helptip' => 'Report the gene symbol (e.g. HGNC)',
       },
 
+      transcript_version => {
+        'label'   => 'Transcript version',
+        'helptip' => 'Report the transcript version (e.g. ENST00000380152.7)',
+      },
+
       ccds => {
         'label'   => 'CCDS',
         'helptip' => 'Report the Consensus CDS identifier where applicable',


### PR DESCRIPTION
WEB VEP input form:
- transcript_version will be used by default unless box is unchecked
Web VEP result: 
- checked: http://ves-hx2-76.ebi.ac.uk:6080/Sus_scrofa/Tools/VEP/Results?db=core;tl=uVMWPfYnPFIU0gWY-720
- unchecked :  http://ves-hx2-76.ebi.ac.uk:6080/Sus_scrofa/Tools/VEP/Results?db=core;tl=DNRX0JO287CnsSp9-722