### PR TITLE
Update urls for 1000 genomes ftp site

### DIFF
--- a/tools/conf/SiteDefs.pm
+++ b/tools/conf/SiteDefs.pm
@@ -158,9 +158,10 @@ sub update_conf {
   $SiteDefs::GENOME_REST_FILE_URL  = "https://www.internationalgenome.org/api/beta/file/_search";
 
   #1000Genome tool variables
-  $SiteDefs::PHASE1_PANEL_URL   = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20110521/phase1_integrated_calls.20101123.ALL.panel";
-  $SiteDefs::PHASE3_PANEL_URL   = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/integrated_call_samples_v3.20130502.ALL.panel";
-  $SiteDefs::PHASE3_MALE_URL    = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/integrated_call_male_samples_v3.20130502.ALL.panel";
+  $SiteDefs::THOUSAND_GENOMES_FTP_ROOT = 'ftp://ftp.ebi.ac.uk/1000g/ftp';
+  $SiteDefs::PHASE1_PANEL_URL   = $SiteDefs::THOUSAND_GENOMES_FTP_ROOT . "/release/20110521/phase1_integrated_calls.20101123.ALL.panel";
+  $SiteDefs::PHASE3_PANEL_URL   = $SiteDefs::THOUSAND_GENOMES_FTP_ROOT . "/release/20130502/integrated_call_samples_v3.20130502.ALL.panel";
+  $SiteDefs::PHASE3_MALE_URL    = $SiteDefs::THOUSAND_GENOMES_FTP_ROOT . "/release/20130502/integrated_call_male_samples_v3.20130502.ALL.panel";
 
 # Populations dropdown for 1000 genomes tools (data slicer, vcf2ped,..), dropdown value => caption (used in ThousandGenomeInputForm.pm), specific to human only
 # if more species are supported, then this need to be moved to species ini file with each phase url as well

--- a/tools/htdocs/components/20_ThousandGenome.js
+++ b/tools/htdocs/components/20_ThousandGenome.js
@@ -232,7 +232,9 @@ Ensembl.Panel.ThousandGenome = Ensembl.Panel.ToolsForm.extend({
           $.each (data.hits.hits, function (index,el) {
             //Matching the specific region file, Grch37 files have a . after region whereas grch38 have an _ after region
             if(el._source.url && !el._source.url.match(/tbi$/gi) && (el._source.url.match(new RegExp(region+"\\.", 'i')) || el._source.url.match(new RegExp(region+"_", 'i')))) {
-              url = el._source.url;
+              var oldFtpRootPath = 'ftp.1000genomes.ebi.ac.uk/vol1/ftp';
+              var newFtpRootPath = 'ftp.ebi.ac.uk/1000g/ftp';
+              url = el._source.url.replace(oldFtpRootPath, newFtpRootPath); // super ugly hack during data server migration
             }
           });
           panel.elLk.form.find('span._span_url').html("Genotype file URL: "+url);

--- a/tools/modules/EnsEMBL/Web/Component/Tools/DataSlicer/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/DataSlicer/InputForm.pm
@@ -113,7 +113,7 @@ sub get_cacheable_form_node {
     'size'          => 30,
     'class'         => 'url',
     'field_class'   => 'hidden _stt_bam',
-    'notes'         => 'e.g: ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/data/NA06984/alignment/NA06984.454.MOSAIK.SRP000033.2009_11.bam'
+    'notes'         => 'e.g: ' . $SiteDefs::THOUSAND_GENOMES_FTP_ROOT . '/pilot_data/data/NA06984/alignment/NA06984.454.MOSAIK.SRP000033.2009_11.bam'
   });    
   
   $fieldset->add_field({

--- a/tools/modules/EnsEMBL/Web/Component/Tools/ThousandGenomeInputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/ThousandGenomeInputForm.pm
@@ -149,7 +149,7 @@ sub common_form {
       'size'          => 30,
       'class'         => 'url',
       'field_class'   => 'hidden _stt_custom',
-      'notes'         => 'e.g: ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz'
+      'notes'         => 'e.g: ' . $SiteDefs::THOUSAND_GENOMES_FTP_ROOT .  '/release/20130502/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz'
     }),
     $input_fieldset->add_field({
     'type'          => 'radiolist',
@@ -168,7 +168,7 @@ sub common_form {
           'label'         => qq{<span class="ht _ht"><span class="_ht_tip hidden">$sample_tip</span>Sample-population mapping file URL</span>}, #documentation is in docs/htdocs; move to help db if outreach want to control this
           'size'          => 30,
           'class'         => 'url',
-          'notes'         => 'e.g: ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/integrated_call_samples_v3.20130502.ALL.panel',
+          'notes'         => 'e.g: ' . $SiteDefs::PHASE3_PANEL_URL,
           'field_class'   => 'hidden _stt_custom _custom_sample_url',
         })]
     }),


### PR DESCRIPTION
Update ftp host name for 1000 ftp server.

Also, hack our way on the client where we talk with the search server at https://www.internationalgenome.org. The server has to receive ftp url as a parameter, returns empty response if we change the ftp url to the new one, and  is not going to be reconfigured to correctly handle the new one 😞 

**Jira:** ENSWEB-5524

**Sandbox:** http://ves-hx2-76.ebi.ac.uk:8410/info/docs/tools/index.html

~Related PR in ebi-plugins: https://github.com/Ensembl/ebi-plugins/pull/36~