### PR TITLE
Fix syntax in Panel.js file in genoverse public plugin

### DIFF
--- a/genoverse/htdocs/genoverse/ensembl/js/Panel.js
+++ b/genoverse/htdocs/genoverse/ensembl/js/Panel.js
@@ -502,7 +502,7 @@ Ensembl.Panel.Genoverse = Ensembl.Panel.ImageMap.extend({
           
           if (track && track.prop('unsortable') !== true) {
             if (track.prop('strand') === -1 && orderReverse) {
-              track.prop('order') = orderReverse;
+              track.prop('order', orderReverse);
               track.prop('label').data('order', orderReverse);
               
               track = track.prop('forwardTrack');


### PR DESCRIPTION
I've been playing with a new google closure compiler, when it complained of an error in the merged javascript:

```
/homes/ens_adm06/tmp/8410/server/minified/11f009db9960d736e3a9413cab8870af.js.tmp:9396:34: ERROR - [JSC_PARSE_ERROR] Parse error. invalid assignment target                                               
  9396|               track.prop('order') = orderReverse; 
```

The error must be coming from [here](https://github.com/Ensembl/public-plugins/blob/release/104/genoverse/htdocs/genoverse/ensembl/js/Panel.js#L505), and the compiler is correct — it is not valid javascript. This looks like a bit of jQuery, where the correct syntax will be as in this PR.

I don't know anything about the genoverse plugin, so couldn't check where this code is expected to run. Does the change make sense to you?