### PR TITLE
Fix VEP column not found bug

### DIFF
--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -144,20 +144,22 @@ sub _configure_plugins {
     
     foreach my $param(@{$plugin->{params}}) {
       
+      my $param_clone = $param;
+
       # links to something in the form
-      if($param =~ /^\@/) {
-        $param =~ s/^\@//;
+      if($param_clone =~ /^\@/) {
+        $param_clone =~ s/^\@//;
         
         my @matched = ();
         
         # fuzzy match?
-        if($param =~ /\*/) {
-          $param =~ s/\*/\.\*/;
-          @matched = grep {$_->{name} =~ /$param/} @{$plugin->{form}};
+        if($param_clone =~ /\*/) {
+          $param_clone =~ s/\*/\.\*/;
+          @matched = grep {$_->{name} =~ /$param_clone/} @{$plugin->{form}};
         }
         
         else {
-          @matched = grep {$_->{name} eq $param} @{$plugin->{form}};
+          @matched = grep {$_->{name} eq $param_clone} @{$plugin->{form}};
         }
         
         foreach my $el(@matched) {
@@ -176,7 +178,7 @@ sub _configure_plugins {
       
       # otherwise just plain text
       else {
-        push @params, $param;
+        push @params, $param_clone;
       }
     }
     


### PR DESCRIPTION
**Description:**
This PR is to fix the intermittent error that was breaking the VEP tool jobs.

The problem is something to do with the following line:
https://github.com/Ensembl/public-plugins/blob/release/100/tools/modules/EnsEMBL/Web/Job/VEP.pm#L155
Modifying the value of $param somehow gets temporarily changed in the stored config.
To fix this, I'm just cloning the $param defined in the foreach to $param_clone and using it instead.

**Example ticket that was throwing this error:**
http://debug.ensembl.org/Homo_sapiens/Tools/VEP/View?db=core;tl=9QezRSx98mS7heaW-6524731

**Related JIRA:**
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5658

