### PR TITLE
Add the display_items_list method that got lost from the inheritance chain

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -30,6 +30,7 @@ use Bio::EnsEMBL::VEP::Constants qw(%FIELD_DESCRIPTIONS);
 use EnsEMBL::Web::Utils::FormatText qw(helptip);
 use EnsEMBL::Web::Utils::Variation qw(render_sift_polyphen);
 use EnsEMBL::Web::Component::Tools::NewJobButton;
+use EnsEMBL::Web::Utils::Variation qw(display_items_list);
 
 use parent qw(EnsEMBL::Web::Component::Tools::VEP);
 
@@ -1301,7 +1302,7 @@ sub get_items_in_list {
 
   if (scalar @items_list > $min_items_count) {
     my $div_id = 'row_'.$row_id.'_'.$type;
-    return $self->display_items_list($div_id, $type, $label, \@items_with_url, \@items_list);
+    return display_items_list($div_id, $type, $label, \@items_with_url, \@items_list);
   }
   else {
     return join('<br />',@items_with_url);

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VR/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VR/Results.pm
@@ -27,6 +27,7 @@ use EnsEMBL::Web::Component::Tools::NewJobButton;
 use POSIX qw(ceil);
 use EnsEMBL::Web::Utils::FormatText qw(helptip);
 use URI::Escape qw(uri_unescape);
+use EnsEMBL::Web::Utils::Variation qw(display_items_list);
 
 use parent qw(EnsEMBL::Web::Component::Tools::VR);
 
@@ -528,7 +529,7 @@ sub get_items_in_list {
 
   if (scalar @items_list > $min_items_count) {
     my $div_id = 'row_'.$row_id.'_'.$type;
-    return $self->display_items_list($div_id, $type, $label, \@items_with_url, \@items_list);
+    return display_items_list($div_id, $type, $label, \@items_with_url, \@items_list);
   }
   else {
     return join('<br />',@items_with_url);


### PR DESCRIPTION
The method was removed from Web::Component::Shared in [this commit](https://github.com/Ensembl/ensembl-webcode/commit/f9f7ddcbf8ac52ab51802a4e0f99951c93152c71) in ensembl-webcode, which broke tables in tools.