### PR TITLE
Update core schema diagrams for Release 105

### DIFF
--- a/docs/htdocs/info/docs/api/core/core_schema.html
+++ b/docs/htdocs/info/docs/api/core/core_schema.html
@@ -80,7 +80,7 @@ tables that they've not used before.
 </p>
 
 <p>
-This document refers to version <span style="font-weight:bold;font-size:11pt;color:#000">104</span> of the EnsEMBL
+This document refers to version <span style="font-weight:bold;font-size:11pt;color:#000">105</span> of the EnsEMBL
 core schema.
 </p>
 
@@ -351,7 +351,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
     <div id="sp_assembly" style="display:none;">      <ul>
         <li class="sql_schema_species_name">Aotus nancymaae</li>
         <li class="sql_schema_species_name">Caenorhabditis elegans</li>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Capra hircus</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia aperea</li>
@@ -422,15 +421,12 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Pan troglodytes</li>
         <li class="sql_schema_species_name">Panthera pardus</li>
         <li class="sql_schema_species_name">Panthera tigris altaica</li>
-        <li class="sql_schema_species_name">Papio anubis</li>
         <li class="sql_schema_species_name">Pelodiscus sinensis</li>
         <li class="sql_schema_species_name">Petromyzon marinus</li>
         <li class="sql_schema_species_name">Poecilia formosa</li>
-        <li class="sql_schema_species_name">Pongo abelii</li>
         <li class="sql_schema_species_name">Procavia capensis</li>
         <li class="sql_schema_species_name">Propithecus coquereli</li>
         <li class="sql_schema_species_name">Pteropus vampyrus</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
         <li class="sql_schema_species_name">Rhinopithecus bieti</li>
         <li class="sql_schema_species_name">Rhinopithecus roxellana</li>
         <li class="sql_schema_species_name">Saccharomyces cerevisiae</li>
@@ -686,6 +682,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -1139,6 +1136,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -1530,6 +1528,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -2001,6 +2000,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -2373,6 +2373,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -2754,6 +2755,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -3127,6 +3129,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -3499,12 +3502,14 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cairina moschata domestica</li>
         <li class="sql_schema_species_name">Calidris pugnax</li>
         <li class="sql_schema_species_name">Calidris pygmaea</li>
+        <li class="sql_schema_species_name">Callithrix jacchus</li>
         <li class="sql_schema_species_name">Callorhinchus milii</li>
         <li class="sql_schema_species_name">Camarhynchus parvulus</li>
         <li class="sql_schema_species_name">Camelus dromedarius</li>
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -3682,6 +3687,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Poecilia mexicana</li>
         <li class="sql_schema_species_name">Poecilia reticulata</li>
         <li class="sql_schema_species_name">Pogona vitticeps</li>
+        <li class="sql_schema_species_name">Pongo abelii</li>
         <li class="sql_schema_species_name">Propithecus coquereli</li>
         <li class="sql_schema_species_name">Pseudonaja textilis</li>
         <li class="sql_schema_species_name">Pundamilia nyererei</li>
@@ -4047,6 +4053,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -4399,7 +4406,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Astyanax mexicanus pachon</li>
         <li class="sql_schema_species_name">Athene cunicularia</li>
-        <li class="sql_schema_species_name">Balaenoptera musculus</li>
         <li class="sql_schema_species_name">Betta splendens</li>
         <li class="sql_schema_species_name">Bison bison bison</li>
         <li class="sql_schema_species_name">Bos grunniens</li>
@@ -4420,20 +4426,18 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
         <li class="sql_schema_species_name">Carassius auratus</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Castor canadensis</li>
-        <li class="sql_schema_species_name">Catagonus wagneri</li>
         <li class="sql_schema_species_name">Catharus ustulatus</li>
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
-        <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
-        <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
         <li class="sql_schema_species_name">Chelydra serpentina</li>
         <li class="sql_schema_species_name">Chinchilla lanigera</li>
         <li class="sql_schema_species_name">Chlorocebus sabaeus</li>
@@ -4471,7 +4475,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Echinops telfairi</li>
         <li class="sql_schema_species_name">Electrophorus electricus</li>
         <li class="sql_schema_species_name">Eptatretus burgeri</li>
