### PR TITLE
Remove trailing comma from array

### DIFF
--- a/widgets/htdocs/components/95_AFDB.js
+++ b/widgets/htdocs/components/95_AFDB.js
@@ -43,7 +43,7 @@ Ensembl.Panel.AFDB = Ensembl.Panel.Content.extend({
   onScriptLoaded: function() {
     var ensemblAlphafoldElement = [
       document.querySelector('ensembl-alphafold-protein'),
-      document.querySelector('ensembl-alphafold-vep'),
+      document.querySelector('ensembl-alphafold-vep')
     ].filter(Boolean).pop(); // <-- a custom element will always be included in server response
     ensemblAlphafoldElement.addEventListener('loaded', function() {
       this.onWidgetReady(ensemblAlphafoldElement);


### PR DESCRIPTION
Google closure compiler is upset by the trailing comma left in the array:

```
 Merging components js files                                                                                         
/nfs/services/nobackup/ensweb/live/www/www_107/server/minified/e7d519713db8eebf97efb160cb072431.js.tmp:34184: ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length
 and objects will not parse at all.                                                                                  
    ].filter(Boolean).pop(); // <-- a custom element will always be included in server response                                                                                                                                            
     ^                                                                                                               
                                                                                                                     
1 error(s), 0 warning(s)
```