### PR TITLE
Notify user of missing alphafold model

### DIFF
--- a/widgets/htdocs/alphafold/dataFetchers.js
+++ b/widgets/htdocs/alphafold/dataFetchers.js
@@ -15,8 +15,13 @@ const commonOptions = {
 export const fetchAlphaFoldId = async (params) => {
   const { rootUrl: apiRoot, enspId } = params;
   const url = `${apiRoot}/overlap/translation/${enspId}?feature=protein_feature;type=alphafold`;
-  const alphafoldFeatures = await fetch(url, commonOptions)
-    .then(response => response.json()); // should be an array of one feature
+  const alphafoldResponse = await fetch(url, commonOptions);
+  const alphafoldFeatures = await alphafoldResponse.json(); // should be an array of one feature
+
+  if (!alphafoldResponse.ok || !alphafoldFeatures.length) {
+    throw new MissingAlphafoldModelError();
+  }
+
   const { id: alphaFoldId } = alphafoldFeatures[0];
 
   // Note that the alphafold id will end in the name of the chain (e.g. "AF-Q9S745-F1.A").
@@ -143,3 +148,11 @@ const processProteinFeatures = (features) => {
   });
   return groupedFeatures;
 };
+
+
+export class MissingAlphafoldModelError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'MissingAlphafoldModelError';
+  }
+}

--- a/widgets/htdocs/alphafold/index.js
+++ b/widgets/htdocs/alphafold/index.js
@@ -4,7 +4,8 @@ import {
   fetchAlphaFoldId,
   fetchExons,
   fetchVariants,
-  fetchProteinFeatures
+  fetchProteinFeatures,
+  MissingAlphafoldModelError
 } from './dataFetchers.js';
 import { getRGBFromHex } from './colorHelpers.js';
 
@@ -75,7 +76,7 @@ export class EnsemblAlphafoldViewer extends LitElement {
           return obj;
         }, {});
     }).catch(error => {
-      this.onLoadFailed();
+      this.onLoadFailed(error);
     });
   }
 
@@ -153,9 +154,13 @@ export class EnsemblAlphafoldViewer extends LitElement {
     this.dispatchEvent(loadCompleteEvent);
   }
 
-  onLoadFailed() {
+  onLoadFailed(error) {
     // will be called if either pdbe-molstar failed to load or one of the REST endpoints failed to respond
-    this.dispatchEvent(new Event('load-error'));
+    if (error instanceof MissingAlphafoldModelError) {
+      this.dispatchEvent(new Event('alphafold-model-missing'));
+    } else {
+      this.dispatchEvent(new Event('load-error'));
+    }
   }
 
   updateMolstarSelections() {

--- a/widgets/htdocs/components/95_AFDB.js
+++ b/widgets/htdocs/components/95_AFDB.js
@@ -44,6 +44,7 @@ Ensembl.Panel.AFDB = Ensembl.Panel.Content.extend({
     var ensemblAlphafoldElement = document.querySelector('ensembl-alphafold-viewer'); // <-- custom element will always be included in server response
     ensemblAlphafoldElement.addEventListener('loaded', this.onWidgetReady.bind(this));
     ensemblAlphafoldElement.addEventListener('load-error', this.onScriptLoadError.bind(this));
+    ensemblAlphafoldElement.addEventListener('alphafold-model-missing', this.onAlphafoldModelMissing.bind(this));
   },
 
   onWidgetReady: function() {
@@ -54,6 +55,12 @@ Ensembl.Panel.AFDB = Ensembl.Panel.Content.extend({
 
   onScriptLoadError: function() {
     var message = 'An error occurred while loading the 3D protein viewer';
+    this.removeSpinner();
+    this.showMsg(message);
+  },
+
+  onAlphafoldModelMissing: function() {
+    var message = 'There is no Alphafold model for this molecule';
     this.removeSpinner();
     this.showMsg(message);
   },


### PR DESCRIPTION
When we are displaying link to alphafold model in the left-hand sidebar, we are only checking:
- that this species has some alphafold analyses
- that the transcript has a translation

We are not checking that a given transcript specifically has alphafold analysis. Which means that sometimes we show users the link that opens a page with no alphafold models available.

![image](https://user-images.githubusercontent.com/6834224/161111648-70f62f21-c920-4756-8557-f413012fd479.png)

The error we are showing in such case is too non-specific and confusing for the user:

![image](https://user-images.githubusercontent.com/6834224/161112291-56a28e17-b107-435d-8ca5-70a070e0f27a.png)

This PR makes the text of the error more specific for cases when the Alphafold model is missing.

Relevant Slack conversation:
https://genomes-ebi.slack.com/archives/C0JBUBFRD/p1648660444283599

Sandbox:
http://wp-np2-1e.ebi.ac.uk:8450/Glycine_max/Transcript/AFDB?db=core;g=GLYMA_12G066300;r=12:4875471-4878097;t=KRH24850