### PR TITLE
replace gnomad exome files for grch38

### DIFF
--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -15,18 +15,20 @@
     },
     {
       "id": "gnomADe_GRCh38",
-      "description": "Genome Aggregation Database exomes r2.1",
+      "description": "Genome Aggregation Database exomes r2.1.1",
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "local",
       "filename_template": "/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1/exomes/gnomad.exomes.r2.1.sites.grch38.chr###CHR###_noVEP.vcf.gz",
+      "filename_template": "/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1.1/exomes/gnomad.exomes.r2.1.1.sites.###CHR###.liftover_grch38_no_VEP.vcf.gz",
+
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
       ],
       "population_prefix": "gnomADe:",
       "population_display_group": {
-        "display_group_name": "gnomAD exomes",
+        "display_group_name": "gnomAD exomes r2.1.1",
         "display_group_priority": 1.4
       },
       "populations": {

--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -19,9 +19,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "local",
-      "filename_template": "/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1/exomes/gnomad.exomes.r2.1.sites.grch38.chr###CHR###_noVEP.vcf.gz",
       "filename_template": "/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1.1/exomes/gnomad.exomes.r2.1.1.sites.###CHR###.liftover_grch38_no_VEP.vcf.gz",
-
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"

--- a/ensembl/conf/json/homo_sapiens_vcf.json
+++ b/ensembl/conf/json/homo_sapiens_vcf.json
@@ -24,6 +24,7 @@
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
       ],
+      "use_seq_region_synonyms": 1,
       "population_prefix": "gnomADe:",
       "population_display_group": {
         "display_group_name": "gnomAD exomes r2.1.1",


### PR DESCRIPTION
We start using gnomAD's liftover files.