### PR TITLE
Update Blast.pm logic to account for versioned regions

### DIFF
--- a/tools/modules/EnsEMBL/Web/Object/Blast.pm
+++ b/tools/modules/EnsEMBL/Web/Object/Blast.pm
@@ -307,10 +307,11 @@ sub get_all_hits_in_slice_region {
   return [ grep {
 
     my $gid    = $_->{'gid'};
+    my $vtid    = $_->{'v_tid'};
     my $gstart = $_->{'gstart'};
     my $gend   = $_->{'gend'};
 
-    $s_name eq $gid && (
+    ($s_name eq $vtid || $s_name eq $gid)  && (
       $gstart >= $s_start && $gend <= $s_end ||
       $gstart < $s_start && $gend <= $s_end && $gend > $s_start ||
       $gstart >= $s_start && $gstart <= $s_end && $gend > $s_end ||


### PR DESCRIPTION
**Problem**
We noticed that running BLAST for species whose "regions" (genetic molecules of a similar class as chromosomes — scaffolds, assemblies, etc.) are versioned produces missing results. For example:
- search for NM_001142896.1 in Ensembl global search; it will result in a number of matches for pig breeds
- click on a match, select `cDNA` in the left-hand sidebar, and click on "Blast this sequence"
- run blast (making sure that you are running it for genomic sequence), and view the results
- click on any result; notice that the `r` parameter in the url begins with a versioned region (the part before the colon); also notice in the bottom image (which should contain the blasted sequence) tracks that say that the sequence was not found

The example above was reported in ENSWEB-5322 and focuses on pig breeds, but the same error will be seen when blasting sequences from any organism with versioned regions. It can be reproduced when blasting the CCS-201 transcript of Australian saltwater crocodile, whose genetic material is represented with versioned assemblies.

**Cause**
When reading blast results back from the blast.out.tab file, which will look something like this:

![image](https://user-images.githubusercontent.com/6834224/67465748-abf66380-f63d-11e9-80a3-6bf20e740660.png)

the parser specifically [removes](https://github.com/Ensembl/public-plugins/blob/release/98/tools_hive/modules/EnsEMBL/Web/Parsers/NCBIBLAST.pm#L70) the version from a possibly versioned identifier (fourth column in the table above):

![image](https://user-images.githubusercontent.com/6834224/67465855-e9f38780-f63d-11e9-8fad-4960cbb1277b.png)

and then [uses](https://github.com/Ensembl/public-plugins/blob/release/98/tools_hive/modules/EnsEMBL/Web/Parsers/NCBIBLAST.pm#L100) this unversioned identifier when building the data structure that is then saved in the database. When the web server then reads this data back, it [compares](https://github.com/Ensembl/public-plugins/blob/release/98/tools/modules/EnsEMBL/Web/Object/Blast.pm#L313) the stored (unversioned) identifier to the region name, and if the region name is versioned, will fail the comparison test and will not find the result of the blast job.

**Solution**
Either the blast file parser should use the versioned id for the `gid` parameter to be saved in the hive database, or the blast tool that retrieves the results of the job from the hive database should compare the region name with the versioned id. As I do not understand the reason for removing the version in the first place (see ticket ENSWEB-2030 for description related to that removal), I suggest we leave the parser code as is, but instead modify Blast tool code so that it will check for the versioned id first (notice that the versioned id field [may be empty](https://github.com/Ensembl/public-plugins/blob/release/98/tools_hive/modules/EnsEMBL/Web/Parsers/NCBIBLAST.pm#L135)).

**Example in sandbox**
blast job results for a pig strain: http://ves-hx2-76.ebi.ac.uk:8410/Sus_scrofa_tibetan/Location/View?r=AORO02070719.1:1200369-1201703;tl=5N3GB1ilVV2saVga-1032-755