### PR TITLE
Add pike-perch EVA variants (108)

### DIFF
--- a/ensembl/conf/json/sander_lucioperca_vcf.json
+++ b/ensembl/conf/json/sander_lucioperca_vcf.json
@@ -12,7 +12,7 @@
         "filename_template": "https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_3/by_species/sander_lucioperca/GCA_008315115.1/GCA_008315115.1_current_ids.vcf.gz"
       },
       {
-        "id": "91_mammals.gerp_conservation_score",
+        "id": "65_fish.gerp_conservation_score",
         "species": "sander_lucioperca",
         "assembly": "SLUC_FBN_1",
         "type": "remote",

--- a/ensembl/conf/json/sander_lucioperca_vcf.json
+++ b/ensembl/conf/json/sander_lucioperca_vcf.json
@@ -1,9 +1,9 @@
 {
     "collections": [
       {
-        "id": "sander_lucioperca_EVA_PRJEB42376",
-        "source_name": "PRJEB42376",
-        "description": "Variants from EVA study PRJEB42376",
+        "id": "sander_lucioperca_EVA",
+        "source_name": "EVA",
+        "description": "Variants from EVA",
         "species": "sander_lucioperca",
         "assembly": "SLUC_FBN_1",
         "type": "remote",

--- a/ensembl/conf/json/sander_lucioperca_vcf.json
+++ b/ensembl/conf/json/sander_lucioperca_vcf.json
@@ -1,0 +1,23 @@
+{
+    "collections": [
+      {
+        "id": "sander_lucioperca_EVA_PRJEB42376",
+        "source_name": "PRJEB42376",
+        "description": "Variants from EVA study PRJEB42376",
+        "species": "sander_lucioperca",
+        "assembly": "SLUC_FBN_1",
+        "type": "remote",
+        "use_as_source" : 1,
+        "use_seq_region_synonyms": 1,
+        "filename_template": "https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_3/by_species/sander_lucioperca/GCA_008315115.1/GCA_008315115.1_current_ids.vcf.gz"
+      },
+      {
+        "id": "91_mammals.gerp_conservation_score",
+        "species": "sander_lucioperca",
+        "assembly": "SLUC_FBN_1",
+        "type": "remote",
+        "filename_template" : "/65_fish.gerp_conservation_score/gerp_conservation_scores.sander_lucioperca.SLUC_FBN_1.bw",
+        "annotation_type": "gerp"
+      }
+    ]
+  }


### PR DESCRIPTION
Add support for remote EVA variants from Pike-perche (_Sander lucioperca_).

Tested in my sandbox: http://wp-np2-11.ebi.ac.uk:6070/Sander_lucioperca/Location/View?r=VTTG01000001.1:5000-6000;db=core