-        <li class="sql_schema_species_name">Equus asinus asinus</li>
         <li class="sql_schema_species_name">Equus caballus</li>
         <li class="sql_schema_species_name">Erinaceus europaeus</li>
         <li class="sql_schema_species_name">Erpetoichthys calabaricus</li>
@@ -4505,11 +4508,9 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Labrus bergylta</li>
         <li class="sql_schema_species_name">Larimichthys crocea</li>
         <li class="sql_schema_species_name">Lates calcarifer</li>
-        <li class="sql_schema_species_name">Laticauda laticaudata</li>
         <li class="sql_schema_species_name">Latimeria chalumnae</li>
         <li class="sql_schema_species_name">Lepidothrix coronata</li>
         <li class="sql_schema_species_name">Lepisosteus oculatus</li>
-        <li class="sql_schema_species_name">Leptobrachium leishanense</li>
         <li class="sql_schema_species_name">Lonchura striata domestica</li>
         <li class="sql_schema_species_name">Loxodonta africana</li>
         <li class="sql_schema_species_name">Lynx canadensis</li>
@@ -4534,29 +4535,13 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Monopterus albus</li>
         <li class="sql_schema_species_name">Moschus moschiferus</li>
         <li class="sql_schema_species_name">Mus caroli</li>
-        <li class="sql_schema_species_name">Mus musculus 129s1svimj</li>
-        <li class="sql_schema_species_name">Mus musculus aj</li>
-        <li class="sql_schema_species_name">Mus musculus akrj</li>
-        <li class="sql_schema_species_name">Mus musculus balbcj</li>
-        <li class="sql_schema_species_name">Mus musculus c3hhej</li>
-        <li class="sql_schema_species_name">Mus musculus c57bl6nj</li>
-        <li class="sql_schema_species_name">Mus musculus casteij</li>
-        <li class="sql_schema_species_name">Mus musculus cbaj</li>
         <li class="sql_schema_species_name">Mus musculus</li>
-        <li class="sql_schema_species_name">Mus musculus dba2j</li>
-        <li class="sql_schema_species_name">Mus musculus fvbnj</li>
-        <li class="sql_schema_species_name">Mus musculus lpj</li>
-        <li class="sql_schema_species_name">Mus musculus nodshiltj</li>
-        <li class="sql_schema_species_name">Mus musculus nzohlltj</li>
-        <li class="sql_schema_species_name">Mus musculus pwkphj</li>
-        <li class="sql_schema_species_name">Mus musculus wsbeij</li>
         <li class="sql_schema_species_name">Mus pahari</li>
         <li class="sql_schema_species_name">Mus spicilegus</li>
         <li class="sql_schema_species_name">Mus spretus</li>
         <li class="sql_schema_species_name">Mustela putorius furo</li>
         <li class="sql_schema_species_name">Myotis lucifugus</li>
         <li class="sql_schema_species_name">Myripristis murdjan</li>
-        <li class="sql_schema_species_name">Naja naja</li>
         <li class="sql_schema_species_name">Nannospalax galili</li>
         <li class="sql_schema_species_name">Neogobius melanostomus</li>
         <li class="sql_schema_species_name">Neolamprologus brichardi</li>
@@ -4614,7 +4599,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Pogona vitticeps</li>
         <li class="sql_schema_species_name">Pongo abelii</li>
         <li class="sql_schema_species_name">Procavia capensis</li>
-        <li class="sql_schema_species_name">Prolemur simus</li>
         <li class="sql_schema_species_name">Propithecus coquereli</li>
         <li class="sql_schema_species_name">Pseudonaja textilis</li>
         <li class="sql_schema_species_name">Pteropus vampyrus</li>
@@ -4629,10 +4613,8 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Salarias fasciatus</li>
         <li class="sql_schema_species_name">Salmo salar</li>
         <li class="sql_schema_species_name">Salmo trutta</li>
-        <li class="sql_schema_species_name">Salvator merianae</li>
         <li class="sql_schema_species_name">Sander lucioperca</li>
         <li class="sql_schema_species_name">Sarcophilus harrisii</li>
