### PR TITLE
Add missing SPECIES_IMAGE_DIR

### DIFF
--- a/ensembl/conf/SiteDefs.pm
+++ b/ensembl/conf/SiteDefs.pm
@@ -26,6 +26,8 @@ sub update_conf {
 
   $SiteDefs::ENSEMBL_PUBLIC_DB          = 'ensembldb.ensembl.org';
 
+  $SiteDefs::SPECIES_IMAGE_DIR          = defer { $SiteDefs::ENSEMBL_SERVERROOT.'/public-plugins/ensembl/'.$SiteDefs::DEFAULT_SPECIES_IMG_DIR };
+  
   $SiteDefs::ARCHIVE_BASE_DOMAIN        = 'archive.ensembl.org';
   $SiteDefs::ENSEMBL_REST_URL           = 'https://rest.ensembl.org';  # URL for the REST API
   $SiteDefs::ENSEMBL_REST_DOC_URL       = 'https://github.com/Ensembl/ensembl-rest/wiki';


### PR DESCRIPTION
This PR fixes the issue with missing species image for Cat on the assembly and annotation page.
https://www.ensembl.org/Felis_catus/Info/Annotation

Related JIRA:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5864

Sandbox URL:
http://ves-hx2-76.ebi.ac.uk:42229/Felis_catus/Info/Annotation