### PR TITLE
Clarify exclusion list filtering

### DIFF
--- a/ensembl/htdocs/info/genome/funcgen/process/peak-calling.html
+++ b/ensembl/htdocs/info/genome/funcgen/process/peak-calling.html
@@ -34,7 +34,7 @@
 
 <h2 id="peakfiltering">Peak filtering</h2>
 
-<p>The <a href="http://hgwdev.cse.ucsc.edu/cgi-bin/hgFileUi?db=hg19&amp;g=wgEncodeMapability">ENCODE DAC Blacklist regions</a> are then used to filter the resultant peaks.</p>
+<p>Currently, we publish our peak tracks unfiltered. However, for downstream analysis (segmentation and regulatory annotation), we filter our peaks to exclude regions using a modified version of the <a href = "https://www.encodeproject.org/annotations/ENCSR636HFF/">ENCODE DAC Exclusion List Regions</a>.</p>
 
 
 </BODY>


### PR DESCRIPTION
A documentation change to info/genome/funcgen/process/peak-calling.html to clarify the procedure we use for filtering peaks (using the ENCODE exclusion list). 