### PR TITLE
Fix direct links space encoding issue

### DIFF
--- a/solr/htdocs/components/65_autocomplete.js
+++ b/solr/htdocs/components/65_autocomplete.js
@@ -322,7 +322,7 @@
           ref3 = d.split('__');
           for (o = 0, len2 = ref3.length; o < len2; o++) {
             p = ref3[o];
-            parts.push(p.replace(/_\+/g, ' ').replace(/_\-?/g, '_'));
+            parts.push(p.replace(/_\+/g, '_').replace(/_\-/g, ' '));
           }
           species = $.solr_config('revspnames.%', parts[0].toLowerCase());
           ucspecies = parts[0].charAt(0).toUpperCase() + parts[0].slice(1);


### PR DESCRIPTION
Description:
- This PR is to fix the broken direct links when the gene stable_id has underscores in it

Related JIRA:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6071

Sandbox URL:
http://ves-hx2-75.ebi.ac.uk:42229/Mus_caroli/Info/Index

Steps to reproduce:
1) Go to http://www.ensembl.org/Mus_caroli/Info/Index
2) Search for `twnk` gene
3) Select the option that says `Twnk  MGP_CAROLIEiJ_....` 
