### PR TITLE
Typo in href link

### DIFF
--- a/ensembl/htdocs/info/genome/compara/Ortholog_qc_manual.html
+++ b/ensembl/htdocs/info/genome/compara/Ortholog_qc_manual.html
@@ -14,7 +14,7 @@
 <p>We have two methods to provide quality scores for orthologue pairs:</p>
 
 <ul>
-<li><a href="#gic">Gene order conservation (GOC) score</a></li>
+<li><a href="#goc">Gene order conservation (GOC) score</a></li>
 
 <li><a href="#wga">Whole genome alignment score</a></li>
 </ul>


### PR DESCRIPTION
_Note:_ Not sure if there was a faster workaround, but this is the one I'm more familiar with.