### PR TITLE
Bugfix: faulty URL in deocumentation

### DIFF
--- a/ensembl/htdocs/info/genome/genebuild/transcript_quality_tags.html
+++ b/ensembl/htdocs/info/genome/genebuild/transcript_quality_tags.html
@@ -20,7 +20,7 @@
   
 <h2 id="mane">MANE (Matched Annotation between NCBI and EBI) Select</h2>
 
-<p>To determine the <a href = "MANE.html">MANE Select transcript</a>, Ensembl and NCBI independently identify which transcript we believe is the most biologically relevant. Where these match, the transcripts are labelled as MANE in both databases. The transcripts are absolutely identical in both databases, having matching splicing structure, sequence which matches the reference genome, 5' and 3' UTRs and start and end.</p>
+<p>To determine the <a href = "mane.html">MANE Select transcript</a>, Ensembl and NCBI independently identify which transcript we believe is the most biologically relevant. Where these match, the transcripts are labelled as MANE in both databases. The transcripts are absolutely identical in both databases, having matching splicing structure, sequence which matches the reference genome, 5' and 3' UTRs and start and end.</p>
 
 <h2 id="tsl">Transcript support level</h2>
 


### PR DESCRIPTION
This bugfix corrects a faulty link in the [transcript tags documentation page](https://www.ensembl.org/info/genome/genebuild/transcript_quality_tags.html).

- Sandbox URL: http://wp-np2-1d.ebi.ac.uk:1610/info/genome/genebuild/transcript_quality_tags.html
- JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6235
