### PR TITLE
Remove dN/dS from Compara docs (homology_method.html)

### DIFF
--- a/ensembl/htdocs/info/genome/compara/homology_method.html
+++ b/ensembl/htdocs/info/genome/compara/homology_method.html
@@ -57,8 +57,6 @@ given internal node of the tree.
 
 <li>A <a href="stables_id.html">stable ID</a> is assigned to each GeneTree.</li>
 
-<li>There is an extra optional step which calculates the dN/dS values for the orthology relationships of closely related pairs of species, using <a href="http://abacus.gene.ucl.ac.uk/software/paml.html">codeml6</a> with the parameters found
-<a href="https://github.com/Ensembl/ensembl-compara/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/scripts/pipeline/protein_trees.codeml.ctl.hash">here</a>.</li>
 </ol>
 
 


### PR DESCRIPTION
Compara is removing dN/dS data from their database, and we are removing dN/dS from the site.

Related PR in ensembl-webcode: https://github.com/Ensembl/ensembl-webcode/pull/767

Jira ticket: ENSWEB-5457

Sandbox: http://ves-hx2-76.ebi.ac.uk:8410/info/genome/compara/homology_method.html