### PR TITLE
Fix project desc and link for VCF species

### DIFF
--- a/ensembl/htdocs/info/genome/variation/species/sources_documentation.html
+++ b/ensembl/htdocs/info/genome/variation/species/sources_documentation.html
@@ -1508,7 +1508,7 @@ the <i>'Configure this page'</i> link on the left-hand side. The <i>'Variation'<
       <tr class="bg1">
         
         <td style="width:4px;padding:0px;margin:0px"></td>
-        <td style="font-weight:bold"><a href="https://www.ebi.ac.uk/eva/?eva-study=PRJEB26368" style="text-decoration:none" target="_blank"></a></td>
+        <td style="font-weight:bold"><a href="https://www.ebi.ac.uk/eva/?eva-study=PRJEB26368" style="text-decoration:none" target="_blank">PRJEB26368</a></td>
         <td>-</td>
         <td style="max-width:800px">Genotyping-by-sequencing of American mink</td>
         <td class="vdoc_extra_column">Variant (from VCF)</td>
@@ -2802,7 +2802,7 @@ the <i>'Configure this page'</i> link on the left-hand side. The <i>'Variation'<
       <tr class="bg1">
         
         <td style="width:4px;padding:0px;margin:0px"></td>
-        <td style="font-weight:bold"><a href="https://www.ebi.ac.uk/eva/?eva-study=PRJEB38548" style="text-decoration:none" target="_blank"></a></td>
+        <td style="font-weight:bold"><a href="https://www.ebi.ac.uk/eva/?eva-study=PRJEB38548" style="text-decoration:none" target="_blank">PRJEB38548</a></td>
         <td>-</td>
         <td style="max-width:800px">Genomic selection to enhance tilapia breeding</td>
         <td class="vdoc_extra_column">Variant (from VCF)</td>


### PR DESCRIPTION
For e105 
The project link and description were missing for American Mink and Nile tilapia for docs generated.
See ENSVAR-4441
Tested on sandbox: 
wp-np2-11.ebi.ac.uk:5050/info/genome/variation/species/sources_documentation.html#neovison_vison
wp-np2-11.ebi.ac.uk:5050/info/genome/variation/species/sources_documentation.html#oreochromis_niloticus