### PR TITLE
Switch to http from ftp URLs for efficiency.

### DIFF
--- a/ensembl/conf/json/canis_lupus_familiaris_vcf.json
+++ b/ensembl/conf/json/canis_lupus_familiaris_vcf.json
@@ -5,7 +5,7 @@
       "species": "canis_lupus_familiaris",
       "assembly": "CanFam3.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/pub/databases/eva/PRJEB24066/dogs.557.publicSamples.ann.vcf.gz",
+      "filename_template" : "http://ftp.ebi.ac.uk/pub/databases/eva/PRJEB24066/dogs.557.publicSamples.ann.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", 
         "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "X", "MT"

--- a/ensembl/conf/json/chlorocebus_sabaeus_vcf.json
+++ b/ensembl/conf/json/chlorocebus_sabaeus_vcf.json
@@ -9,7 +9,7 @@
       "type": "remote",
       "use_as_source" : 1,
       "strict_name_match" : 0,
-      "filename_template" : "ftp://ftp.ebi.ac.uk/pub/databases/eva/PRJEB22988/Svardal_et_al_2017_vervet_monkey_SNPs_imputed_phased.vcf.gz"
+      "filename_template" : "http://ftp.ebi.ac.uk/pub/databases/eva/PRJEB22988/Svardal_et_al_2017_vervet_monkey_SNPs_imputed_phased.vcf.gz"
     },
     {
       "id": "91_mammals.gerp_conservation_score",

--- a/ensembl/conf/json/neovison_vison_vcf.json
+++ b/ensembl/conf/json/neovison_vison_vcf.json
@@ -8,7 +8,7 @@
       "assembly": "NNQGG.v01",
       "type": "remote",
       "use_as_source" : 1,
-      "filename_template" : "ftp://ftp.ebi.ac.uk/pub/databases/eva/PRJEB26368/GBS_mink_eva.vcf.gz",
+      "filename_template" : "http://ftp.ebi.ac.uk/pub/databases/eva/PRJEB26368/GBS_mink_eva.vcf.gz",
       "population_display_group": {
         "display_group_name": "PRJEB26368",
         "display_group_priority": "1"

--- a/ensembl/conf/json/oreochromis_niloticus_vcf.json
+++ b/ensembl/conf/json/oreochromis_niloticus_vcf.json
@@ -9,7 +9,7 @@
       "type": "remote",
       "use_as_source" : 1,
       "use_seq_region_synonyms": 1,
-      "filename_template" : "ftp://ftp.ebi.ac.uk/pub/databases/eva/PRJEB38548/tilapia_snp_array.vcf.gz",
+      "filename_template" : "http://ftp.ebi.ac.uk/pub/databases/eva/PRJEB38548/tilapia_snp_array.vcf.gz",
       "chromosomes": [
         "LG1", "LG2","LG3","LG4","LG5","LG6","LG7","LG8","LG9","LG10","LG11","LG12","LG13","LG14","LG15","LG16","LG17","LG18","LG19","LG20","LG21","LG22","LG23"
       ],

--- a/ensembl/conf/json/oryctolagus_cuniculus_vcf.json
+++ b/ensembl/conf/json/oryctolagus_cuniculus_vcf.json
@@ -9,7 +9,7 @@
       "type": "remote",
       "use_as_source" : 1,
       "use_seq_region_synonyms": 1,
-      "filename_template" : "ftp://ftp.ebi.ac.uk/pub/databases/eva/PRJEB27278/Craniosnyostotic_Rabbit_Colony_eva08062018.vcf.gz",
+      "filename_template" : "http://ftp.ebi.ac.uk/pub/databases/eva/PRJEB27278/Craniosnyostotic_Rabbit_Colony_eva08062018.vcf.gz",
       "chromosomes": [
         "1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","X"
       ]

--- a/ensembl/conf/json/parus_major_vcf.json
+++ b/ensembl/conf/json/parus_major_vcf.json
@@ -8,7 +8,7 @@
       "assembly": "Parus_major1.1",
       "type": "remote",
       "use_as_source" : 1,
-      "filename_template" : "ftp://ftp.ebi.ac.uk/pub/databases/eva/PRJEB24964/GreatTits_PolyMonoMinorHom1.10_NoUN_NoScaffolds.vcf.gz"
+      "filename_template" : "http://ftp.ebi.ac.uk/pub/databases/eva/PRJEB24964/GreatTits_PolyMonoMinorHom1.10_NoUN_NoScaffolds.vcf.gz"
     },
     {
       "id": "58_amniotes.gerp_conservation_score",


### PR DESCRIPTION
The EBI ftp site supports both ftp and http URLs. We should use http rather than ftp for things like VCFs as they use random access and ftp handles this very badly. This diff will take a significant amount of load off the EBI ftp server.