### PR TITLE
move ggvp data to ensembl file system

### DIFF
--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -202,8 +202,8 @@
       "id": "gambian_genome_variation_project_GRCh38",
       "species": "homo_sapiens",
       "assembly": "GRCh38",
-      "type": "remote",
-      "filename_template" : "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/gambian_genome_variation_project/release/20200217_biallelic_SNV/ALL_GGVP.chr###CHR###.shapeit2_integrated_snvindels_v1b_20200120.GRCh38.phased.vcf.gz",
+      "type": "local",
+      "filename_template" : "/homo_sapiens/GRCh38/variation_genotype/ggvp/ALL_GGVP.chr###CHR###.shapeit2_integrated_snvindels_v1b_20200120.GRCh38.phased.vcf.gz",
       "sample_prefix": "GGVP:",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",


### PR DESCRIPTION
Same as #389 and #390 Data is now retrieved from internal file system: e.g. [rs2827458](http://www.ensembl.org/Homo_sapiens/Variation/Population?db=core;r=21:22398177-22399177;v=rs2827458;vdb=variation;vf=51942999)