### PR TITLE
Update DisGeNET output (104)

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -149,9 +149,9 @@ sub content {
   # Description example: "Variant-Disease-PMID associations from the DisGeNET database. The output includes 
   #   the PMID of the publication reporting the Variant-Disease association, DisGeNET score for the Variant-Disease association, 
   #   name of associated disease. Each value is separated by ':'"
-  # In Web VEP, the values are not separated by ':'
+  # In Web VEP, the values are not separated by ':' and therefore remove it from the description.
   if(exists $header_extra_descriptions->{'DisGeNET'}) {
-    $header_extra_descriptions->{'DisGeNET'} =~ s/Each value is separated.*//;
+    $header_extra_descriptions->{'DisGeNET'} =~ s/ Each value is separated.*//;
   }
 
   my $actual_to = $from - 1 + ($line_count || 0);

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -146,19 +146,12 @@ sub content {
   my $header_extra_descriptions = $header_hash->{'descriptions'} || {};
 
   # Overwrite DisGeNET header description
+  # Description example: "Variant-Disease-PMID associations from the DisGeNET database. The output includes 
+  #   the PMID of the publication reporting the Variant-Disease association, DisGeNET score for the Variant-Disease association, 
+  #   name of associated disease. Each value is separated by ':'"
+  # In Web VEP, the values are not separated by ':'
   if(exists $header_extra_descriptions->{'DisGeNET'}) {
-    my %new_header_extra_descriptions;
-    foreach my $key (keys %$header_extra_descriptions) {
-      if($key eq 'DisGeNET') {
-        my $description = $header_extra_descriptions->{$key};
-        $description =~ s/Each value is separated.*//;
-        $new_header_extra_descriptions{$key} = $description;
-      }
-      else {
-        $new_header_extra_descriptions{$key} = $header_extra_descriptions->{$key};
-      }
-    }
-    $header_extra_descriptions = \%new_header_extra_descriptions;
+    $header_extra_descriptions->{'DisGeNET'} =~ s/Each value is separated.*//;
   }
 
   my $actual_to = $from - 1 + ($line_count || 0);

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -63,8 +63,7 @@
   DisGeNET => {
     "params" => [
       "file=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/all_variant_disease_pmid_associations_final.tsv.gz",
-      "disease=1",
-      "unique=1"
+      "disease=1"
     ]
   },
 


### PR DESCRIPTION
DisGeNET has a different output structure, `DisGeNET_PMID`, `DisGeNET_SCORE` and `DisGeNET_disease` are no longer used. Instead, the header is just `DisGeNET`. 
Sandbox to test: http://ves-hx2-76.ebi.ac.uk:7040/Tools/VEP 
input variant: rs699