### PR TITLE
Update error message when data slicer cannot get url to file with data

### DIFF
--- a/tools/htdocs/components/20_ThousandGenome.js
+++ b/tools/htdocs/components/20_ThousandGenome.js
@@ -213,7 +213,7 @@ Ensembl.Panel.ThousandGenome = Ensembl.Panel.ToolsForm.extend({
     function handleEmptyResponse () {
       var subjectLine = "Data slicer unable to retrieve genotype file from 1000G FTP site";
       var linkToContactForm = '<a href="/Help/Contact?subject=' + encodeURIComponent(subjectLine) + '">contact us</a>';
-      var errorMessage = 'We are currently unable to retrieve the genotype data. Please try and again and if the problem persists please ' + linkToContactForm;
+      var errorMessage = 'We are currently unable to retrieve the genotype data. Please try again and if the problem persists please ' + linkToContactForm;
       panel.elLk.form
         .find('span._span_url')
         .html('<label class="invalid" style="display: inline;">' + errorMessage + '</label>');

--- a/tools/htdocs/components/20_ThousandGenome.js
+++ b/tools/htdocs/components/20_ThousandGenome.js
@@ -210,6 +210,16 @@ Ensembl.Panel.ThousandGenome = Ensembl.Panel.ToolsForm.extend({
     region = region.match(/^chr/gi) ?  region : "chr"+region;
     collection = "1000 Genomes phase "+collection.replace("phase","")+" release";
 
+    function handleEmptyResponse () {
+      var subjectLine = "Data slicer unable to retrieve genotype file from 1000G FTP site";
+      var linkToContactForm = '<a href="/Help/Contact?subject=' + encodeURIComponent(subjectLine) + '">contact us</a>';
+      var errorMessage = 'We are currently unable to retrieve the genotype data. Please try and again and if the problem persists please ' + linkToContactForm;
+      panel.elLk.form
+        .find('span._span_url')
+        .html('<label class="invalid" style="display: inline;">' + errorMessage + '</label>');
+      panel.elLk.form.find('input[name=generated_file_url]').val("");
+    }
+
     $.ajax({
       'type'    : "POST",      
       'url'     : panel.fileRestURL,
@@ -217,8 +227,7 @@ Ensembl.Panel.ThousandGenome = Ensembl.Panel.ToolsForm.extend({
       'beforeSend' : function() { panel.toggleSpinner(true); },
       'success' : function(data) {
         if(!data.hits || !data.hits.total) {
-          panel.elLk.form.find('span._span_url').html('<label class="invalid" style="display: inline;">Genotype file URL: We were unable to retrieve the file, please try again later.(No file obtained)</label>');
-          panel.elLk.form.find('input[name=generated_file_url]').val("");
+          handleEmptyResponse();
         } else {
           $.each (data.hits.hits, function (index,el) {
             //Matching the specific region file, Grch37 files have a . after region whereas grch38 have an _ after region
@@ -242,8 +251,7 @@ Ensembl.Panel.ThousandGenome = Ensembl.Panel.ToolsForm.extend({
       },
       'error'     : function () {
         panel.toggleSpinner(false);
-        panel.elLk.form.find('span._span_url').html('<label class="invalid" style="display: inline;">Genotype file URL: We were unable to retrieve the file, please try again later.</label>');
-        panel.elLk.form.find('input[name=generated_file_url]').val("");        
+        handleEmptyResponse();
       }
     });
   },  


### PR DESCRIPTION
Ticket ENSWEB-4799 (see @ens-st3 's comment)

## Description
When data slicer cannot retrieve url to data file on ftp from 1000 genomes, it shows an error message that reads: "Genotype file URL: We were unable to retrieve the file, please try again later.(No file obtained)". This PR:
- replaces this message with a friendlier and more human-readable message
- the message has a link to the contact form for helpdesk
- contact form's subject field is pre-populated with a meaningful title: "Data slicer unable to retrieve genotype file from 1000G FTP site"

**Sandbox for testing:**
http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Tools/DataSlicer

In order to see the new error message in the sandbox, you can simply block the request to the `_search` endpoint in Chrome Dev Tools (open dev tools, click on More tools, then on Request blocking):

![image](https://user-images.githubusercontent.com/6834224/70550029-0f484080-1b6d-11ea-8751-d78d37aef39e.png)