-        <li class="sql_schema_species_name">Sciurus vulgaris</li>
         <li class="sql_schema_species_name">Scleropages formosus</li>
         <li class="sql_schema_species_name">Scophthalmus maximus</li>
         <li class="sql_schema_species_name">Serinus canaria</li>
@@ -4645,7 +4627,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Sparus aurata</li>
         <li class="sql_schema_species_name">Spermophilus dauricus</li>
         <li class="sql_schema_species_name">Sphaeramia orbicularis</li>
-        <li class="sql_schema_species_name">Sphenodon punctatus</li>
         <li class="sql_schema_species_name">Stachyris ruficeps</li>
         <li class="sql_schema_species_name">Stegastes partitus</li>
         <li class="sql_schema_species_name">Strigops habroptila</li>
@@ -4851,6 +4832,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -5177,6 +5159,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Anolis carolinensis</li>
         <li class="sql_schema_species_name">Anser cygnoides</li>
         <li class="sql_schema_species_name">Aotus nancymaae</li>
+        <li class="sql_schema_species_name">Apteryx haastii</li>
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Astyanax mexicanus pachon</li>
         <li class="sql_schema_species_name">Bos grunniens</li>
@@ -5188,18 +5171,19 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Camelus dromedarius</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
         <li class="sql_schema_species_name">Carassius auratus</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
-        <li class="sql_schema_species_name">Cebus capucinus</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Chinchilla lanigera</li>
         <li class="sql_schema_species_name">Chlorocebus sabaeus</li>
         <li class="sql_schema_species_name">Ciona intestinalis</li>
         <li class="sql_schema_species_name">Clupea harengus</li>
+        <li class="sql_schema_species_name">Colobus angolensis palliatus</li>
         <li class="sql_schema_species_name">Coturnix japonica</li>
         <li class="sql_schema_species_name">Cricetulus griseus chok1gshd</li>
         <li class="sql_schema_species_name">Cricetulus griseus crigri</li>
@@ -5289,7 +5273,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Ovis aries rambouillet</li>
         <li class="sql_schema_species_name">Pan paniscus</li>
         <li class="sql_schema_species_name">Pan troglodytes</li>
-        <li class="sql_schema_species_name">Panthera leo</li>
+        <li class="sql_schema_species_name">Panthera pardus</li>
         <li class="sql_schema_species_name">Panthera tigris altaica</li>
         <li class="sql_schema_species_name">Papio anubis</li>
         <li class="sql_schema_species_name">Parus major</li>
@@ -5314,6 +5298,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Seriola dumerili</li>
         <li class="sql_schema_species_name">Sinocyclocheilus grahami</li>
         <li class="sql_schema_species_name">Sparus aurata</li>
+        <li class="sql_schema_species_name">Sphenodon punctatus</li>
         <li class="sql_schema_species_name">Sus scrofa bamei</li>
         <li class="sql_schema_species_name">Sus scrofa berkshire</li>
         <li class="sql_schema_species_name">Sus scrofa</li>
@@ -5488,6 +5473,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -5808,6 +5794,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -6209,6 +6196,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -6582,6 +6570,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -7016,7 +7005,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Camarhynchus parvulus</li>
         <li class="sql_schema_species_name">Camelus dromedarius</li>
         <li class="sql_schema_species_name">Canis lupus dingo</li>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
@@ -7039,7 +7027,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Ciona intestinalis</li>
         <li class="sql_schema_species_name">Ciona savignyi</li>
         <li class="sql_schema_species_name">Clupea harengus</li>
-        <li class="sql_schema_species_name">Colobus angolensis palliatus</li>
         <li class="sql_schema_species_name">Corvus moneduloides</li>
         <li class="sql_schema_species_name">Cottoperca gobio</li>
         <li class="sql_schema_species_name">Coturnix japonica</li>
@@ -7156,10 +7143,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Ovis aries</li>
         <li class="sql_schema_species_name">Ovis aries rambouillet</li>
         <li class="sql_schema_species_name">Pan troglodytes</li>
