### PR TITLE
Tools LD - Remove extra text appearing next to the new job button

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/LD/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/LD/Results.pm
@@ -94,7 +94,7 @@ sub content {
     my @content = file_get_contents($output_file_full_path, sub { s/\R/\r\n/r });
     if (scalar @content) {
       my $down_url  = $object->download_url({output_file => $output_file});
-      $html .= qq{<p><div class="component-tools tool_buttons"><a class="export" href="$down_url">Download all results</a><div class="left-margin">' . $new_job_button . '</div></div></p>};
+      $html .= qq{<p><div class="component-tools tool_buttons"><a class="export" href="$down_url">Download all results</a><div class="left-margin">$new_job_button</div></div></p>};
     }
   }
 


### PR DESCRIPTION
This PR is to fix a minor bug introduced in the following PR:
https://github.com/Ensembl/public-plugins/pull/240

Views affected: Tools -> LD -> Results page

