### PR TITLE
move ggvp data to ensembl file system

### DIFF
--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -134,8 +134,8 @@
       "id": "gambian_genome_variation_project_GRCh38",
       "species": "homo_sapiens",
       "assembly": "GRCh38",
-      "type": "remote",
-      "filename_template" : "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/gambian_genome_variation_project/release/20200217_biallelic_SNV/ALL_GGVP.chr###CHR###.shapeit2_integrated_snvindels_v1b_20200120.GRCh38.phased.vcf.gz",
+      "type": "local",
+      "filename_template" : "/homo_sapiens/GRCh38/variation_genotype/ggvp/ALL_GGVP.chr###CHR###.shapeit2_integrated_snvindels_v1b_20200120.GRCh38.phased.vcf.gz",
       "sample_prefix": "GGVP:",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",


### PR DESCRIPTION
Because of problems with igsr FTP site it was decided to move files to the ensembl ftp site and sync with internal file system (base path = /.../ensweb-data/data_files/www). The VCF files need to be copied to the internal file system before this PR is merged.
The files have already been copied to ../ensemblftp/data_files/homo_sapiens/GRCh38/variation_genotype/ggvp