### PR TITLE
Change margin-top for extra-options-fieldset

### DIFF
--- a/tools/htdocs/components/31_forms.css
+++ b/tools/htdocs/components/31_forms.css
@@ -34,7 +34,7 @@ span.extra_configs_info           { color: [[MEDIUM_GREY]]; font-style: italic; 
 .plugin-subfield                  { padding-left: 50px; }
 
 form.bgcolour div.form-field div.ff-right.run_container, form.bgcolour div.form-field.ff-multi div.ff-right.run_container    { background-color: #fff; text-align: center; }
-fieldset.extra-options-fieldset   { background-color: #eeeeee; margin: -40px 0px 8px 300px; padding-top: 8px; padding-left: 8px;}
+fieldset.extra-options-fieldset   { background-color: #eeeeee; margin: -20px 0px 8px 300px; padding-top: 8px; padding-left: 8px;}
 input.run_button                  { width: 50%; background-color: [[OK_MEDIUM]]; height: 25px; font-weight: bold; }
 input.run_button:hover            { background-color: [[OK_DARK]]; }
 div.assembly_msg                  { clear: left; font-size: 90%; margin-top: 8px;}


### PR DESCRIPTION
### Problem
Bottom fieldset in the BLAST and VEP tools form overlaps with the previous field:

![image](https://user-images.githubusercontent.com/6834224/68577493-1eea4180-0468-11ea-9633-09ed515330ba.png)

### Cause
`.extra-options-fieldset` has a negative margin of `-40px`, which is too much and pulls the bottom fieldset over the previous field.

### Solution
Change the negative margin to a smaller one?

![image](https://user-images.githubusercontent.com/6834224/68582224-27477a00-0472-11ea-89fe-437130c78a1b.png)

**Sandbox:** http://ves-hx2-76.ebi.ac.uk:8410/Multi/Tools/Blast?db=core for BLAST and http://ves-hx2-76.ebi.ac.uk:8410/Multi/Tools/VEP?db=core for VEP

### Notes
The markup of the whole Tools form is currently very... unorthodox and fragile, and I couldn't find the actual change that was responsible for the broken interface. But it will take too much time to refactor this form to a more predictable markup. I am sure it isn't worth the time and effort.