### PR TITLE
Check if we have ID mapping before submitting form

### DIFF
--- a/tools/modules/EnsEMBL/Web/JSONServer/Tools.pm
+++ b/tools/modules/EnsEMBL/Web/JSONServer/Tools.pm
@@ -50,6 +50,20 @@ sub json_form_submit {
     return $self->call_js_panel_method('ticketNotSubmitted', [ $sp_err ]);
   }
 
+  ## if ID mapper, do we have data for this species?
+  if ($object->tool_type eq 'IDMapper') {
+    my $species = $hub->param('species');
+    my $history = $hub->species_defs->table_info_other($species, 'core', 'stable_id_event');
+    unless ($history->{'rows'}) {
+      my $sp_err = {
+        'heading' => "No ID mapping available",
+        'message' => "Please select a different species to map IDs against.",
+        'stage'   => "validation"
+      };
+      return $self->call_js_panel_method('ticketNotSubmitted', [ $sp_err ]);
+    }
+  }
+
   $ticket->process;
 
   if (my $error = $ticket->error) {


### PR DESCRIPTION
As reported in this ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6242

Some bacteria lack ID mapping, which results in the user submitted jobs that inevitably fail, with a cryptic error message. Hopefully this small addition will gracefully reject jobs that don't have the data, but I haven't been able to test it in a sandbox yet. It shouldn't affect anything except the ID History Mapper.

I suggest that if it looks sensible, we merge it in and try it out on the test sites when they go up. We should ensure that it produces the error message when tried out on the bacterial species mentioned in the JIRA ticket, and also check it does not break either www or another NV site such as plants.