### PR TITLE
feat: Add new AF options

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -496,9 +496,15 @@ sub _build_variants_frequency_data {
           'value'         => 'yes',
           'checked'       => 0
         }, {
-          'name'          => "af_gnomad",
-          'caption'       => $fd->{af_gnomad}->{label},
-          'helptip'       => $fd->{af_gnomad}->{helptip},
+          'name'          => "af_gnomade",
+          'caption'       => $fd->{af_gnomade}->{label},
+          'helptip'       => $fd->{af_gnomade}->{helptip},
+          'value'         => 'yes',
+          'checked'       => 0
+        }, {
+          'name'          => "af_gnomadg",
+          'caption'       => $fd->{af_gnomadg}->{label},
+          'helptip'       => $fd->{af_gnomadg}->{helptip},
           'value'         => 'yes',
           'checked'       => 0
         }]

--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -96,7 +96,7 @@ sub prepare_to_dispatch {
 
     # Allele frequencies in human
     if ($species eq 'Homo_sapiens') {
-      foreach my $pop_af (qw(af af_1kg af_esp af_gnomad)) {
+      foreach my $pop_af (qw(af af_1kg af_gnomade af_gnomadg)) {
         $vep_configs->{$pop_af} = $job_data->{$pop_af} if ($job_data->{$pop_af});
       }
       $vep_configs->{'pubmed'} = $job_data->{'pubmed'} if $job_data->{'pubmed'};

--- a/tools/modules/EnsEMBL/Web/Object/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Object/VEP.pm
@@ -231,14 +231,14 @@ sub get_form_details {
         'helptip' => 'Report allele frequencies for the combined 1000 Genomes Project phase 3 continental populations - AFR (African), AMR (American), EAS (East Asian), EUR (European) and SAS (South Asian)',
       },
 
-      af_esp => {
-        'label'   => 'ESP allele frequencies',
-        'helptip' => 'Report allele frequencies for the NHLBI Exome Sequencing Project populations - AA (African American) and EA (European American)',
-      },
-
-      af_gnomad => {
+      af_gnomade => {
         'label'   => 'gnomAD (exomes) allele frequencies',
         'helptip' => 'Report allele frequencies from the genome Aggregation Database (exomes)',
+      },
+
+      af_gnomadg => {
+        'label'   => 'gnomAD (genomes) allele frequencies',
+        'helptip' => 'Report allele frequencies from the genome Aggregation Database (genomes)',
       },
 
       pubmed => {


### PR DESCRIPTION
## Description

Newer version of VEP cache should have two new options `--af_gnomade` and `--af_gnomadg`, also `--af_esp` should be deprecated.

## Test

...