-        <li class="sql_schema_species_name">Panthera leo</li>
-        <li class="sql_schema_species_name">Panthera pardus</li>
-        <li class="sql_schema_species_name">Panthera tigris altaica</li>
-        <li class="sql_schema_species_name">Papio anubis</li>
         <li class="sql_schema_species_name">Parambassis ranga</li>
         <li class="sql_schema_species_name">Paramormyrops kingsleyae</li>
         <li class="sql_schema_species_name">Parus major</li>
@@ -7180,14 +7163,12 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Poecilia mexicana</li>
         <li class="sql_schema_species_name">Poecilia reticulata</li>
         <li class="sql_schema_species_name">Pogona vitticeps</li>
-        <li class="sql_schema_species_name">Pongo abelii</li>
         <li class="sql_schema_species_name">Procavia capensis</li>
         <li class="sql_schema_species_name">Prolemur simus</li>
         <li class="sql_schema_species_name">Pseudonaja textilis</li>
         <li class="sql_schema_species_name">Pteropus vampyrus</li>
         <li class="sql_schema_species_name">Pundamilia nyererei</li>
         <li class="sql_schema_species_name">Pygocentrus nattereri</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
         <li class="sql_schema_species_name">Rhinolophus ferrumequinum</li>
         <li class="sql_schema_species_name">Rhinopithecus roxellana</li>
         <li class="sql_schema_species_name">Saccharomyces cerevisiae</li>
@@ -7209,7 +7190,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Sparus aurata</li>
         <li class="sql_schema_species_name">Spermophilus dauricus</li>
         <li class="sql_schema_species_name">Sphaeramia orbicularis</li>
-        <li class="sql_schema_species_name">Sphenodon punctatus</li>
         <li class="sql_schema_species_name">Stachyris ruficeps</li>
         <li class="sql_schema_species_name">Stegastes partitus</li>
         <li class="sql_schema_species_name">Strigops habroptila</li>
@@ -7356,6 +7336,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -7775,6 +7756,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -8151,10 +8133,12 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Bos taurus hybrid</li>
         <li class="sql_schema_species_name">Caenorhabditis elegans</li>
         <li class="sql_schema_species_name">Cairina moschata domestica</li>
+        <li class="sql_schema_species_name">Callithrix jacchus</li>
         <li class="sql_schema_species_name">Camarhynchus parvulus</li>
         <li class="sql_schema_species_name">Camelus dromedarius</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -8385,10 +8369,12 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Bos taurus hybrid</li>
         <li class="sql_schema_species_name">Caenorhabditis elegans</li>
         <li class="sql_schema_species_name">Cairina moschata domestica</li>
+        <li class="sql_schema_species_name">Callithrix jacchus</li>
         <li class="sql_schema_species_name">Camarhynchus parvulus</li>
         <li class="sql_schema_species_name">Camelus dromedarius</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -8890,6 +8876,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -9031,10 +9018,10 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Poecilia mexicana</li>
         <li class="sql_schema_species_name">Poecilia reticulata</li>
         <li class="sql_schema_species_name">Pogona vitticeps</li>
+        <li class="sql_schema_species_name">Pongo abelii</li>
         <li class="sql_schema_species_name">Pseudonaja textilis</li>
         <li class="sql_schema_species_name">Pundamilia nyererei</li>
         <li class="sql_schema_species_name">Pygocentrus nattereri</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
         <li class="sql_schema_species_name">Rhinolophus ferrumequinum</li>
         <li class="sql_schema_species_name">Rhinopithecus bieti</li>
         <li class="sql_schema_species_name">Rhinopithecus roxellana</li>
@@ -9146,10 +9133,8 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
     <img src="/i/16/plus-button.png" class="sql_schema_icon" alt="show"/> Show species
   </a></p>
     <div id="sp_map" style="display:none;">      <ul>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Homo sapiens</li>
         <li class="sql_schema_species_name">Ovis aries</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
       </ul>
     </div>
   </td></tr></table></div></div><div class="sql_schema_table">
@@ -9253,11 +9238,9 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
     <img src="/i/16/plus-button.png" class="sql_schema_icon" alt="show"/> Show species
   </a></p>
     <div id="sp_marker" style="display:none;">      <ul>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Gasterosteus aculeatus</li>
         <li class="sql_schema_species_name">Homo sapiens</li>
         <li class="sql_schema_species_name">Ovis aries</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
       </ul>
     </div>
   </td></tr></table></div></div><div class="sql_schema_table">
