### PR TITLE
Fix sgd url

### DIFF
--- a/ensembl/conf/ini-files/saccharomyces_cerevisiae.ini
+++ b/ensembl/conf/ini-files/saccharomyces_cerevisiae.ini
@@ -69,10 +69,10 @@ ASSEMBLY_CONVERTER_FILES = [EF2_to_R64-1-1 EF3_to_R64-1-1 R64-1-1_to_EF2 R64-1-1
 
 [ENSEMBL_EXTERNAL_URLS]
 
-OPERON          = http://db.yeastgenome.org/cgi-bin/locus.pl?locus=###ID###
-SGD             = http://db.yeastgenome.org/cgi-bin/locus.pl?locus=###ID###
-SGD_GENE        = http://db.yeastgenome.org/cgi-bin/locus.pl?locus=###ID###
-SGD_TRANSCRIPT  = http://db.yeastgenome.org/cgi-bin/locus.pl?locus=###ID###
+OPERON          = https://www.yeastgenome.org/locus/###ID###
+SGD             = https://www.yeastgenome.org/locus/###ID###
+SGD_GENE        = https://www.yeastgenome.org/locus/###ID###
+SGD_TRANSCRIPT  = https://www.yeastgenome.org/locus/###ID###
 UNIPARC         = http://www.uniprot.org/uniparc/###ID###
 
 [ENSEMBL_DICTIONARY]


### PR DESCRIPTION
The bug was initially reported by Ameya and is described in the JIRA ticket:
https://www.ebi.ac.uk/panda/jira/browse/ENSINT-491
There has been a change in the syntax on how SGD is accessed
Instead of 
http://db.yeastgenome.org/cgi-bin/locus.pl?locus=###ID###
It needs to be
https://www.yeastgenome.org/locus/###ID###
 
There are at least two files where this information is stored:
https://github.com/Ensembl/public-plugins/blob/release/100/ensembl/conf/ini-files/saccharomyces_cerevisiae.ini#L70
and
https://github.com/EnsemblGenomes/eg-web-common/blob/release/eg/47/conf/ini-files/DEFAULTS.ini

Are there any others? 