### PR TITLE
add gnomad v3 grch38 vcf location

### DIFF
--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -215,7 +215,7 @@
       "id": "103_mammals.gerp_conservation_score",
       "species": "homo_sapiens",
       "assembly": "GRCh38",
-      "type": "remote",
+      "type": "local",
       "filename_template" : "/103_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh38.bw",
       "annotation_type": "gerp"
     },

--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -212,11 +212,11 @@
       }
     },
     {
-      "id": "100_mammals.gerp_conservation_score",
+      "id": "103_mammals.gerp_conservation_score",
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template" : "/100_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh38.bw",
+      "filename_template" : "/103_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh38.bw",
       "annotation_type": "gerp"
     },
     {

--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -75,7 +75,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r3.0/genomes/gnomad.genomes.r3.0.sites.chr###CHR###_trimmed_info.vcf.bgz",
+      "filename_template": "/homo_sapiens/GRCh38/variation_genotype/gnomad/r3.0/genomes/gnomad.genomes.r3.0.sites.chr###CHR###_trimmed_info.vcf.bgz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"

--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -14,58 +14,6 @@
       "sample_prefix": "1000GENOMES:phase_3:"
     },
     {
-      "id": "gnomADg_GRCh38",
-      "description": "Genome Aggregation Database genomes r2.1",
-      "species": "homo_sapiens",
-      "assembly": "GRCh38",
-      "type": "local",
-      "filename_template": "/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1/genomes/gnomad.genomes.r2.1.sites.grch38.chr###CHR###_noVEP.vcf.gz",
-      "chromosomes": [
-        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
-        "15", "16", "17", "18", "19", "20", "21", "22", "X"
-      ],
-      "population_prefix": "gnomADg:",
-      "population_display_group": {
-        "display_group_name": "gnomAD genomes",
-        "display_group_priority": 1.5
-      },
-      "populations": {
-        "9900000": {
-          "name": "gnomADg:ALL",
-          "_raw_name": "",
-          "description": "All gnomAD genomes individuals"
-        },
-        "9900001": {
-          "name": "afr",
-          "description": "African/African American"
-        },
-        "9900002": {
-          "name": "amr",
-          "description": "Latino"
-        },
-        "9900003": {
-          "name": "asj",
-          "description": "Ashkenazi Jewish"
-        },
-        "9900004": {
-          "name": "eas",
-          "description": "East Asian"
-        },
-        "9900005": {
-          "name": "fin",
-          "description": "Finnish"
-        },
-        "9900006": {
-          "name": "nfe",
-          "description": "Non-Finnish European"
-        },
-        "9900007": {
-          "name": "oth",
-          "description": "Other"
-        }
-      }
-    },
-    {
       "id": "gnomADe_GRCh38",
       "description": "Genome Aggregation Database exomes r2.1",
       "species": "homo_sapiens",
@@ -133,7 +81,7 @@
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
       ],
       "use_seq_region_synonyms": 1,
-      "population_prefix": "gnomADg.r3.0:",
+      "population_prefix": "gnomADg:",
       "population_display_group": {
         "display_group_name": "gnomAD genomes r3.0",
         "display_group_priority": 1.6

--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -122,6 +122,67 @@
       }
     },
     {
+      "id": "gnomADg_r3.0_GRCh38",
+      "description": "Genome Aggregation Database genomes r3.0",
+      "species": "homo_sapiens",
+      "assembly": "GRCh38",
+      "type": "remote",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r3.0/genomes/gnomad.genomes.r3.0.sites.chr###CHR###_trimmed_info.vcf.bgz",
+      "chromosomes": [
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
+        "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
+      ],
+      "use_seq_region_synonyms": 1,
+      "population_prefix": "gnomADg.r3.0:",
+      "population_display_group": {
+        "display_group_name": "gnomAD genomes r3.0",
+        "display_group_priority": 1.6
+      },
+      "populations": {
+        "9900028": {
+          "name": "gnomADg:ALL",
+          "_raw_name": "",
+          "description": "All gnomAD genomes individuals"
+        },
+        "9900029": {
+          "name": "afr",
+          "description": "African/African American"
+        },
+        "9900030": {
+          "name": "ami",
+          "description": "Amish"
+        },
+        "9900031": {
+          "name": "amr",
+          "description": "Latino/Admixed American"
+        },
+        "9900032": {
+          "name": "asj",
+          "description": "Ashkenazi Jewish"
+        },
+        "9900033": {
+          "name": "eas",
+          "description": "East Asian"
+        },
+        "9900034": {
+          "name": "fin",
+          "description": "Finnish"
+        },
+        "9900035": {
+          "name": "nfe",
+          "description": "Non-Finnish European"
+        },
+        "9900036": {
+          "name": "sas",
+          "description": "South Asian"
+        },
+        "9900037": {
+          "name": "oth",
+          "description": "Other"
+        }
+      }
+    },
+    {
       "id": "topmed_GRCh38",
       "species": "homo_sapiens",
       "assembly": "GRCh38",


### PR DESCRIPTION
Display new gnomad v3 data on [variant page](http://ves-hx2-76.ebi.ac.uk:5040/Homo_sapiens/Variation/Population?db=core;r=1:230845294-230846294;v=rs699;vdb=variation;vf=179#gnomadgenomes_anchor).