@@ -9356,11 +9339,9 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
     <img src="/i/16/plus-button.png" class="sql_schema_icon" alt="show"/> Show species
   </a></p>
     <div id="sp_marker_feature" style="display:none;">      <ul>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Gasterosteus aculeatus</li>
         <li class="sql_schema_species_name">Homo sapiens</li>
         <li class="sql_schema_species_name">Ovis aries</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
       </ul>
     </div>
   </td></tr></table></div></div><div class="sql_schema_table">
@@ -9450,10 +9431,8 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
     <img src="/i/16/plus-button.png" class="sql_schema_icon" alt="show"/> Show species
   </a></p>
     <div id="sp_marker_map_location" style="display:none;">      <ul>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Homo sapiens</li>
         <li class="sql_schema_species_name">Ovis aries</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
       </ul>
     </div>
   </td></tr></table></div></div><div class="sql_schema_table">
@@ -9524,11 +9503,9 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
     <img src="/i/16/plus-button.png" class="sql_schema_icon" alt="show"/> Show species
   </a></p>
     <div id="sp_marker_synonym" style="display:none;">      <ul>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Gasterosteus aculeatus</li>
         <li class="sql_schema_species_name">Homo sapiens</li>
         <li class="sql_schema_species_name">Ovis aries</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
       </ul>
     </div>
   </td></tr></table></div></div><div class="sql_schema_table">
@@ -9857,6 +9834,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -10285,6 +10263,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -10686,6 +10665,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -11066,6 +11046,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -11496,6 +11477,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -11908,6 +11890,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -12285,6 +12268,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -12426,10 +12410,10 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Poecilia mexicana</li>
         <li class="sql_schema_species_name">Poecilia reticulata</li>
         <li class="sql_schema_species_name">Pogona vitticeps</li>
+        <li class="sql_schema_species_name">Pongo abelii</li>
         <li class="sql_schema_species_name">Pseudonaja textilis</li>
         <li class="sql_schema_species_name">Pundamilia nyererei</li>
         <li class="sql_schema_species_name">Pygocentrus nattereri</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
         <li class="sql_schema_species_name">Rhinolophus ferrumequinum</li>
         <li class="sql_schema_species_name">Rhinopithecus bieti</li>
         <li class="sql_schema_species_name">Rhinopithecus roxellana</li>
@@ -12842,6 +12826,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -13230,6 +13215,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -13610,6 +13596,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -14096,6 +14083,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -14615,6 +14603,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -14988,6 +14977,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -15467,6 +15457,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -15840,6 +15831,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -16318,6 +16310,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -16785,6 +16778,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -17158,6 +17152,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -17626,6 +17621,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -17999,6 +17995,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -18371,6 +18368,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -18798,6 +18796,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -19172,6 +19171,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Canis lupus dingo</li>
         <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
         <li class="sql_schema_species_name">Capra hircus</li>
@@ -19555,7 +19555,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Bos taurus</li>
         <li class="sql_schema_species_name">Callithrix jacchus</li>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Choloepus hoffmanni</li>
@@ -19727,7 +19727,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Bos taurus</li>
         <li class="sql_schema_species_name">Callithrix jacchus</li>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
@@ -19868,6 +19868,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Anas platyrhynchos</li>
         <li class="sql_schema_species_name">Anas platyrhynchos platyrhynchos</li>
         <li class="sql_schema_species_name">Anas zonorhyncha</li>
+        <li class="sql_schema_species_name">Anolis carolinensis</li>
         <li class="sql_schema_species_name">Anser brachyrhynchus</li>
         <li class="sql_schema_species_name">Anser cygnoides</li>
         <li class="sql_schema_species_name">Aotus nancymaae</li>
@@ -19893,12 +19894,10 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cairina moschata domestica</li>
         <li class="sql_schema_species_name">Calidris pugnax</li>
         <li class="sql_schema_species_name">Calidris pygmaea</li>
