### PR TITLE
Reg subtracks on Genoverse

### DIFF
--- a/genoverse/htdocs/genoverse/ensembl/js/Track/library/RegulatoryFeature.js
+++ b/genoverse/htdocs/genoverse/ensembl/js/Track/library/RegulatoryFeature.js
@@ -16,15 +16,24 @@
  */
 
 Genoverse.Track.RegulatoryFeature = Genoverse.Track.extend({
-  legendType   : 'Regulation', // this forces single legend for all reg feature tracks
-  legendName   : 'Regulation Legend',
-  legend       : true,
+  legendType    : 'Regulation', // this forces single legend for all reg feature tracks
+  legendName    : 'Regulation Legend',
+  legend        : true,
+  height        : 50,
+  featureHeight : 12,
 
   view: Genoverse.Track.View.extend({
-    bump   : true,
+    bump   : false,
     labels : false,
 
     drawFeature: function (feature, featureContext, labelContext, scale) {
+      
+      if(feature.row > 1){
+        var row = feature.row-1;
+        feature.y += (this.featureMargin.top * row) + (this.featureHeight  * row);
+        feature.position[scale].bottom +=  (this.featureMargin.top * row) + (this.featureHeight * row);
+      }
+
       this.base(feature, featureContext, labelContext, scale); 
       feature.legend = feature.label;
     },


### PR DESCRIPTION
**NOTE**: To be merged along with https://github.com/Ensembl/ensembl-webcode/pull/882

**Description:**
- Genoverse does not seem to have the functionality to display subtracks. I have introduced a `row` key to the features data returned by `fetch_fg_regulatory_features` that tells which feature needs to go into which row. The `row` key is then used to position the features on different `y-axis` to make them appear as if they are subtracks.

- Turned off the bumping for regulation tracks

**Sandbox URL**:
http://wp-np2-1d.ebi.ac.uk:42228/Homo_sapiens/Location/View?r=8:26291508-26372680

**Related JIRA**:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6596

