### PR TITLE
Add tracking to VEP tool run buttons

### DIFF
--- a/ga/htdocs/components/95_ga_configs.js
+++ b/ga/htdocs/components/95_ga_configs.js
@@ -758,6 +758,31 @@ Ensembl.GA.eventConfigs.push(
                       },
     action          : function () { return this.getURL(); },
     label           : function() { return $(this.currentTarget).text(); }
+  },
+
+  // Track Run VEP button
+  {
+    id              : 'RunVEPButton',
+    event           : 'click',
+    wrapper         : '.ajax.initial_panel',
+    selector        : 'input.run_button',
+    category        : 'RunVEPButton',
+    action          : 'Tools/VEP',
+    label           : ''
+  },
+
+  /* 
+    Track Run Instant VEP button
+    Using `mouseup` handler here as `click` is already handled by JQuery and it stops the propagation.
+    */
+  {
+    id              : 'RunInstantVEPButton',
+    event           : 'mouseup',
+    wrapper         : '.ajax.initial_panel',
+    selector        : 'input.quick-vep-button',
+    category        : 'RunInstantVEPButton',
+    action          : 'Tools/VEP',
+    label           : ''
   }
 
 );


### PR DESCRIPTION
Added tracking to the `Run` and `Run Instant VEP` buttons on the VEP tool page.

Sandbox URL:
http://ves-hx2-76.ebi.ac.uk:42228/Homo_sapiens/Tools/VEP?db=core