### PR TITLE
Zebra finch search fix for 99

### DIFF
--- a/solr/htdocs/solr/02_solr_search.js
+++ b/solr/htdocs/solr/02_solr_search.js
@@ -559,7 +559,11 @@
       for (k in ref) {
         v = ref[k];
         if (v) {
-          out[k] = v;
+          if (k === 'species' && v === 'Zebra finch') {
+            out[k] = "Zebra Finch";
+          } else {
+            out[k] = v;
+          }
         }
       }
       return out;

--- a/solr/src/search.coffee
+++ b/solr/src/search.coffee
@@ -289,7 +289,11 @@ class Hub
   current_facets: ->
     out = {}
     for k,v of @sections['facet']
-      if v then out[k] = v
+      if v 
+        if(k=='species' and v == 'Zebra finch')
+          out[k] = "Zebra Finch";
+        else 
+          out[k] = v
     return out
 
   ddg_style_search: ->


### PR DESCRIPTION
Description:
Quick and dirty fix for the Zebra finch search issue for e99.

Sandbox URL:
http://ves-hx2-76.ebi.ac.uk:42229/Taeniopygia_guttata/Info/Index

Related ticket:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5610