### PR TITLE
Add mutfunc plugin for web VEP

### DIFF
--- a/tools/conf/vep_plugins_web_config.txt
+++ b/tools/conf/vep_plugins_web_config.txt
@@ -59,6 +59,10 @@
     "available" => 1
   },
 
+  mutfunc => {
+    "available" => 1
+  },
+
   NMD => {
     "available" => 1
   }

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -94,5 +94,12 @@
       "mutation_file=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/mutations.tsv",
       "@*"
     ]
-  }
+  },
+
+  mutfunc => {
+    "params" => [
+      "db=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/mutfunc_human_data.db",
+      "@*"
+    ]
+  },
 }


### PR DESCRIPTION
Adding new VEP plugin - mutfunc
sandbox link - http://wp-np2-11.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?from=6;size=5;tl=Yylb3Po1ohtqmdGj-96;to=10#Results 