### PR TITLE
Add phenotype class docs

### DIFF
--- a/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
+++ b/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
@@ -119,28 +119,29 @@ using an automated process. Ontologies used are:</p>
 phenotypes </p> -->
 <table class="ss" style="width:auto">
   <thead>
-    <tr><th colspan="2">Type</th><th style="border-left:1px solid #BBB">Example</th></tr>
+    <tr><th>Classes</th><th style="border-left:1px solid #BBB"> Example phenotypes</th><th style="border-left:1px solid #BBB">Example variants</th></tr>
   </thead>
   <tbody>
     <tr>
-      <td><b>trait</b></td>
-      <td> eg. Hepatocellular carcinoma from <a href="https://www.ncbi.nlm.nih.gov/clinvar/">ClinVar</a></td>
+      <td><b>trait</b>
+      <td style="border-left:1px solid #BBB">'Hepatocellular carcinoma' from <a href="https://www.ncbi.nlm.nih.gov/clinvar/">ClinVar</a></td>
       <td style="border-left:1px solid #BBB"><a href="/Homo_sapiens/Variation/Phenotype/?v=rs11554290">rs11554290</a></td>
     </tr>
     <tr class="bg2">
       <td><b>tumour</b></a></td>
-      <td> eg. Skin tumour from <a href="https://cancer.sanger.ac.uk/cosmic">COSMIC</a></td>
+      <td style="border-left:1px solid #BBB">'Skin tumour' from <a href="https://cancer.sanger.ac.uk/cosmic">COSMIC</a></td>
       <td style="border-left:1px solid #BBB"><a href="/Homo_sapiens/Variation/Phenotype/?v=COSV99082046">COSV99082046 </a></td>
     </tr>
     <tr>
       <td><b>non_specified</b></td>
-      <td>eg. ClinVar: phenotype not specified</td>
+      <td style="border-left:1px solid #BBB">'not specified' from <a href="https://www.ncbi.nlm.nih.gov/clinvar/">ClinVar</a></td>
       <td style="border-left:1px solid #BBB"><a href="/Homo_sapiens/Variation/Phenotype/?v=rs757730609">rs757730609</a></td>
     </tr>
 
   </tbody>
 </table>
-<p>These can be used to retrieve corresponding subsets of phenotype annotations for genes or in a specific region via the <a href="http://rest.ensembl.org/">REST</a> API.</p>
+<p>These can be used to retrieve corresponding subsets of phenotype annotations for genes or in a specific region via the <a href="http://rest.ensembl.org/">REST</a> API.
+ Phenotype pages are displayed for all classes except 'non_specified' class.</p>
 
 <br />
 <p>

--- a/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
+++ b/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
@@ -138,7 +138,7 @@ using an automated process. Ontologies used are:</p>
 
   </tbody>
 </table>
-<p>These can be used to retrieve corresponding subsets of phenotype annotations for genes or in a specific region via the <a href="http://rest.ensembl.org/">REST</a> API.
+<p>These can be used to retrieve corresponding subsets of phenotype annotations for genes or in a specific region via the <a href="https://rest.ensembl.org/">REST</a> API.
  Phenotype pages are displayed for all classes except 'non_specified' class.</p>
 
 <br />

--- a/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
+++ b/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
@@ -114,7 +114,7 @@ using an automated process. Ontologies used are:</p>
 <hr style="margin-bottom:4px" />
 <p></p>
 <h2 id="phenotype_ontologies">Phenotype classes</h2>
-<p>We group phenotype terms into the following classes: </p>
+<p>We group phenotype terms into the classes below: </p>
 <!--  For phenotypes depicting tumours we deferentiate between phenotypes directly linked to a gene or variation AND
 phenotypes </p> -->
 <table class="ss" style="width:auto">
@@ -140,6 +140,7 @@ phenotypes </p> -->
 
   </tbody>
 </table>
+<p>These can be used to retrieve corresponding subsets of phenotype annotations for genes or in a specific region via the <a href="http://rest.ensembl.org/">REST</a> API.</p>
 
 <br />
 <p>

--- a/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
+++ b/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
@@ -113,10 +113,8 @@ using an automated process. Ontologies used are:</p>
 <br />
 <hr style="margin-bottom:4px" />
 <p></p>
-<h2 id="phenotype_ontologies">Phenotype classes</h2>
+<h2 id="phenotype_classes">Phenotype classes</h2>
 <p>We group phenotype terms into the classes below: </p>
-<!--  For phenotypes depicting tumours we deferentiate between phenotypes directly linked to a gene or variation AND
-phenotypes </p> -->
 <table class="ss" style="width:auto">
   <thead>
     <tr><th>Classes</th><th style="border-left:1px solid #BBB"> Example phenotypes</th><th style="border-left:1px solid #BBB">Example variants</th></tr>

--- a/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
+++ b/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
@@ -125,7 +125,7 @@ phenotypes </p> -->
     <tr>
       <td><b>trait</b></td>
       <td> eg. Hepatocellular carcinoma from <a href="https://www.ncbi.nlm.nih.gov/clinvar/">ClinVar</a></td>
