### PR TITLE
Extend tracking to variation tables

### DIFF
--- a/ga/htdocs/components/95_ga_configs.js
+++ b/ga/htdocs/components/95_ga_configs.js
@@ -739,41 +739,25 @@ Ensembl.GA.eventConfigs.push(
     action          : function () { return this.data.url }
   },
 
-  // Gene Vatiation table links
+  // Vatiation table links
   {
-    id              : 'GeneVariationTableLink',
-    url             : /\/Variation_Gene\/Table/,
+    id              : 'VariationTableLink',
+    url             : /\/(Variation_Gene\/Table|Variation_Transcript\/Table|ProtVariations)/,
     event           : 'click',
     wrapper         : '.ajax.initial_panel',
-    selector        : '#VariationTable td a',
-    category        : 'GeneVariationTableLink',
+    selector        : '#VariationTable td a, #ProteinVariations td a',
+    category        : function () { 
+                        if(window.location.pathname.match(/Variation_Gene/)) {
+                          return 'GeneVariationTableLink';
+                        } else if(window.location.pathname.match(/Variation_Transcript/)){
+                          return 'TranscriptVariationTableLink';
+                        } else if(window.location.pathname.match(/ProtVariations/)){
+                          return 'ProteinVariationTableLink';
+                        }
+                        return 'VariationTable';
+                      },
     action          : function () { return this.getURL(); },
     label           : function() { return $(this.currentTarget).text(); }
   },
-
-  // Transcript Vatiation table links
-  {
-    id              : 'TranscriptVariationTableLink',
-    url             : /\/Variation_Transcript\/Table/,
-    event           : 'click',
-    wrapper         : '.ajax.initial_panel',
-    selector        : '#VariationTable td a',
-    category        : 'TranscriptVariationTableLink',
-    action          : function () { return this.getURL(); },
-    label           : function() { return $(this.currentTarget).text(); }
-  },
-
-  // Protein Vatiation table links
-  {
-    id              : 'ProteinVariationTableLink',
-    url             : /\/Transcript\/ProtVariations/,
-    event           : 'click',
-    wrapper         : '.ajax.initial_panel',
-    selector        : '#ProteinVariations td a',
-    category        : 'ProteinVariationTableLink',
-    action          : function () { return this.getURL(); },
-    label           : function() { return $(this.currentTarget).text(); }
-  }
-
 
 );

