### PR TITLE
Pig-strains gene-trees not shown on staging #5275 

### DIFF
--- a/ensembl/conf/ini-files/sus_scrofa.ini
+++ b/ensembl/conf/ini-files/sus_scrofa.ini
@@ -23,6 +23,8 @@ EXPORTABLE_MISC_SETS = [ BAC ]
 
 ASSEMBLY_CONVERTER_FILES = []
 
+RELATED_TAXON         = Ungulates
+
 ####################
 # Species-specific colours
 ####################

--- a/ensembl/conf/ini-files/sus_scrofa_bamei.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_bamei.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_berkshire.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_berkshire.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_hampshire.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_hampshire.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_jinhua.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_jinhua.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_landrace.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_landrace.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_largewhite.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_largewhite.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_meishan.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_meishan.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_pietrain.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_pietrain.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_rongchang.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_rongchang.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_tibetan.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_tibetan.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 2
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_usmarc.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_usmarc.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 1
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_wuzhishan.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_wuzhishan.ini
@@ -13,6 +13,8 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 SPECIES_RELEASE_VERSION = 10
+IS_STRAIN_OF            = Sus_scrofa
+RELATED_TAXON           = Ungulates
 
 ####################
 # Species-specific colours


### PR DESCRIPTION
Fixed the issue with missing 'Strains' link on the nav bar for Pigs.


Related JIRA ticket:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5275


Views affected:
http://ves-hx2-76.ebi.ac.uk:42228/Sus_scrofa/Gene/Summary?g=ENSSSCG00000004244;r=1:42729112-42896283
