### PR TITLE
Bugfix/enscoresw 3826

### DIFF
--- a/docs/htdocs/info/docs/api/api_git.html
+++ b/docs/htdocs/info/docs/api/api_git.html
@@ -48,6 +48,17 @@ $ git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live
 
 <li>
 <p>
+Rename the bioperl-live directory. In the Unix command line, type:
+</p>
+<pre>
+$ mv bioperl-live bioperl-1.6.924
+</pre>
+<p>
+In classic Windows command line, use <kbd>ren</kbd> instead of <kbd>mv</kbd>.
+</p>
+
+<li>
+<p>
 Install the <a href="https://github.com/Ensembl/ensembl-git-tools/blob/master/README.md" rel="external">Ensembl git tools</a> to allow easy management of the Ensembl repos.
 </p>
 <pre>

--- a/docs/htdocs/info/docs/api/api_git.html
+++ b/docs/htdocs/info/docs/api/api_git.html
@@ -56,7 +56,7 @@ $ mv bioperl-live bioperl-1.6.924
 <p>
 In classic Windows command line, use <kbd>ren</kbd> instead of <kbd>mv</kbd>.
 </p>
-
+ 
 <li>
 <p>
 Install the <a href="https://github.com/Ensembl/ensembl-git-tools/blob/master/README.md" rel="external">Ensembl git tools</a> to allow easy management of the Ensembl repos.

--- a/docs/htdocs/info/docs/api/api_installation.html
+++ b/docs/htdocs/info/docs/api/api_installation.html
@@ -54,7 +54,7 @@ $ cd
 $ mkdir src
 $ cd src
 $ wget [[SPECIESDEFS::ENSEMBL_FTP_URL]]/ensembl-api.tar.gz
-$ wget https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/BioPerl-1.6.924.tar.gz 
+$ wget https://github.com/bioperl/bioperl-live/archive/release-1-6-924.zip
 </pre>
 </li>
 
@@ -64,13 +64,24 @@ Unpack the downloaded files. In the Unix command line, type:
 </p>
 <pre>
 $ tar zxvf ensembl-api.tar.gz
-$ tar zxvf BioPerl-1.6.924.tar.gz
+$ unzip release-1-6-924.zip
 </pre>
 
 <p>
 In Windows, you will need an unzipping utility such as <a rel="external" href="http://www.7-zip.org/">7-Zip</a>.
 </p>
 </li>
+
+<li>
+<p>
+Rename the bioperl-live directory. In the Unix command line, type:
+</p>
+<pre>
+$ mv bioperl-live-release-1-6-924 bioperl-1.6.924
+</pre>
+<p>
+In classic Windows command line, use <kbd>ren</kbd> instead of <kbd>mv</kbd>.
+</p>
 
 <li>
 <p>

--- a/docs/htdocs/info/docs/api/api_installation.html
+++ b/docs/htdocs/info/docs/api/api_installation.html
@@ -85,7 +85,7 @@ In classic Windows command line, use <kbd>ren</kbd> instead of <kbd>mv</kbd>.
 
 <li>
 <p>
-Set up your environment
+Set up your environment 
 </p>
 
 <p>

--- a/docs/htdocs/info/docs/api/core/core_tutorial.html
+++ b/docs/htdocs/info/docs/api/core/core_tutorial.html
@@ -680,7 +680,14 @@ foreach my $feature ( @features ) {
     my @ungapped = $feature->ungapped_features();
 
     print "ungapped:\n";
-    print_feature_pairs( \@ungapped );
+    foreach my $feature_pair (@ungapped) { 
+        printf( 
+	    "%s %d-%d (%+d)\t=> %d-%d (%+d)\n", 
+	    $feature_pair->hseqname(), $feature_pair->hstart(), $feature_pair->hend(), 
+	    $feature_pair->hstrand(), $feature_pair->start(), $feature_pair->end(), 
+	    $feature_pair->strand() 
+	    ); 
+    }
     print "\n";
 }
 </pre>

--- a/docs/htdocs/info/docs/api/core/core_tutorial.html
+++ b/docs/htdocs/info/docs/api/core/core_tutorial.html
@@ -679,7 +679,7 @@ foreach my $feature ( @features ) {
 
     my @ungapped = $feature->ungapped_features();
 
-    print "ungapped:\n";
+    print "ungapped:\n"; 
     foreach my $feature_pair (@ungapped) { 
         printf( 
 	    "%s %d-%d (%+d)\t=> %d-%d (%+d)\n", 


### PR DESCRIPTION
## Description

1. Fixed mismatches/typos about `bioperl-live` naming, paths and PERL5LIB.

2. Fixed undefined subroutine `print_feature_pairs( @ungapped )` in the Alignment Fetaures section under Core API tutorial.

## Use case

N/A

## Benefits

Clarity and consistency in public documentation

## Possible Drawbacks

None

## Testing

Manual by looking at the web pages
