### PR TITLE
Add space below each expanded transcript feature in genoverse - V2

### DIFF
--- a/genoverse/htdocs/genoverse/ensembl/js/Track/View/Gene.js
+++ b/genoverse/htdocs/genoverse/ensembl/js/Track/View/Gene.js
@@ -122,6 +122,6 @@ Genoverse.Track.View.Gene.Collapsed = Genoverse.Track.View.Gene.extend({
 });
 
 Genoverse.Track.View.Gene.Transcript = Genoverse.Track.View.Gene.Collapsed.extend({
-  featureMargin : { top: 3, right: 1, bottom: 3, left: 0 },
+  featureMargin : { top: 10, right: 1, bottom: 3, left: 0 },
   expanded      : true
 });


### PR DESCRIPTION
A simple solution to add spacing between the transcript features.

Only problem is that it adds some spacing above first line of feature like shown in the image below.

![Screenshot 2022-01-06 at 17 41 59](https://user-images.githubusercontent.com/3085815/148753239-1026f3fb-f2fb-4507-8f8a-61911270699b.png)


Related PR:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6334


Sandbox URL:
http://wp-np2-1d.ebi.ac.uk:42229/Homo_sapiens/Location/View?db=core;g=ENSG00000139618;r=13:52315086-52400268;t=ENST00000544455