### PR TITLE
Fix VEP PDB display

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/PDB.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/PDB.pm
@@ -41,7 +41,13 @@ sub content {
   my $var_id  = $hub->param('var');
   my $var_pos = $hub->param('pos');
   my $var_cons  = $hub->param('cons');
-  my $var_enst  = $hub->param('t');
+
+  ## VEP outputs versioned stable IDS, but we need an unversioned one for the widget,
+  ## so use the API to try and do the conversion 
+  my $db_adaptor  = $hub->database('core');
+  my $adaptor     = $db_adaptor->get_TranscriptAdaptor;
+  my $transcript  = $adaptor->fetch_by_stable_id($hub->param('t'));
+  my $var_enst    = $transcript ? $transcript->stable_id : $hub->param('t');
   
   # Add REST API URLs as hidden param
   my $html = $self->get_rest_urls();


### PR DESCRIPTION
Since this is specific to this tool, I think a workaround is the best option for now. It defers handling of versioned stable IDs to the API, which is (I think) the right thing to do.

See ticket https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6409