-      <td style="border-left:1px solid #BBB"><a href="/Homo_sapiens/Phenotype/Locations?oa=HP:0001402">rs11554290</a></td>
+      <td style="border-left:1px solid #BBB"><a href="/Homo_sapiens/Variation/Phenotype/?v=rs11554290">rs11554290</a></td>
     </tr>
     <tr class="bg2">
       <td><b>tumour</b></a></td>

--- a/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
+++ b/ensembl/htdocs/info/genome/variation/phenotype/phenotype_annotation.html
@@ -98,6 +98,7 @@ using an automated process. Ontologies used are:</p>
     
   </tbody>
 </table>
+
 <p></p>
 <p>
 <h3>Descriptions are linked to ontology terms using:</h3>
@@ -108,6 +109,39 @@ using an automated process. Ontologies used are:</p>
 <li><a href="http://www.ebi.ac.uk/ols/">Ontology LookUp Service</a> searches of full or truncated descriptions for exact matches to terms or synomyms</li>
 <li><a href="http://www.ebi.ac.uk/spot/zooma/">Zooma</a> searches of annotations curated by the <a href="http://www.ebi.ac.uk/eva/">European Variation Archive</a> team</li>
 </ul>
+
+<br />
+<hr style="margin-bottom:4px" />
+<p></p>
+<h2 id="phenotype_ontologies">Phenotype classes</h2>
+<p>We group phenotype terms into the following classes: </p>
+<!--  For phenotypes depicting tumours we deferentiate between phenotypes directly linked to a gene or variation AND
+phenotypes </p> -->
+<table class="ss" style="width:auto">
+  <thead>
+    <tr><th colspan="2">Type</th><th style="border-left:1px solid #BBB">Example</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><b>trait</b></td>
+      <td> eg. Hepatocellular carcinoma from <a href="https://www.ncbi.nlm.nih.gov/clinvar/">ClinVar</a></td>
+      <td style="border-left:1px solid #BBB"><a href="/Homo_sapiens/Phenotype/Locations?oa=HP:0001402">rs11554290</a></td>
+    </tr>
+    <tr class="bg2">
+      <td><b>tumour</b></a></td>
+      <td> eg. Skin tumour from <a href="https://cancer.sanger.ac.uk/cosmic">COSMIC</a></td>
+      <td style="border-left:1px solid #BBB"><a href="/Homo_sapiens/Variation/Phenotype/?v=COSV99082046">COSV99082046 </a></td>
+    </tr>
+    <tr>
+      <td><b>non_specified</b></td>
+      <td>eg. ClinVar: phenotype not specified</td>
+      <td style="border-left:1px solid #BBB"><a href="/Homo_sapiens/Variation/Phenotype/?v=rs757730609">rs757730609</a></td>
+    </tr>
+
+  </tbody>
+</table>
+
+<br />
 <p>
 <h3>References</h3>
 <ul>

--- a/ensembl/htdocs/info/genome/variation/tools/data_access.html
+++ b/ensembl/htdocs/info/genome/variation/tools/data_access.html
@@ -147,7 +147,7 @@ display.
     <span style="vertical-align:top">: Sample clients and information for using the Ensembl REST APIs.</span>
   </li>
   <li style="list-style-image: url(/i/16/documentation.png);vertical-align:top">
-    <a href="http://rest.ensembl.org/documentation" style="font-weight:bold;vertical-align:top">REST Endpoints</a>
+    <a href="https://rest.ensembl.org/documentation" style="font-weight:bold;vertical-align:top">REST Endpoints</a>
     <span style="vertical-align:top">: A complete reference to the Endpoints used in the Ensembl REST API.</span>
   </li> 
 </ul>

--- a/ensembl/htdocs/info/genome/variation/tools/variant_tools.html
+++ b/ensembl/htdocs/info/genome/variation/tools/variant_tools.html
@@ -89,7 +89,7 @@
           </div>
           <div style="float:right">
             <span style="display:table-cell">Availability:</span>
-            <a href="http://rest.ensembl.org/documentation/info/variant_recoder" class="_ht" style="display:table-cell" title="REST API"><img src="/img/restlogo_sq.png" style="border:1px solid #CCC;border-radius:5px;width:48px;vertical-align:middle;margin-left:15px"/></a>
+            <a href="https://rest.ensembl.org/documentation/info/variant_recoder" class="_ht" style="display:table-cell" title="REST API"><img src="/img/restlogo_sq.png" style="border:1px solid #CCC;border-radius:5px;width:48px;vertical-align:middle;margin-left:15px"/></a>
             <a href="/info/docs/tools/vep/recoder/index.html" class="_ht" style="display:table-cell" title="Standalone Perl script"><img src="/img/vep_cmd.png" style="border:1px solid #CCC;border-radius:5px;width:48px;vertical-align:middle;margin-left:15px"/></a>
           </div>
           <div class="clear"></div>


### PR DESCRIPTION
New section "Phenotype classes":
http://ves-hx2-76.ebi.ac.uk:6080/info/genome/variation/phenotype/phenotype_annotation.html
vs
https://www.ensembl.org/info/genome/variation/phenotype/phenotype_annotation.html

Also update http to https for REST in :
http://ves-hx2-76.ebi.ac.uk:6080/info/genome/variation/tools/data_access.html
http://ves-hx2-76.ebi.ac.uk:6080/info/genome/variation/tools/variant_tools.html