### PR TITLE
Fix link for embedded youtube video

### DIFF
--- a/ensembl/htdocs/info/genome/genebuild/haplotypes_patches.html
+++ b/ensembl/htdocs/info/genome/genebuild/haplotypes_patches.html
@@ -26,7 +26,7 @@
 
 <p>In Ensembl, we display the primary assembly for all species as default. This means that our chromosome coordinates for human and mouse will match those on other genome browsers for the same major assembly release. The alternate loci are displayed alongside the primary assembly, allowing their annotation to be viewed and compared to the primary.</p>
 
-<iframe width="480" height="390" src="https://www.youtube.com/embed/sPE9j_Hw9HU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Haplotype video" width="480" height="390" src="https://www.youtube.com/embed/sPE9j_Hw9HU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <h2 id="notesonterminology">Notes on terminology</h2>
 

--- a/ensembl/htdocs/info/genome/genebuild/haplotypes_patches.html
+++ b/ensembl/htdocs/info/genome/genebuild/haplotypes_patches.html
@@ -26,7 +26,7 @@
 
 <p>In Ensembl, we display the primary assembly for all species as default. This means that our chromosome coordinates for human and mouse will match those on other genome browsers for the same major assembly release. The alternate loci are displayed alongside the primary assembly, allowing their annotation to be viewed and compared to the primary.</p>
 
-<iframe  title="Haplotype video" width="480" height="390" src="https://www.youtube.com/watch?v=sPE9j_Hw9HU&ab_channel=EnsemblHelpdesk" frameborder="0" allowfullscreen></iframe>
+<iframe width="480" height="390" src="https://www.youtube.com/embed/sPE9j_Hw9HU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <h2 id="notesonterminology">Notes on terminology</h2>
 


### PR DESCRIPTION
This PR fixes link for an embedded youtube video (as [explained on StackOverflow](https://stackoverflow.com/a/25661346/3925302), links to youtube videos in iframes embedded in external sites should have pathname that contains the word `embed` instead of `watch`).

Before fix:

![image](https://user-images.githubusercontent.com/6834224/70444588-06cf0780-1a92-11ea-9a53-0b8cdd536922.png)

After fix:

![image](https://user-images.githubusercontent.com/6834224/70444607-12bac980-1a92-11ea-9405-f31bc5d0f848.png)

Link to page in a sandbox:
http://ves-hx2-76.ebi.ac.uk:8410/info/genome/genebuild/haplotypes_patches.html