### PR TITLE
add configuration for GGVP data

### DIFF
--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -131,6 +131,18 @@
       }
     },
     {
+      "id": "gambian_genome_variation_project_GRCh38",
+      "species": "homo_sapiens",
+      "assembly": "GRCh38",
+      "type": "remote",
+      "filename_template" : "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/gambian_genome_variation_project/release/20200217_biallelic_SNV/ALL_GGVP.chr###CHR###.shapeit2_integrated_snvindels_v1b_20200120.GRCh38.phased.vcf.gz",
+      "sample_prefix": "GGVP:",
+      "chromosomes": [
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
+        "15", "16", "17", "18", "19", "20", "21", "22", "X"
+      ]
+    },
+    {
       "id": "topmed_GRCh38",
       "species": "homo_sapiens",
       "assembly": "GRCh38",


### PR DESCRIPTION
We are planning to display frequencies from the Gambian Variation Project. The data is remotely stored under http://ftp.1000genomes.ebi.ac.uk/
I tested the configuration on my sandbox. However, I cannot get tabix to retrieve data from remote VCF files on my sandbox and had to copy one VCF file to my sandbox for testing.

I can retrieve the data on the farm with a script I have written.