### PR TITLE
replace variation_set_1kg_3 with gnomad

### DIFF
--- a/ensembl/conf/ini-files/homo_sapiens.ini
+++ b/ensembl/conf/ini-files/homo_sapiens.ini
@@ -47,7 +47,7 @@ ASSEMBLY_CONVERTER_FILES = [GRCh37_to_GRCh38 GRCh37_to_NCBI34 GRCh37_to_NCBI35 G
 
 [DEFAULT_VARIATION_TRACKS]
 
-variation_set_1kg_3       = compact
+variation_set_gnomAD      = compact
 variation_set_ph_variants = compact
 sv_set_1kg_3              = compact
 


### PR DESCRIPTION
We didn't correctly set which variants belong to the set "1000 Genomes 3 - All" which means that the default track variation_set_1kg_3 would be empty. We switched the default track to variation_set_gnomAD instead.