### PR TITLE
Variant Recoder - update documentation 

### DIFF
--- a/ensembl/htdocs/info/genome/variation/tools/variant_tools.html
+++ b/ensembl/htdocs/info/genome/variation/tools/variant_tools.html
@@ -89,6 +89,7 @@
           </div>
           <div style="float:right">
             <span style="display:table-cell">Availability:</span>
+            <a href="/Tools/VR" class="_ht" style="display:table-cell" title="Web tool"><img src="/img/vep_globe.png" style="border:1px solid #CCC;border-radius:5px;background-color:#336;width:48px;vertical-align:middle;margin-left:15px"/></a>
             <a href="https://rest.ensembl.org/documentation/info/variant_recoder" class="_ht" style="display:table-cell" title="REST API"><img src="/img/restlogo_sq.png" style="border:1px solid #CCC;border-radius:5px;width:48px;vertical-align:middle;margin-left:15px"/></a>
             <a href="/info/docs/tools/vep/recoder/index.html" class="_ht" style="display:table-cell" title="Standalone Perl script"><img src="/img/vep_cmd.png" style="border:1px solid #CCC;border-radius:5px;width:48px;vertical-align:middle;margin-left:15px"/></a>
           </div>


### PR DESCRIPTION
Variant recoder is also available as a web tool.
Sandbox: http://ves-hx2-76.ebi.ac.uk:7040/info/genome/variation/tools/variant_tools.html 