### PR TITLE
Add assembly converter chain files to configpacker

### DIFF
--- a/tools/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/tools/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -164,8 +164,6 @@ sub _configure_assembly_converter_files {
     my @files = ();
     # Get all the available chain files to add entry to corresponding species
     find(sub {
-      my $file = $_;
-      my $dir  = [split /\//, $File::Find::dir]->[-1];
       push @files, s/.chain.gz$//r if /.chain.gz$/;
     }, $chain_file_dir);
 

--- a/tools/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/tools/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -21,6 +21,7 @@ package EnsEMBL::Web::ConfigPacker;
 
 use strict;
 use warnings;
+use File::Find;
 
 use EnsEMBL::Web::Utils::FileHandler qw(file_get_contents);
 
@@ -30,6 +31,7 @@ sub munge_config_tree {
   my $self = shift;
   $self->PREV::munge_config_tree(@_);
   $self->_configure_blast;
+  $self->_configure_assembly_converter_files;
 }
 
 sub munge_config_tree_multi {
@@ -152,6 +154,24 @@ sub _vep_config_warning {
 
   $message = $fatal ? "[ERROR] VEP Plugins are not configured: $message" : "[WARNING] $message";
   warn $message." - thrown by ".__FILE__."\n";
+}
+
+sub _configure_assembly_converter_files {
+  my $self = shift;
+  my $species = $self->species;
+  my $version = $SiteDefs::ENSEMBL_VERSION;
+  my $chain_file_dir = File::Spec->catfile($SiteDefs::ENSEMBL_CHAIN_FILE_DIR, $species);
+  if (-d $chain_file_dir) {
+    my @files = ();
+    # Get all the available chain files to add entry to corresponding species
+    find(sub {
+      my $file = $_;
+      my $dir  = [split /\//, $File::Find::dir]->[-1];
+      push @files, s/.chain.gz$//r if /.chain.gz$/;
+    }, $chain_file_dir);
+
+    push @{$self->tree->{'ASSEMBLY_CONVERTER_FILES'}}, @files;
+  }
 }
 
 1;

--- a/tools/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/tools/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -159,7 +159,6 @@ sub _vep_config_warning {
 sub _configure_assembly_converter_files {
   my $self = shift;
   my $species = $self->species;
-  my $version = $SiteDefs::ENSEMBL_VERSION;
   my $chain_file_dir = File::Spec->catfile($SiteDefs::ENSEMBL_CHAIN_FILE_DIR, $species);
   if (-d $chain_file_dir) {
     my @files = ();


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6641

This PR adds assembly converter chain files config to Configpacker.
This way there is less hassle during the release - updating configs in this ticket https://www.ebi.ac.uk/panda/jira/browse/ENSWEBREL-892

This is where we use the newly added configs will be used https://github.com/Ensembl/public-plugins/blob/release/107/tools/modules/EnsEMBL/Web/Object/AssemblyConverter.pm#L100

We may also delete the script to dump these configs mentioned in the above ticket.

http://wp-np2-1e.ebi.ac.uk:9002/