### PR TITLE
Fix search autocomplete ontology directlinks

### DIFF
--- a/solr/htdocs/components/65_autocomplete.js
+++ b/solr/htdocs/components/65_autocomplete.js
@@ -339,6 +339,12 @@
             var ref4;
             return (ref4 = doc[m1]) != null ? ref4 : '';
           }));
+
+          // check if this is ontology accession where the id will have the following format 'XXX:XXX'
+          if(typeof doc.id === 'string' && doc.id.split(':').length === 2){
+            doc.url = doc.url.replace(/ph=/g, 'oa=');
+          }
+          
           output.push(doc);
           j += 1;
           if (j >= direct_limit) {


### PR DESCRIPTION
**Related JIRA:**
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5504


**Description**
Fixed the issue with the autocomplete where the ontology accession direct links are broken. 


**Sandbox URL:**
http://ves-hx2-76.ebi.ac.uk:42229/Homo_sapiens/Info/Index?db=core