### PR TITLE
new variation species from VCF only

### DIFF
--- a/ensembl/conf/json/salmo_salar_vcf.json
+++ b/ensembl/conf/json/salmo_salar_vcf.json
@@ -1,0 +1,19 @@
+{
+  "collections": [
+    {
+      "id": "atlantic_salmon_EVA_PRJEB34225",
+      "source_name": "PRJEB34225",
+      "description": "Variants from EVA study PRJEB34225",
+      "species": "salmo_salar",
+      "assembly": "ICSASG_v2",
+      "type": "remote",
+      "use_as_source" : 1,
+      "use_seq_region_synonyms": 1,
+      "strict_name_match" : 0,
+      "filename_template" : "ftp://ftp.ebi.ac.uk/pub/databases/eva/PRJEB34225/Salmon_SNP_80_samples_freebayes_EBI_noINFO.vcf.gz",
+      "chromosomes": [
+        "ssa01", "ssa02", "ssa03", "ssa04", "ssa05", "ssa06", "ssa09", "ssa10", "ssa11", "ssa12", "ssa13", "ssa14", "ssa15", "ssa16", "ssa17", "ssa18", "ssa19", "ssa20", "ssa21", "ssa22", "ssa23", "ssa24", "ssa25", "ssa26", "ssa27", "ssa28", "ssa29"
+      ]
+    }
+  ]
+}

--- a/ensembl/conf/json/salmo_salar_vcf.json
+++ b/ensembl/conf/json/salmo_salar_vcf.json
@@ -14,6 +14,14 @@
       "chromosomes": [
         "ssa01", "ssa02", "ssa03", "ssa04", "ssa05", "ssa06", "ssa09", "ssa10", "ssa11", "ssa12", "ssa13", "ssa14", "ssa15", "ssa16", "ssa17", "ssa18", "ssa19", "ssa20", "ssa21", "ssa22", "ssa23", "ssa24", "ssa25", "ssa26", "ssa27", "ssa28", "ssa29"
       ]
+    },
+    {
+      "id": "75_fish.gerp_conservation_score",
+      "species": "salmo_salar",
+      "assembly": "ICSASG_v2",
+      "type": "remote",
+      "filename_template" : "/75_fish.gerp_conservation_score/gerp_conservation_scores.salmo_salar.ICSASG_v2.bw",
+      "annotation_type": "gerp"
     }
   ]
 }


### PR DESCRIPTION
Read variants for Atlantic salmon from VCF file hosted by EVA.