### PR TITLE
Add tasmanian devil publication - requested by collaborators

### DIFF
--- a/ensembl/htdocs/ssi/species/Sarcophilus_harrisii_annotation.html
+++ b/ensembl/htdocs/ssi/species/Sarcophilus_harrisii_annotation.html
@@ -4,3 +4,6 @@
   <li><a href="/info/genome/genebuild/2020_08_tasmania_devil_gene_annotation.pdf">Detailed information on the genebuild</a> (PDF)</li>
 </ul>
 <p>In accordance with the <a href="https://en.wikipedia.org/wiki/Fort_Lauderdale_Agreement">Fort Lauderdale Agreement</a>, please check the publication status of the genome/assembly before publishing any genome-wide analyses using these data.</p>
+<br>
+<p><b>Data citation</b><br>
+For use of these resources, please cite: <b>Stammnitz, MR et al. 2022, The evolution of two transmissible cancers in Tasmanian devils</b> (https://www.biorxiv.org/content/10.1101/2022.05.27.493404v1)<br></p>


### PR DESCRIPTION
Via Outreach:

We have received a ticket on the helpdesk from Max Stammnitz who is involved in sequencing the Tasmanian devil genome. They have recently released the preprint describing the new Tasmanian devil genome assembly (mSarHar1.11) and its Ensembl gene annotation: https://www.biorxiv.org/content/10.1101/2022.05.27.493404v1

Since the embargo for open use of this resource is thereby effectively lifted, they have asked if we could add the following data citation lines to the description of the associated Ensembl pages:

<br>
<p><b>Data citation</b><br>
For use of these resources, please cite: <b>Stammnitz, MR et al. 2022, The evolution of two transmissible cancers in Tasmanian devils
</b> (https://www.biorxiv.org/content/10.1101/2022.05.27.493404v1)<br></p>