### PR TITLE
ENSWEB-5921: Fix wrong example FTP URL

### DIFF
--- a/docs/htdocs/info/docs/webcode/mirror/install/ensembl-data.html
+++ b/docs/htdocs/info/docs/webcode/mirror/install/ensembl-data.html
@@ -13,7 +13,7 @@ in the form of tab-delimited text files for importing into MySQL. Go to the appr
 directory and then to  'mysql'.
 </p>
 
-<p>e.g. <a href="[[SPECIESDEFS::ENSEMBL_EXAMPLE_FTP_URL]]">[[SPECIESDEFS::ENSEMBL_EXAMPLE_FTP_URL]]</a></p>
+<p>e.g. <a href="[[SPECIESDEFS::ENSEMBL_FTP_OVER_FTP_URL]]">[[SPECIESDEFS::ENSEMBL_FTP_OVER_FTP_URL]]</a></p>
 <h2>The MySQL data</h2>
 <p>Each database directory contains a data file for each table in that database an SQL file that contains the SQL commands necessary to build that database's table structure and a checksum file (using a UNIX "sum" utility) so you can verify that the data has downloaded correctly.</p>
 

--- a/docs/htdocs/info/docs/webcode/mirror/install/ensembl-data.html
+++ b/docs/htdocs/info/docs/webcode/mirror/install/ensembl-data.html
@@ -13,7 +13,7 @@ in the form of tab-delimited text files for importing into MySQL. Go to the appr
 directory and then to  'mysql'.
 </p>
 
-<p>e.g. <a href="ftp://ftp.ensembl.org/pub/current_mysql/">ftp://ftp.ensembl.org/pub/current_mysql/</a></p>
+<p>e.g. <a href="[[SPECIESDEFS::ENSEMBL_EXAMPLE_FTP_URL]]">[[SPECIESDEFS::ENSEMBL_EXAMPLE_FTP_URL]]</a></p>
 <h2>The MySQL data</h2>
 <p>Each database directory contains a data file for each table in that database an SQL file that contains the SQL commands necessary to build that database's table structure and a checksum file (using a UNIX "sum" utility) so you can verify that the data has downloaded correctly.</p>
 

--- a/docs/htdocs/info/docs/webcode/mirror/install/ensembl-data.html
+++ b/docs/htdocs/info/docs/webcode/mirror/install/ensembl-data.html
@@ -13,7 +13,7 @@ in the form of tab-delimited text files for importing into MySQL. Go to the appr
 directory and then to  'mysql'.
 </p>
 
-<p>e.g. <a href="[[SPECIESDEFS::ENSEMBL_FTP_OVER_FTP_URL]]">[[SPECIESDEFS::ENSEMBL_FTP_OVER_FTP_URL]]</a></p>
+<p>e.g. <a href="[[SPECIESDEFS::ENSEMBL_MYSQL_FTP_URL]]">[[SPECIESDEFS::ENSEMBL_MYSQL_FTP_URL]]</a></p>
 <h2>The MySQL data</h2>
 <p>Each database directory contains a data file for each table in that database an SQL file that contains the SQL commands necessary to build that database's table structure and a checksum file (using a UNIX "sum" utility) so you can verify that the data has downloaded correctly.</p>
 

--- a/ensembl/conf/SiteDefs.pm
+++ b/ensembl/conf/SiteDefs.pm
@@ -32,7 +32,6 @@ sub update_conf {
   $SiteDefs::ARCHIVE_BASE_DOMAIN        = 'archive.ensembl.org';
   $SiteDefs::ENSEMBL_REST_URL           = 'https://rest.ensembl.org';  # URL for the REST API
   $SiteDefs::ENSEMBL_REST_DOC_URL       = 'https://github.com/Ensembl/ensembl-rest/wiki';
-  $SiteDefs::ENSEMBL_EXAMPLE_FTP_URL    = 'ftp://ftp.ensembl.org/pub/current_mysql';
 
   $SiteDefs::GXA                        = 1; #enabling gene expression atlas
 

--- a/ensembl/conf/SiteDefs.pm
+++ b/ensembl/conf/SiteDefs.pm
@@ -32,6 +32,7 @@ sub update_conf {
   $SiteDefs::ARCHIVE_BASE_DOMAIN        = 'archive.ensembl.org';
   $SiteDefs::ENSEMBL_REST_URL           = 'https://rest.ensembl.org';  # URL for the REST API
   $SiteDefs::ENSEMBL_REST_DOC_URL       = 'https://github.com/Ensembl/ensembl-rest/wiki';
+  $SiteDefs::ENSEMBL_EXAMPLE_FTP_URL    = 'ftp://ftp.ensembl.org/pub/current_mysql';
 
   $SiteDefs::GXA                        = 1; #enabling gene expression atlas
 

--- a/ensembl/conf/ini-files/DEFAULTS.ini
+++ b/ensembl/conf/ini-files/DEFAULTS.ini
@@ -5,6 +5,7 @@ ENSEMBL_SITE_NAME = Ensembl genome browser
 ENSEMBL_SITE_NAME_SHORT = Ensembl
 ENSEMBL_FTP_URL = ftp://ftp.ensembl.org/pub
 ENSEMBL_FTP_OVER_HTTP_URL = http://ftp.ensembl.org/pub
+ENSEMBL_FTP_OVER_FTP_URL = ftp://ftp.ensembl.org/pub/current_mysql
 ENSEMBL_ROADMAP   = 1
 USE_COMMON_NAMES = 1
 

--- a/ensembl/conf/ini-files/DEFAULTS.ini
+++ b/ensembl/conf/ini-files/DEFAULTS.ini
@@ -5,7 +5,7 @@ ENSEMBL_SITE_NAME = Ensembl genome browser
 ENSEMBL_SITE_NAME_SHORT = Ensembl
 ENSEMBL_FTP_URL = ftp://ftp.ensembl.org/pub
 ENSEMBL_FTP_OVER_HTTP_URL = http://ftp.ensembl.org/pub
-ENSEMBL_FTP_OVER_FTP_URL = ftp://ftp.ensembl.org/pub/current_mysql
+ENSEMBL_MYSQL_FTP_URL = ftp://ftp.ensembl.org/pub/current_mysql
 ENSEMBL_ROADMAP   = 1
 USE_COMMON_NAMES = 1
 


### PR DESCRIPTION
The GRCh37 site's help page 'Installing the Ensembl Data' shows the vertebrate (www) FTP URL. This PR fixes that by adding a SiteDefs variable.

This PR needs to be merged at the same time as [68 in ebi-plugins](https://github.com/Ensembl/ebi-plugins/pull/68) is merged. 
