### PR TITLE
Update pig related taxon

### DIFF
--- a/ensembl/conf/ini-files/sus_scrofa.ini
+++ b/ensembl/conf/ini-files/sus_scrofa.ini
@@ -23,7 +23,7 @@ EXPORTABLE_MISC_SETS = [ BAC ]
 
 ASSEMBLY_CONVERTER_FILES = []
 
-RELATED_TAXON         = Ungulates
+RELATED_TAXON         = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_bamei.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_bamei.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_berkshire.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_berkshire.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_hampshire.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_hampshire.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_jinhua.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_jinhua.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_landrace.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_landrace.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_largewhite.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_largewhite.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_meishan.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_meishan.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_pietrain.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_pietrain.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_rongchang.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_rongchang.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_tibetan.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_tibetan.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 2
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_usmarc.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_usmarc.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 1
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours

--- a/ensembl/conf/ini-files/sus_scrofa_wuzhishan.ini
+++ b/ensembl/conf/ini-files/sus_scrofa_wuzhishan.ini
@@ -14,7 +14,7 @@
 
 SPECIES_RELEASE_VERSION = 10
 IS_STRAIN_OF            = Sus_scrofa
-RELATED_TAXON           = Ungulates
+RELATED_TAXON           = Sus
 
 ####################
 # Species-specific colours


### PR DESCRIPTION
This PR is to update the wrong `RELATED_TAXON` used in the following PR:
https://github.com/Ensembl/public-plugins/pull/252

Related JIRA ticket:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5275

Views affected:
http://ves-hx2-76.ebi.ac.uk:42228/Sus_scrofa/Gene/Strain_Compara?g=ENSSSCG00000004484;r=1:90744429-90875118