### PR TITLE
COVID-19 - Fix FTP site URLs in the species homepage

### DIFF
--- a/covid19/modules/EnsEMBL/Web/Component/Info.pm
+++ b/covid19/modules/EnsEMBL/Web/Component/Info.pm
@@ -26,7 +26,8 @@ use EnsEMBL::Web::Controller::SSI;
 
 sub ftp_url {
   my $self = shift;
-  return $ftp_site ? sprintf '%s/', $self->hub->species_defs->ENSEMBL_FTP_URL : undef;
+  my $ftp_site = $self->hub->species_defs->ENSEMBL_FTP_URL;
+  return $ftp_site ? sprintf '%s', $ftp_site: undef;
 }
 
 

--- a/covid19/modules/EnsEMBL/Web/Component/Info.pm
+++ b/covid19/modules/EnsEMBL/Web/Component/Info.pm
@@ -23,6 +23,13 @@ use strict;
 
 use EnsEMBL::Web::Controller::SSI;
 
+
+sub ftp_url {
+  my $self = shift;
+  return $ftp_site ? sprintf '%s/', $self->hub->species_defs->ENSEMBL_FTP_URL : undef;
+}
+
+
 sub include_more_annotations {
   my $self              = shift;
   my $hub               = $self->hub;

--- a/covid19/modules/EnsEMBL/Web/Component/Info.pm
+++ b/covid19/modules/EnsEMBL/Web/Component/Info.pm
@@ -26,8 +26,7 @@ use EnsEMBL::Web::Controller::SSI;
 
 sub ftp_url {
   my $self = shift;
-  my $ftp_site = $self->hub->species_defs->ENSEMBL_FTP_URL;
-  return $ftp_site ? sprintf '%s', $ftp_site: undef;
+  return $self->hub->species_defs->ENSEMBL_FTP_URL;
 }
 
 


### PR DESCRIPTION
This PR is to fix the broken FTP site URLs in the COVID-19 site species homepage.

Related JIRA:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5872

Sandbox URL:
http://ves-hx2-76.ebi.ac.uk:42227/Sars_cov_2/Info/Index