### PR TITLE
switch default SV track from 1KG to gnomAD

### DIFF
--- a/ensembl/conf/ini-files/homo_sapiens.ini
+++ b/ensembl/conf/ini-files/homo_sapiens.ini
@@ -49,7 +49,7 @@ ASSEMBLY_CONVERTER_FILES = [GRCh37_to_GRCh38 GRCh37_to_NCBI34 GRCh37_to_NCBI35 G
 
 variation_set_gnomAD      = compact
 variation_set_ph_variants = compact
-sv_set_1kg_3              = compact
+nstd166                   = compact
 
 
 [ENSEMBL_INTERNAL_BIGBED_SOURCES]


### PR DESCRIPTION
We wish to show the 'gnomAD-SV (dbVar study nstd166) (structural variants)' track by default and not the '1000 Genomes 3 - All (structural variants)' track. The 1000 Genomes track will still be available on the configuration options.