### PR TITLE
Remove potential new line and carriage return characters in 'Instant …

### DIFF
--- a/tools/htdocs/components/20_VEPForm.js
+++ b/tools/htdocs/components/20_VEPForm.js
@@ -155,6 +155,8 @@ Ensembl.Panel.VEPForm = Ensembl.Panel.ToolsForm.extend({
     if (!val) {
       return;
     }
+    // Remove potential new line and carriage return characters
+    val = val.replace(/[\r\n]g/, '');
 
     // reset preview div
     this.elLk.previewDiv.empty().removeClass('active').addClass('loading').css(position);


### PR DESCRIPTION
…VEP'

Fix for the reported issue on `Instant VEP`: https://github.com/Ensembl/ensembl-vep/issues/503

Here is the fix on my sandbox, working with the user example:
```
chrX 659083 . A AT

chrX 659083 . A AT
chrX 659083 . A AT
```
http://ves-hx2-76.ebi.ac.uk:5060/Multi/Tools/VEP?db=core