### PR TITLE
Prairie vole EVA variants support (108)

### DIFF
--- a/ensembl/conf/ini-files/microtus_ochrogaster.ini
+++ b/ensembl/conf/ini-files/microtus_ochrogaster.ini
@@ -1,6 +1,9 @@
 ###############################################################################
 #   
-#   Description:    Configuration file for species 
+#   Name:           microtus_ochrogaster.ini
+#   
+#   Description:    Configuration file for Prairie vole Ensembl
+#   
 #
 ###############################################################################
 
@@ -8,7 +11,27 @@
 # GENERAL CONFIG
 #################
 [general]
+
+# Database info: only specify values if different from those in DEFAULTS
+
+# Assembly info
+FTP_DATA                = 0
 SPECIES_RELEASE_VERSION = 10
+
+[databases]
+
+DATABASE_CORE       = microtus_ochrogaster_core_108_10
+DATABASE_VARIATION  = microtus_ochrogaster_variation_108_10
+
+[DATABASE_CORE]
+USER = ensro
+HOST = mysql-ens-sta-1
+PORT = 4519
+
+[DATABASE_VARIATION]
+USER = ensro
+HOST = mysql-ens-var-prod-1
+PORT = 4449
 
 ####################
 # Species-specific colours
@@ -16,13 +39,46 @@ SPECIES_RELEASE_VERSION = 10
 
 [ENSEMBL_STYLE]
 
-[ENSEMBL_COLOURS] 
+[ENSEMBL_COLOURS]
 # Accept defaults
+
+
+####################
+# External Database ad Indexer Config
+####################
+[ENSEMBL_EXTERNAL_DATABASES]
+# Accept defaults
+
+[ENSEMBL_EXTERNAL_INDEXERS]
+# Accept defaults
+
+
+####################
+# Configure External Genome Browsers
+####################
+
+[EXTERNAL_GENOME_BROWSERS] 
+# None
+
+
+[ENSEMBL_EXTERNAL_URLS]
+# Accept defaults
+
+####################
+# Configure search example links
+####################
+
+[ENSEMBL_DICTIONARY]
 
 
 [SAMPLE_DATA]
 
+VARIATION_PARAM = rs159255877;vf=1:14087779:T_C:EVA
+VARIATION_TEXT  = rs159255877
 
+VEP_HGVS          = ENSMOCT00000000366.1:c.4A>G\nENSMOCT00000000562.1:c.161+16C>G\nENSMOCT00000000441.1:c.4del
+VEP_VCF           = 1 23719298 . A G . . .\n2 4164800 . C G . . .\n5 13598836 . GA G . . .
+VEP_SPDI          = NC_022009.1:23719297:A:G\nNC_022010.1:4164799:C:G\nNC_022012.1:13598836:A:
+VEP_ENSEMBL       = 1 23719298 23719298 A/G 1\n2 4164800 4164800 C/G 1\n5 13598837 13598837 A/- 1
 
-SEARCH_TEXT       = Clpx  
-
+SEARCH_TEXT      = Clpx

--- a/ensembl/conf/ini-files/microtus_ochrogaster.ini
+++ b/ensembl/conf/ini-files/microtus_ochrogaster.ini
@@ -15,7 +15,6 @@
 # Database info: only specify values if different from those in DEFAULTS
 
 # Assembly info
-FTP_DATA                = 0
 SPECIES_RELEASE_VERSION = 10
 
 [databases]

--- a/ensembl/conf/ini-files/microtus_ochrogaster.ini
+++ b/ensembl/conf/ini-files/microtus_ochrogaster.ini
@@ -12,25 +12,7 @@
 #################
 [general]
 
-# Database info: only specify values if different from those in DEFAULTS
-
-# Assembly info
 SPECIES_RELEASE_VERSION = 10
-
-[databases]
-
-DATABASE_CORE       = microtus_ochrogaster_core_108_10
-DATABASE_VARIATION  = microtus_ochrogaster_variation_108_10
-
-[DATABASE_CORE]
-USER = ensro
-HOST = mysql-ens-sta-1
-PORT = 4519
-
-[DATABASE_VARIATION]
-USER = ensro
-HOST = mysql-ens-var-prod-1
-PORT = 4449
 
 ####################
 # Species-specific colours
@@ -40,34 +22,6 @@ PORT = 4449
 
 [ENSEMBL_COLOURS]
 # Accept defaults
-
-
-####################
-# External Database ad Indexer Config
-####################
-[ENSEMBL_EXTERNAL_DATABASES]
-# Accept defaults
-
-[ENSEMBL_EXTERNAL_INDEXERS]
-# Accept defaults
-
-
-####################
-# Configure External Genome Browsers
-####################
-
-[EXTERNAL_GENOME_BROWSERS] 
-# None
-
-
-[ENSEMBL_EXTERNAL_URLS]
-# Accept defaults
-
-####################
-# Configure search example links
-####################
-
-[ENSEMBL_DICTIONARY]
 
 
 [SAMPLE_DATA]

--- a/ensembl/conf/json/microtus_ochrogaster_vcf.json
+++ b/ensembl/conf/json/microtus_ochrogaster_vcf.json
@@ -1,0 +1,27 @@
+{
+    "collections": [
+      {
+        "id": "prairie_vole_EVA",
+        "source_name": "EVA",
+        "description": "Variants from EVA",
+        "species": "microtus_ochrogaster",
+        "assembly": "MicOch1.0",
+        "type": "remote",
+        "use_as_source" : 1,
+        "filename_template": "ftp://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_3/by_species/microtus_ochrogaster/GCA_000317375.1/GCA_000317375.1_current_ids.vcf.gz",
+        "chromosomes": [
+          "1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+          "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+          "21", "22", "23", "24", "25", "26", "X"
+        ]
+      },
+      {
+        "id": "91_mammals.gerp_conservation_score",
+        "species": "microtus_ochrogaster",
+        "assembly": "MicOch1.0",
+        "type": "remote",
+        "filename_template" : "/91_mammals.gerp_conservation_score/gerp_conservation_scores.microtus_ochrogaster.MicOch1.0.bw",
+        "annotation_type": "gerp"
+      }
+    ]
+  }


### PR DESCRIPTION
Add support for remote EVA variants from Prairie vole (_Microtus ochrogaster_).

Tested in my sandbox: http://wp-np2-11.ebi.ac.uk:6070/Microtus_ochrogaster/Info/Index