-        <li class="sql_schema_species_name">Callithrix jacchus</li>
         <li class="sql_schema_species_name">Callorhinchus milii</li>
         <li class="sql_schema_species_name">Camarhynchus parvulus</li>
         <li class="sql_schema_species_name">Camelus dromedarius</li>
         <li class="sql_schema_species_name">Canis lupus dingo</li>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
         <li class="sql_schema_species_name">Canis lupus familiarisbasenji</li>
         <li class="sql_schema_species_name">Canis lupus familiarisgreatdane</li>
         <li class="sql_schema_species_name">Capra hircus blackbengal</li>
@@ -19959,6 +19958,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Esox lucius</li>
         <li class="sql_schema_species_name">Falco tinnunculus</li>
         <li class="sql_schema_species_name">Felis catus</li>
+        <li class="sql_schema_species_name">Ficedula albicollis</li>
         <li class="sql_schema_species_name">Fukomys damarensis</li>
         <li class="sql_schema_species_name">Fundulus heteroclitus</li>
         <li class="sql_schema_species_name">Gadus morhua</li>
@@ -20001,6 +20001,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Marmota marmota marmota</li>
         <li class="sql_schema_species_name">Mastacembelus armatus</li>
         <li class="sql_schema_species_name">Maylandia zebra</li>
+        <li class="sql_schema_species_name">Meleagris gallopavo</li>
         <li class="sql_schema_species_name">Melopsittacus undulatus</li>
         <li class="sql_schema_species_name">Meriones unguiculatus</li>
         <li class="sql_schema_species_name">Mesocricetus auratus</li>
@@ -20069,7 +20070,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Panthera leo</li>
         <li class="sql_schema_species_name">Panthera pardus</li>
         <li class="sql_schema_species_name">Panthera tigris altaica</li>
-        <li class="sql_schema_species_name">Papio anubis</li>
         <li class="sql_schema_species_name">Parambassis ranga</li>
         <li class="sql_schema_species_name">Paramormyrops kingsleyae</li>
         <li class="sql_schema_species_name">Parus major</li>
@@ -20090,7 +20090,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Poecilia mexicana</li>
         <li class="sql_schema_species_name">Poecilia reticulata</li>
         <li class="sql_schema_species_name">Pogona vitticeps</li>
-        <li class="sql_schema_species_name">Pongo abelii</li>
         <li class="sql_schema_species_name">Procavia capensis</li>
         <li class="sql_schema_species_name">Prolemur simus</li>
         <li class="sql_schema_species_name">Propithecus coquereli</li>
@@ -20098,7 +20097,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Pteropus vampyrus</li>
         <li class="sql_schema_species_name">Pundamilia nyererei</li>
         <li class="sql_schema_species_name">Pygocentrus nattereri</li>
-        <li class="sql_schema_species_name">Rattus norvegicus</li>
         <li class="sql_schema_species_name">Rhinolophus ferrumequinum</li>
         <li class="sql_schema_species_name">Rhinopithecus bieti</li>
         <li class="sql_schema_species_name">Rhinopithecus roxellana</li>
@@ -20112,6 +20110,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Sarcophilus harrisii</li>
         <li class="sql_schema_species_name">Sciurus vulgaris</li>
         <li class="sql_schema_species_name">Scleropages formosus</li>
+        <li class="sql_schema_species_name">Scophthalmus maximus</li>
         <li class="sql_schema_species_name">Serinus canaria</li>
         <li class="sql_schema_species_name">Seriola dumerili</li>
         <li class="sql_schema_species_name">Seriola lalandi dorsalis</li>
@@ -20227,7 +20226,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Bos taurus</li>
         <li class="sql_schema_species_name">Callithrix jacchus</li>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Ciona intestinalis</li>
@@ -20451,7 +20450,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Bos taurus</li>
         <li class="sql_schema_species_name">Callithrix jacchus</li>
-        <li class="sql_schema_species_name">Canis lupus familiaris</li>
+        <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>


### PR DESCRIPTION
The file `core_schema.html` has been updated for Release 105. 

No SVG file changes found (verified by checking file histories: [sql/table.sql](https://github.com/Ensembl/ensembl/commits/release/105/sql/table.sql) and [sql/foreign_keys.sql](https://github.com/Ensembl/ensembl/commits/release/105/sql/foreign_keys.sql)).