### PR TITLE
add identifiers to VEP default input for sv

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/vep_formats.html
+++ b/docs/htdocs/info/docs/tools/vep/vep_formats.html
@@ -255,8 +255,8 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <p> Examples of structural variants encoded in tab-delimited format: </p>
     
     <pre class="code sh_sh">
-1    160283    471362    DUP
-1    1385015   1387562   DEL</pre>
+1    160283    471362    DUP  + sv1
+1    1385015   1387562   DEL  + sv2</pre>
     
     <p> Examples of structural variants encoded in VCF format: </p>
     


### PR DESCRIPTION
Update the example input for representing structural variants with the VEP tab-delimited default file format.