### PR TITLE
Use http instead of ftp protocol to access files form ftp server

### DIFF
--- a/ensembl/conf/ini-files/DEFAULTS.ini
+++ b/ensembl/conf/ini-files/DEFAULTS.ini
@@ -4,7 +4,7 @@
 
 ENSEMBL_SITE_NAME = Ensembl genome browser
 ENSEMBL_SITE_NAME_SHORT = Ensembl
-ENSEMBL_FTP_URL = ftp://ftp.ensembl.org/pub
+ENSEMBL_FTP_URL = http://ftp.ensembl.org/pub
 ENSEMBL_ROADMAP   = 1
 
 TRANSCRIPT_HAPLOTYPES = 0

--- a/ensembl/conf/ini-files/DEFAULTS.ini
+++ b/ensembl/conf/ini-files/DEFAULTS.ini
@@ -4,7 +4,8 @@
 
 ENSEMBL_SITE_NAME = Ensembl genome browser
 ENSEMBL_SITE_NAME_SHORT = Ensembl
-ENSEMBL_FTP_URL = http://ftp.ensembl.org/pub
+ENSEMBL_FTP_URL = ftp://ftp.ensembl.org/pub
+ENSEMBL_FTP_OVER_HTTP_URL = http://ftp.ensembl.org/pub
 ENSEMBL_ROADMAP   = 1
 
 TRANSCRIPT_HAPLOTYPES = 0


### PR DESCRIPTION
Changing the protocol for accessing files on ftp.ensembl.org from `ftp://` to `http://`, because:

- there is a firewall on web machines, which the FTP client was not using (potentially solvable by adding the [firewall option](https://perldoc.perl.org/Net/FTP.html) to the FTP client (see _ftp_file_exists method on [BaseAnnotationAdaptor](https://github.com/Ensembl/ensembl-variation/blob/release/99/modules/Bio/EnsEMBL/Variation/DBSQL/BaseAnnotationAdaptor.pm))
- in general, http protocol should be preferred over ftp as more resilient

Sandbox:
http://ves-hx2-76.ebi.ac.uk:8410/Homo_sapiens/Variation/Explore?r=1:230709548-230710548;v=rs699;vdb=variation;vf=179

notice the presence of the GERP score in the "Change tolerance" line
![image](https://user-images.githubusercontent.com/6834224/77675359-c0d87980-6f84-11ea-9ba1-7bfa6f50a8e1.png)

**Note:** the sandbox also contains changes in BaseAnnotationAdaptor.pm (from ensembl-variation repo) for switching between http and ftp protocols.