### PR TITLE
Update Solr SiteDefs to account for pig strains in sidebar

### DIFF
--- a/solr/conf/SiteDefs.pm
+++ b/solr/conf/SiteDefs.pm
@@ -145,7 +145,7 @@ sub update_conf {
       ],
 
       facets_sidebar_deps => {
-        strain => { "species" => ["Mouse"] }
+        strain => { "species" => ["Mouse", "Pig"] }
       },
 
       #######################


### PR DESCRIPTION
### Description
Strains that can be shown in the left-hand sidebar of the search page are white-listed in SiteDefs of the Solr plugin. This PR updates the SideDefs so that pig strains are also searchable.

### Related Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5295

([view in sandbox](http://ves-hx2-76.ebi.ac.uk:8410/Sus_scrofa/Search/Results?q=ENSSSCG00055009074;page=1;facet_species=Pig))