### PR TITLE
Add text to image header configuration icons

### DIFF
--- a/genoverse/htdocs/genoverse/ensembl/css/ensembl.css
+++ b/genoverse/htdocs/genoverse/ensembl/css/ensembl.css
@@ -303,12 +303,12 @@ body.mac .gv-label-container li .gv-handle {
 
 .image_toolbar .genoverse_switch {
   background-image: url(/i/switch.png);
+  background-position: 6px;
+  background-repeat: no-repeat;
+  padding: 0 10px 0 28px;
   float: left;
   height: 16px;
-  width: 16px;
-  margin: -2px 4px 2px 2px;
   border: 2px solid inherit;
-  border-radius: 2px;
   cursor: pointer;
 }
 

--- a/genoverse/htdocs/genoverse/ensembl/js/00_extensions.js
+++ b/genoverse/htdocs/genoverse/ensembl/js/00_extensions.js
@@ -60,7 +60,7 @@ Ensembl.Panel.ImageMap = Ensembl.Panel.ImageMap.extend({
   addGenoverseSwitch: function () {
     var panel = this;
 
-    $('<div class="genoverse_switch"></div>').appendTo(this.elLk.toolbars).on('click', function () {
+    $('<div class="genoverse_switch">Switch image</div>').appendTo(this.elLk.toolbars).on('click', function () {
       panel.params.updateURL = Ensembl.updateURL({ genoverse: panel.isGenoverse ? 1 : 0 }, panel.params.updateURL);
       panel.toggleLoading(true);
 


### PR DESCRIPTION
## Description
Added text to the `genoverse_switch` image icon. This was the only icon in `public-plugins`. All the other icons are in `ensembl-webcode` repo and [a separate PR](https://github.com/Ensembl/ensembl-webcode/pull/887) is created for it.

## Release version
e107

## Sandbox link
http://wp-np2-1e.ebi.ac.uk:8320/Homo_sapiens/Location/View?db=core;g=ENSG00000139618;r=13:32315086-32400268

## Views affected
Configuration headers/toolbars in Region in detail and Gene pages

## Related JIRA Issues (EBI developers only)
[ENSWEB-6553](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6553)