### PR TITLE
show gerp scores for new sheep reference

### DIFF
--- a/ensembl/conf/json/ovis_aries_rambouillet_vcf.json
+++ b/ensembl/conf/json/ovis_aries_rambouillet_vcf.json
@@ -1,0 +1,12 @@
+{
+  "collections": [
+    {
+      "id": "111_mammals.gerp_conservation_score",
+      "species": "ovis_aries_rambouillet",
+      "assembly": "Oar_rambouillet_v1.0",
+      "type": "remote",
+      "filename_template" : "/111_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries_rambouillet.Oar_rambouillet_v1.0.bw",
+      "annotation_type": "gerp"
+    }
+  ]
+}


### PR DESCRIPTION
ovis_aries_rambouillet is the new reference and we have a variation database for this species from release 102. This PR is needed to configure the location of the GERP file. GERP scores are shown on the variation summary page. 