### PR TITLE
Fix SIFT and PolyPhen displays when the option 'Score only' or 'Predi…

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -1074,7 +1074,19 @@ sub linkify {
   elsif($field =~ /sift|polyphen|condel/i && $value =~ /\w+/) {
     my ($pred, $score) = split /\(|\)/, $value;
     $pred =~ s/\_/ /g if $pred;
-    $new_value = $self->render_sift_polyphen($pred, $score);
+
+    # Missing prediction term
+    if ($score and !defined($pred)) {
+      $new_value = $score;
+    }
+    # Missing numerical score
+    elsif (!defined($score) && $pred) {
+      $new_value = $pred;
+    }
+    # Having both prediction term and numerical score, or none of them (handled by 'render_sift_polyphen')
+    else {
+      $new_value = $self->render_sift_polyphen($pred, $score);
+    }
   }
 
   # LoFTool


### PR DESCRIPTION
…ction only' has been selected

Reference JIRA: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5298

We decided to remove the rendering if the score or the prediction is missing.

Example not working (SIFT "Score only") on test: http://test.ensembl.org/Homo_sapiens/Tools/VEP/Results?tl=IAjuil2HJ6cMrnRQ-1305

Example working on my sandbox, with the fix (SIFT "Prediction only" and PolyPhen "Score only):
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Tools/VEP/Results?tl=RDvkMQcqkgTfqkvY-1003

Example on my sandbox with normal rendering (SIFT and PolyPhen "Prediction and score"):
http://ves-hx2-76.ebi.ac.uk:5060/Homo_sapiens/Tools/VEP/Results?tl=OY96IJZs0Jnffo5P-1001