### PR TITLE
Add empty string to avoid warning when comparing a string to undef

### DIFF
--- a/tools/modules/EnsEMBL/Web/Object/Blast.pm
+++ b/tools/modules/EnsEMBL/Web/Object/Blast.pm
@@ -307,7 +307,7 @@ sub get_all_hits_in_slice_region {
   return [ grep {
 
     my $gid    = $_->{'gid'};
-    my $vtid    = $_->{'v_tid'};
+    my $vtid    = $_->{'v_tid'} || '';
     my $gstart = $_->{'gstart'};
     my $gend   = $_->{'gend'};
 


### PR DESCRIPTION
PR https://github.com/Ensembl/public-plugins/pull/275 introduced a faulty bit of code that Perl is complaining about. It doesn't like to compare `undef` to a string and is spamming our logs with warning messages about its unhappiness.