### PR TITLE
update bam file loction to stable release

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_other.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_other.html
@@ -504,7 +504,7 @@ var_2  1:230710514  -  -  -  -  missense_variant,synonymous_variant,downstream_g
   <p>BAM files are available from NCBI:</p>
 
   <ul>
-    <li><a href="https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/Homo_sapiens/annotation_releases/current/GCF_000001405.38_GRCh38.p12/RefSeq_transcripts_alignments/" rel="external">Human GRCh38.p12</a></li>
+    <li><a href="https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/Homo_sapiens/annotation_releases/109.20200815/GCF_000001405.39_GRCh38.p13/RefSeq_transcripts_alignments/" rel="external">Human GRCh38.p13</a></li>
     <li><a href="https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/Homo_sapiens/annotation_releases/105.20190906/GCF_000001405.25_GRCh37.p13/RefSeq_transcripts_alignments/" rel="external">Human GRCh37.p13</a></li>
   </ul>
 


### PR DESCRIPTION
The url to download bam files has changed and is now creating a 404 error. I changed the url with a stable release version now.