### PR TITLE
Update json configuration for new genotype data

### DIFF
--- a/ensembl/conf/json/canis_lupus_familiaris_vcf.json
+++ b/ensembl/conf/json/canis_lupus_familiaris_vcf.json
@@ -3,6 +3,19 @@
     {
       "id": "dog_EVA_PRJEB24066",
       "species": "canis_lupus_familiaris",
+      "source_name": "PRJEB24066",
+      "description": "Variants remapped from EVA study PRJEB24066",
+      "assembly": "ROS_Cfam_1.0",
+      "type": "local",
+      "filename_template" : "/canis_lupus_familiaris/ROS_Cfam_1.0/variation_genotype/ROS_Cfam_1.0_remap_PRJEB24066.vcf.gz",
+      "chromosomes": [
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21",
+        "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "X", "Y"
+      ]
+    },
+    {
+      "id": "dog_EVA_PRJEB24066",
+      "species": "canis_lupus_familiaris",
       "assembly": "CanFam3.1",
       "type": "remote",
       "filename_template" : "http://ftp.ebi.ac.uk/pub/databases/eva/PRJEB24066/dogs.557.publicSamples.ann.vcf.gz",

--- a/ensembl/conf/json/canis_lupus_familiarisboxer_vcf.json
+++ b/ensembl/conf/json/canis_lupus_familiarisboxer_vcf.json
@@ -1,6 +1,19 @@
 {
   "collections": [
     {
+      "id": "dog_EVA_PRJEB24066",
+      "species": "canis_lupus_familiarisboxer",
+      "source_name": "PRJEB24066",
+      "description": "Variants remmaped from EVA study PRJEB24066",
+      "assembly": "Dog10K_Boxer_Tasha",
+      "type": "local",
+      "filename_template" : "/canis_lupus_familiarisboxer/Dog10K_Boxer_Tasha/variation_genotype/Dog10K_Boxer_Tasha_remap_PRJEB24066.vcf.gz",
+      "chromosomes": [
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21",
+        "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "X"
+      ]
+    },
+    {
       "id": "91_mammals.gerp_conservation_score",
       "species": "canis_lupus_familiarisboxer",
       "assembly": "Dog10K_Boxer_Tasha",

--- a/ensembl/conf/json/gallus_gallus_vcf.json
+++ b/ensembl/conf/json/gallus_gallus_vcf.json
@@ -1,6 +1,17 @@
 {
   "collections": [
     {
+      "id": "gallus_gallus_EVA_PRJEB44919",
+      "source_name": "PRJEB44919",
+      "description": "Variants from EVA study PRJEB44919",
+      "species": "gallus_gallus",
+      "assembly": "bGalGal1.mat.broiler.GRCg7b",
+      "type": "local",
+      "filename_template": "/gallus_gallus/bGalGal1.mat.broiler.GRCg7b/variation_genotype/cohort188.ALL.1-28.fixed_remap7b.vcf.gz",
+      "use_as_source": 0,
+      "strict_name_match": 0
+    },
+    {
       "id": "58_amniotes.gerp_conservation_score",
       "species": "gallus_gallus",
       "assembly": "GRCg6a",


### PR DESCRIPTION
We are adding new genotype data from EVA vcf -
https://www.ebi.ac.uk/eva/?eva-study=PRJEB44919

In this process we need to update the vcf file information in the json config file. The genotype data is tested on sandbox -

e.g. - http://wp-np2-11.ebi.ac.uk:7070/Gallus_gallus/Variation/Population?db=core;r=1:196051926-196053237;v=rs739477247;vdb=variation;vf=4893594)