### PR TITLE
Add great-tit and japanese-quail EVA variants (108)

### DIFF
--- a/ensembl/conf/json/coturnix_japonica_vcf.json
+++ b/ensembl/conf/json/coturnix_japonica_vcf.json
@@ -1,0 +1,22 @@
+{
+  "collections": [
+    {
+    "id": "coturnix_japonica_EVA",
+    "source_name": "EVA",
+    "description": "Variants from EVA",
+    "species": "coturnix_japonica",
+    "assembly": "Coturnix_japonica_2.0",
+    "type": "remote",
+    "use_as_source" : 1,
+    "filename_template": "https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_3/by_species/coturnix_japonica/Coturnix_japonica_2.0/GCA_001577835.1_current_ids.vcf.gz"
+    },
+    {
+    "id": "27_sauropsids.gerp_conservation_score",
+    "species": "coturnix_japonica",
+    "assembly": "Coturnix_japonica_2.0",
+    "type": "remote",
+    "filename_template" : "/27_sauropsids.gerp_conservation_score/gerp_conservation_scores.coturnix_japonica.Coturnix_japonica_2.0.bw",
+    "annotation_type": "gerp"
+    }
+  ]
+}

--- a/ensembl/conf/json/parus_major_vcf.json
+++ b/ensembl/conf/json/parus_major_vcf.json
@@ -1,14 +1,14 @@
 {
   "collections": [
     {
-      "id": "great_tit_EVA_PRJEB24964",
-      "source_name": "PRJEB24964",
-      "description": "Variants from EVA study PRJEB24964",
+      "id": "parus_major_EVA",
+      "source_name": "EVA",
+      "description": "Variants from EVA",
       "species": "parus_major",
       "assembly": "Parus_major1.1",
       "type": "remote",
       "use_as_source" : 1,
-      "filename_template" : "http://ftp.ebi.ac.uk/pub/databases/eva/PRJEB24964/GreatTits_PolyMonoMinorHom1.10_NoUN_NoScaffolds.vcf.gz"
+      "filename_template": "https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_3/by_species/parus_major/GCA_001522545.2/GCA_001522545.2_current_ids.vcf.gz"
     },
     {
       "id": "58_amniotes.gerp_conservation_score",


### PR DESCRIPTION

[ENSVAR-4962](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4962)
Added support for Great tit (Parus_major)
Sandbox: http://wp-np2-11.ebi.ac.uk:6070/Parus_major/Location/View?r=2:71746274-71844284

[ENSVAR-4963](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4963)
Added support for Japanese quail (Coturnix_japonica)
Sandbox: http://wp-np2-11.ebi.ac.uk:6070/Coturnix_japonica/Location/View?r=3:71823736-72447687