### PR TITLE
Fix documentation of VEP --everything argument

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -189,19 +189,19 @@ host          useastdb.ensembl.org</pre>
           <a href="#opt_canonical">--canonical</a>,
           <a href="#opt_protein">--protein</a>,
           <a href="#opt_biotype">--biotype</a>,
-          <a href="#opt_uniprot">--uniprot</a>,
-          <a href="#opt_tsl">--tsl</a>,
-          <a href="#opt_appris">--appris</a>,
-          <a href="#opt_gene_phenotype">--gene_phenotype</a>
           <a href="#opt_af">--af</a>,
           <a href="#opt_af_1kg">--af_1kg</a>,
           <a href="#opt_af_esp">--af_esp</a>,
           <a href="#opt_af_gnomad">--af_gnomad</a>,
           <a href="#opt_max_af">--max_af</a>,
           <a href="#opt_pubmed">--pubmed</a>,
-          <a href="#opt_var_synonyms">--var_synonyms</a>,
+          <a href="#opt_uniprot">--uniprot</a>,
+          <a href="#opt_mane">--mane</a>,
+          <a href="#opt_tsl">--tsl</a>,
+          <a href="#opt_appris">--appris</a>,
           <a href="#opt_variant_class">--variant_class</a>,
-          <a href="#opt_mane">--mane</a>
+          <a href="#opt_gene_phenotype">--gene_phenotype</a>,
+          <a href="#opt_mirna">--mirna</a>
         </ul>
       </td>
       <td>&nbsp;</td>


### PR DESCRIPTION
There ia a mismatch between `--everything` flags mentioned in the documentation and those set in [Config.pm][code]. As such,

1. `--mirna` was added to the documentation.
2. `--var_synonyms` was removed from the documentation.
3. The arguments were reordered based on [Config.pm][code].

The changes were tested via the sandbox and seem to be working as expected.

[code]: https://github.com/Ensembl/ensembl-vep/blob/5aa4f5c8bdcdeb4dc27ba114497601dacdc66e73/modules/Bio/EnsEMBL/VEP/Config.pm#L139-L166