--- a/ga/htdocs/components/95_ga_configs.js
+++ b/ga/htdocs/components/95_ga_configs.js
@@ -664,7 +664,7 @@ Ensembl.GA.eventConfigs.push(
   //variation table  tracking
   {
     id              : 'InpageConfig',
-    url             : /\/Variation_Gene\/Table/,
+    url             : /\/(Variation_Gene\/Table|Variation_Transcript\/Table|ProtVariations)/,
     event           : 'click',
     selector        : 'li.prec_pri',
     wrapper         : 'div.initial_panel',
@@ -677,7 +677,7 @@ Ensembl.GA.eventConfigs.push(
     id              : 'InpageConfigSelector',
     url             : /\/(Variation_Gene\/Table|Variation_Transcript\/Table|ProtVariations)/,
     event           : 'click',
-    selector        : 'div.baked, div.use_cols li, div.newtable_filtertype_more li',
+    selector        : 'div.baked, div.use_cols li, div.newtable_filtertype_more',
     wrapper         : 'div.initial_panel',
     category        : "InpageConfigSelector",
     action          : function (e) {
@@ -689,11 +689,11 @@ Ensembl.GA.eventConfigs.push(
                           var name  = $(this.currentTarget).find('div.coltab-text').length ? $(this.currentTarget).find('div.coltab-text').text() : $(this.currentTarget).find('div.main').text()
                           return name + ": " + state;
                         }
-                        if(this.currentTarget.className.match('newtable_filtertype_more')) { //TODO selecting filter is not working
-                          return "filter";
+                        if(this.currentTarget.className.match('newtable_filtertype_more')) { 
+                          return "Filter Other Columns";
                         }
                       },
-    label           : function () { return $(this.currentTarget).parentsUntil('div.m').find('div.title').text(); }
+    label           : function () { return $(this.currentTarget).parentsUntil('div.m').find('div.title').last().text(); }
   },
 
   {
@@ -742,7 +742,7 @@ Ensembl.GA.eventConfigs.push(
   // Gene Vatiation table links
   {
     id              : 'GeneVariationTableLink',
-    url             : /.+/,
+    url             : /\/Variation_Gene\/Table/,
     event           : 'click',
     wrapper         : '.ajax.initial_panel',
     selector        : '#VariationTable td a',
@@ -751,10 +751,22 @@ Ensembl.GA.eventConfigs.push(
     label           : function() { return $(this.currentTarget).text(); }
   },
 
+  // Transcript Vatiation table links
+  {
+    id              : 'TranscriptVariationTableLink',
+    url             : /\/Variation_Transcript\/Table/,
+    event           : 'click',
+    wrapper         : '.ajax.initial_panel',
+    selector        : '#VariationTable td a',
+    category        : 'TranscriptVariationTableLink',
+    action          : function () { return this.getURL(); },
+    label           : function() { return $(this.currentTarget).text(); }
+  },
+
   // Protein Vatiation table links
   {
     id              : 'ProteinVariationTableLink',
-    url             : /.+/,
+    url             : /\/Transcript\/ProtVariations/,
     event           : 'click',
     wrapper         : '.ajax.initial_panel',
     selector        : '#ProteinVariations td a',

--- a/ga/htdocs/components/95_ga_configs.js
+++ b/ga/htdocs/components/95_ga_configs.js
@@ -675,7 +675,7 @@ Ensembl.GA.eventConfigs.push(
 
   {
     id              : 'InpageConfigSelector',
-    url             : /\/Variation_Gene\/Table/,
+    url             : /\/(Variation_Gene\/Table|Variation_Transcript\/Table|ProtVariations)/,
     event           : 'click',
     selector        : 'div.baked, div.use_cols li, div.newtable_filtertype_more li',
     wrapper         : 'div.initial_panel',
@@ -698,7 +698,7 @@ Ensembl.GA.eventConfigs.push(
 
   {
     id              : 'InpageConfigApply',
-    url             : /\/Variation_Gene\/Table/,
+    url             : /\/(Variation_Gene\/Table|Variation_Transcript\/Table|ProtVariations)/,
     event           : 'click',
     selector        : 'li.apply, li.cancel',
     wrapper         : 'div.initial_panel',
@@ -737,6 +737,31 @@ Ensembl.GA.eventConfigs.push(
     data            : { url: function() { return this.getURL(window.location.href); } },
     category        : 'SpeciesSelectorLink',
     action          : function () { return this.data.url }
+  },
+
+  // Gene Vatiation table links
+  {
+    id              : 'GeneVariationTableLink',
+    url             : /.+/,
+    event           : 'click',
+    wrapper         : '.ajax.initial_panel',
+    selector        : '#VariationTable td a',
+    category        : 'GeneVariationTableLink',
+    action          : function () { return this.getURL(); },
+    label           : function() { return $(this.currentTarget).text(); }
+  },
+
+  // Protein Vatiation table links
+  {
+    id              : 'ProteinVariationTableLink',
+    url             : /.+/,
+    event           : 'click',
+    wrapper         : '.ajax.initial_panel',
+    selector        : '#ProteinVariations td a',
+    category        : 'ProteinVariationTableLink',
+    action          : function () { return this.getURL(); },
+    label           : function() { return $(this.currentTarget).text(); }
   }
+
 
 );


### PR DESCRIPTION
**NOTE:** This needs to released along with the following PR:
https://github.com/Ensembl/ensembl-webcode/pull/719

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5228

## Description
Extended the analytics tracking to the variation tables on the following pages:
- Gene
- Transcripts
- Protein

All the clicks to the links inside the table along with the filters are now tracked.


## Views affected

- Gene - http://ves-hx2-76.ebi.ac.uk:42229/Danio_rerio/Gene/Variation_Gene/Table?db=core;g=ENSDARG00000024771;r=18:5213338-5227420;t=ENSDART00000033574;v=rs506965281;vdb=variation;vf=14193096

- Transcript - http://ves-hx2-76.ebi.ac.uk:42229/Danio_rerio/Transcript/Variation_Transcript/Table?db=core;g=ENSDARG00000024771;r=18:5213338-5227420;t=ENSDART00000033574;v=rs506965281;vdb=variation;vf=14193096

- Protein - http://ves-hx2-76.ebi.ac.uk:42229/Danio_rerio/Transcript/ProtVariations?db=core;g=ENSDARG00000024771;r=18:5213338-5227420;t=ENSDART00000033574;v=rs506965281;vdb=variation;vf=14193096
