### PR TITLE
Include the species parameter when checking with Psychic

### DIFF
--- a/solr/htdocs/solr/template_data.js
+++ b/solr/htdocs/solr/template_data.js
@@ -434,16 +434,21 @@
       },
       postproc: function(el, data) {
         $(document).on('maybe_update_state', function(e, change, incr) {
-          var ref1;
-          $.getJSON("/Multi/Ajax/psychic", {
-            q: (ref1 = change.q) != null ? ref1 : ''
-          }, function(data) {
+          var facet_species, query_params, ref1, ref2, ref3;
+          facet_species = data != null ? (ref1 = data.state) != null ? (ref2 = ref1.hub) != null ? (ref3 = ref2.params) != null ? ref3.facet_species : void 0 : void 0 : void 0 : void 0;
+          query_params = {
+            q: ''
+          };
+          change.q && (query_params.q = change.q);
+          facet_species && (query_params.species = facet_species);
+          return $.getJSON("/Multi/Ajax/psychic", query_params, function(data) {
             if (data != null ? data.redirect : void 0) {
               $(document).trigger('ga', ['SrchPsychic', 'redirect', data.url]);
               return window.location.href = data.url;
+            } else {
+              return $(document).trigger('update_state', change);
             }
           });
-          return $(document).trigger('update_state', change);
         });
         return $(document).on('state_known', function(e, state, update_seq) {
           var f, facets, filter, ids, l, left, len1, ref1, ref2, right, strain_type, texts, title;

--- a/solr/modules/EnsEMBL/Web/Controller/Ajax.pm
+++ b/solr/modules/EnsEMBL/Web/Controller/Ajax.pm
@@ -353,10 +353,13 @@ sub ajax_psychic { # Invoke psychic via AJAX, to see if we need to redirect.
   $proxy = undef if($SiteDefs::SOLR_NO_PROXY);
   $ua->proxy('http',$proxy) if $proxy;
   $ua->requests_redirectable([]);
-  my $psychic = $SiteDefs::ENSEMBL_PROXY_PROTOCOL.":".
+  my $query_parameter = "q=" . uri_escape($hub->param('q'));
+  my $species_parameter = $hub->param('species') ?  "species=" . uri_escape($hub->param('species')) : undef;
+  my $full_query = join '&', grep { !!$_ } ($query_parameter, $species_parameter);
+  my $psychic_url = $SiteDefs::ENSEMBL_PROXY_PROTOCOL.":".
               $hub->species_defs->ENSEMBL_BASE_URL.
-              "/Multi/psychic?q=".uri_escape($hub->param('q'));
-  my $response = $ua->get($psychic);
+              "/Multi/psychic?$full_query";
+  my $response = $ua->get($psychic_url);
   my $location;
   if($response->is_redirect) {
     $location = $response->header("Location");

--- a/solr/src/obj/template_data.coffee
+++ b/solr/src/obj/template_data.coffee
@@ -389,11 +389,16 @@ window.google_templates =
             $(document).trigger('maybe_update_state',{ q: $(this).val(), page: 1 })
     postproc: (el,data) ->
       $(document).on 'maybe_update_state', (e,change,incr) ->
-        $.getJSON "/Multi/Ajax/psychic",{ q: change.q ? '' }, (data) ->
+        facet_species = data?.state?.hub?.params?.facet_species
+        query_params = { q: '' }
+        change.q && query_params.q = change.q
+        facet_species && query_params.species = facet_species
+        $.getJSON "/Multi/Ajax/psychic", query_params , (data) ->
           if data?.redirect
             $(document).trigger('ga',['SrchPsychic','redirect',data.url])
             window.location.href = data.url
-        $(document).trigger('update_state',change)
+          else
+            $(document).trigger('update_state',change)
       $(document).on 'state_known', (e,state,update_seq) ->
         if $(document).data('update_seq') != update_seq then return
         facets = state.q_facets()

--- a/solr/src/templates/google_templates.coffee
+++ b/solr/src/templates/google_templates.coffee
@@ -389,11 +389,16 @@ window.google_templates =
             $(document).trigger('maybe_update_state',{ q: $(this).val(), page: 1 })
     postproc: (el,data) ->
       $(document).on 'maybe_update_state', (e,change,incr) ->
-        $.getJSON "/Multi/Ajax/psychic",{ q: change.q ? '' }, (data) ->
+        facet_species = data?.state?.hub?.params?.facet_species
+        query_params = { q: '' }
+        change.q && query_params.q = change.q
+        facet_species && query_params.species = facet_species
+        $.getJSON "/Multi/Ajax/psychic", query_params , (data) ->
           if data?.redirect
             $(document).trigger('ga',['SrchPsychic','redirect',data.url])
             window.location.href = data.url
-        $(document).trigger('update_state',change)
+          else
+            $(document).trigger('update_state',change)
       $(document).on 'state_known', (e,state,update_seq) ->
         if $(document).data('update_seq') != update_seq then return
         facets = state.q_facets()


### PR DESCRIPTION
## Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6224

## Description
### Reproduction steps
1. On Ensembl home page, type in a search term in the search box in the middle of the page, and select a species from the select box above the search box. Example: search for gene KIT for Horse
2. This will bring you to the search page (e.g. https://www.ensembl.org/Equus_caballus/Search/Results?q=kit;site=ensembl;facet_species=Horse). Notice that a species is selected (a green lozenge below the search input in the top of the page)
3. Enter a different query in the search box (example: search for MITF)

**Expected:** the search for the gene should only happen for the selected species (Horse)

**Bug:** the page gets redirected to the Multi section (https://www.ensembl.org/Multi/Search/Results), which shows results for all species, and the selection of the previous species is lost.

### Cause
Every search request is first sent over to psychic through a sort of proxy (the [`ajax_psychic` method](https://github.com/Ensembl/public-plugins/blob/release/105/solr/modules/EnsEMBL/Web/Controller/Ajax.pm#L345); nine years ago a developer left a comment that it's a horrible hack; but it is still with us till this day). There were several problems with the code:
- the client didn't include the species when it sent the request
- the server's `ajax_psychic` method didn't expect a species in the url
- the client-side code was not correctly handling the asynchronous nature of the request and was not waiting for the response (see [here](https://github.com/Ensembl/public-plugins/blob/release/105/solr/src/templates/google_templates.coffee#L396)).

This PR tries to address the above problems. **Notice** that the proper source of the fixed client-side code is the `google_templates.coffee` file (I don't know why it is named this way). The `template_data.coffee` file that has the same changes in the diff is generated automatically as a copy of `google_templates.coffee`.