### PR TITLE
[ON HOLD] Add source param to the gxa request url

### DIFF
--- a/widgets/htdocs/widgets/95_GXA.js
+++ b/widgets/htdocs/widgets/95_GXA.js
@@ -39,23 +39,36 @@ Ensembl.Panel.GXA = Ensembl.Panel.Content.extend({
     });
   },
 
-  insertWidget: function() {
+  insertWidget: function(source) {
     var panel = this;
     if ('expressionAtlasHeatmapHighcharts' in window) {
-      try {
+
+      var queryParams = {
+        gene: this.params.geneId, 
+        species: this.params.species
+      };
+      if(source){
+        queryParams.source = source;
         expressionAtlasHeatmapHighcharts.render({
-//atlasHost: "https://wwwdev.ebi.ac.uk", //uncomment for testing widget before GXA release
-          query:{gene: this.params.geneId, species: this.params.species, source:'strain'} ,
+          //atlasHost: "https://wwwdev.ebi.ac.uk", //uncomment for testing widget before GXA release
+          query: queryParams,
           isMultiExperiment: true,
           target : this.elLk.target.attr('id'),
-          fail: function() {
-            panel.showError();
+          fail: function(ex) {
+              console.log(ex);
+              panel.showError();
           }
         });
-      } catch (ex) {
-        console.log(ex);
-        this.showError();
       }
+      expressionAtlasHeatmapHighcharts.render({
+        query: queryParams,
+        isMultiExperiment: true,
+        target : this.elLk.target.attr('id'),
+        fail: function(ex) {
+          panel.insertWidget('strain');
+        }
+      });
+      
     }
   },
 

--- a/widgets/htdocs/widgets/95_GXA.js
+++ b/widgets/htdocs/widgets/95_GXA.js
@@ -59,6 +59,7 @@ Ensembl.Panel.GXA = Ensembl.Panel.Content.extend({
               panel.showError();
           }
         });
+        return;
       }
       expressionAtlasHeatmapHighcharts.render({
         query: queryParams,

--- a/widgets/htdocs/widgets/95_GXA.js
+++ b/widgets/htdocs/widgets/95_GXA.js
@@ -45,7 +45,7 @@ Ensembl.Panel.GXA = Ensembl.Panel.Content.extend({
       try {
         expressionAtlasHeatmapHighcharts.render({
 //atlasHost: "https://wwwdev.ebi.ac.uk", //uncomment for testing widget before GXA release
-          query:{gene: this.params.geneId, species: this.params.species} ,
+          query:{gene: this.params.geneId, species: this.params.species, source:'strain'} ,
           isMultiExperiment: true,
           target : this.elLk.target.attr('id'),
           fail: function() {


### PR DESCRIPTION
Description:
This PR fixes the broken Expression Atlas widget for Fruit Fly (also other species?). The issue was with the missing 'source' param in the request that gets sent to gxa

Sandbox URLs:
Works fine for Humans and Fruit fly:
http://wp-np2-1d.ebi.ac.uk:42229/Homo_sapiens/Gene/ExpressionAtlas?g=ENSG00000139618;r=13:32315086-32400268

http://wp-np2-1d.ebi.ac.uk:42229/Drosophila_melanogaster/Gene/ExpressionAtlas?db=core;g=FBgn0004513;r=3L:6240500-6245746;t=FBtr0077011

Still breaks for Zebrafish:
http://wp-np2-1d.ebi.ac.uk:42229/Danio_rerio/Gene/ExpressionAtlas?g=ENSDARG00000024771;r=18:5213338-5227420;t=ENSDART00000033574



Related JIRA ticket:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-4932

