### PR TITLE
Changed path of vertebrates species tree

### DIFF
--- a/ensembl/htdocs/info/about/speciestree.html
+++ b/ensembl/htdocs/info/about/speciestree.html
@@ -12,7 +12,7 @@ The species tree is maintained by the <a href="/info/genome/compara/">Compara te
 (more information <a href="/info/genome/compara/index.html#species_tree">here</a> on how it is constructed).
 </p>
 <p>
-It is available for download in our <a href="https://github.com/Ensembl/ensembl-compara/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/scripts/pipeline/species_tree.vertebrates.branch_len.nw">GitHub repository</a>
+It is available for download in our <a href="https://github.com/Ensembl/ensembl-compara/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/conf/vertebrates/species_tree.branch_len.nw">GitHub repository</a>
 and as a
 <a href="species_tree.pdf" id="speciestree">Static image</a> in PDF.
 </p>

--- a/ensembl/htdocs/info/genome/compara/species_trees.html
+++ b/ensembl/htdocs/info/genome/compara/species_trees.html
@@ -22,7 +22,7 @@ The Compara pipelines use two main species trees.
         <li>the CAFE pipelines (Gene Gain/Loss trees), with branch lengths coming from  <a href="http://www.timetree.org">the TimeTree database</a>
     </ul>
     </li>
-    <li>A tree with branch-lengths computed in-house with Mash (available for download <a href="https://github.com/Ensembl/ensembl-compara/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/scripts/pipeline/species_tree.vertebrates.branch_len.nw">here</a>) in:
+    <li>A tree with branch-lengths computed in-house with Mash (available for download <a href="https://github.com/Ensembl/ensembl-compara/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/conf/vertebrates/species_tree.branch_len.nw">here</a>) in:
     <ul>
         <li>the <a href="/info/genome/compara/multiple_genome_alignments.html">Multiple-alignment</a> pipelines</li>
         <li>the <a href="/info/genome/compara/conservation_and_constrained.html">Constrained Elements / Conservation Scores</a> pipelines</li>

--- a/widgets/htdocs/info/about/speciestree.html
+++ b/widgets/htdocs/info/about/speciestree.html
@@ -12,7 +12,7 @@ The species tree is maintained by the <a href="/info/genome/compara/">Compara te
 (more information <a href="/info/genome/compara/index.html#species_tree">here</a> on how it is constructed).
 </p>
 <p>
-It is available for download in our <a href="https://github.com/Ensembl/ensembl-compara/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/scripts/pipeline/species_tree.vertebrates.branch_len.nw">GitHub repository</a>
+It is available for download in our <a href="https://github.com/Ensembl/ensembl-compara/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/conf/vertebrates/species_tree.branch_len.nw">GitHub repository</a>
 .
 </p>
 


### PR DESCRIPTION
The default location of the species trees has changed in `ensembl-compara` from e99 on. This PR updates the location (and filename) of the vertebrates species tree file.