### PR TITLE
Update core schema for 108

### DIFF
--- a/docs/htdocs/info/docs/api/core/core_schema.html
+++ b/docs/htdocs/info/docs/api/core/core_schema.html
@@ -80,7 +80,7 @@ tables that they've not used before.
 </p>
 
 <p>
-This document refers to version <span style="font-weight:bold;font-size:11pt;color:#000">107</span> of the EnsEMBL
+This document refers to version <span style="font-weight:bold;font-size:11pt;color:#000">108</span> of the EnsEMBL
 core schema.
 </p>
 
@@ -356,6 +356,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Chinchilla lanigera</li>
         <li class="sql_schema_species_name">Chlorocebus sabaeus</li>
@@ -693,6 +694,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -1151,6 +1153,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -1547,6 +1550,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -2023,6 +2027,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -2400,6 +2405,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -2786,6 +2792,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -3164,6 +3171,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -3548,6 +3556,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -4096,6 +4105,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -4472,6 +4482,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Chelydra serpentina</li>
         <li class="sql_schema_species_name">Chinchilla lanigera</li>
@@ -4884,6 +4895,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -5338,7 +5350,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Saimiri boliviensis boliviensis</li>
         <li class="sql_schema_species_name">Salmo salar</li>
         <li class="sql_schema_species_name">Salmo trutta</li>
-        <li class="sql_schema_species_name">Sarcophilus harrisii</li>
         <li class="sql_schema_species_name">Scleropages formosus</li>
         <li class="sql_schema_species_name">Scophthalmus maximus</li>
         <li class="sql_schema_species_name">Serinus canaria</li>
@@ -5531,6 +5542,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Chelydra serpentina</li>
         <li class="sql_schema_species_name">Chinchilla lanigera</li>
@@ -5859,6 +5871,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -5926,6 +5939,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Heterocephalus glaber female</li>
         <li class="sql_schema_species_name">Heterocephalus glaber male</li>
         <li class="sql_schema_species_name">Hippocampus comes</li>
+        <li class="sql_schema_species_name">Homo sapiens</li>
         <li class="sql_schema_species_name">Hucho hucho</li>
         <li class="sql_schema_species_name">Ictalurus punctatus</li>
         <li class="sql_schema_species_name">Ictidomys tridecemlineatus</li>
@@ -5972,6 +5986,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Mus musculus c57bl6nj</li>
         <li class="sql_schema_species_name">Mus musculus casteij</li>
         <li class="sql_schema_species_name">Mus musculus cbaj</li>
+        <li class="sql_schema_species_name">Mus musculus</li>
         <li class="sql_schema_species_name">Mus musculus dba2j</li>
         <li class="sql_schema_species_name">Mus musculus fvbnj</li>
         <li class="sql_schema_species_name">Mus musculus lpj</li>
@@ -6263,6 +6278,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -6641,6 +6657,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -7076,6 +7093,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Catharus ustulatus</li>
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
         <li class="sql_schema_species_name">Chelydra serpentina</li>
@@ -7231,7 +7249,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Salmo trutta</li>
         <li class="sql_schema_species_name">Salvator merianae</li>
         <li class="sql_schema_species_name">Sander lucioperca</li>
-        <li class="sql_schema_species_name">Sarcophilus harrisii</li>
         <li class="sql_schema_species_name">Sciurus vulgaris</li>
         <li class="sql_schema_species_name">Scleropages formosus</li>
         <li class="sql_schema_species_name">Serinus canaria</li>
@@ -7401,6 +7418,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -7825,6 +7843,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -8957,6 +8976,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Catharus ustulatus</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -9916,6 +9936,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -10349,6 +10370,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -10750,6 +10772,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -11130,6 +11153,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -11565,6 +11589,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -11982,6 +12007,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -12358,6 +12384,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Catharus ustulatus</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -12917,6 +12944,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -13310,6 +13338,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -13695,6 +13724,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -14187,6 +14217,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -14711,6 +14742,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -15089,6 +15121,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -15573,6 +15606,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -15951,6 +15985,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -16434,6 +16469,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -16906,6 +16942,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -17284,6 +17321,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -17757,6 +17795,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -18135,6 +18174,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -18513,6 +18553,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -18945,6 +18986,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -19324,6 +19366,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -19699,12 +19742,14 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Bos taurus</li>
         <li class="sql_schema_species_name">Callithrix jacchus</li>
+        <li class="sql_schema_species_name">Camarhynchus parvulus</li>
         <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Choloepus hoffmanni</li>
         <li class="sql_schema_species_name">Ciona intestinalis</li>
         <li class="sql_schema_species_name">Ciona savignyi</li>
+        <li class="sql_schema_species_name">Corvus moneduloides</li>
         <li class="sql_schema_species_name">Cyprinus carpio carpio</li>
         <li class="sql_schema_species_name">Danio rerio</li>
         <li class="sql_schema_species_name">Dasypus novemcinctus</li>
@@ -19728,6 +19773,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Macaca mulatta</li>
         <li class="sql_schema_species_name">Mastacembelus armatus</li>
         <li class="sql_schema_species_name">Meleagris gallopavo</li>
+        <li class="sql_schema_species_name">Melopsittacus undulatus</li>
         <li class="sql_schema_species_name">Microcebus murinus</li>
         <li class="sql_schema_species_name">Monodelphis domestica</li>
         <li class="sql_schema_species_name">Mus musculus</li>
@@ -19875,14 +19921,17 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Bos taurus</li>
         <li class="sql_schema_species_name">Callithrix jacchus</li>
+        <li class="sql_schema_species_name">Camarhynchus parvulus</li>
         <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Choloepus hoffmanni</li>
         <li class="sql_schema_species_name">Ciona intestinalis</li>
         <li class="sql_schema_species_name">Ciona savignyi</li>
+        <li class="sql_schema_species_name">Corvus moneduloides</li>
         <li class="sql_schema_species_name">Cyprinus carpio carpio</li>
         <li class="sql_schema_species_name">Danio rerio</li>
         <li class="sql_schema_species_name">Dasypus novemcinctus</li>
@@ -19910,6 +19959,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Macaca nemestrina</li>
         <li class="sql_schema_species_name">Mastacembelus armatus</li>
         <li class="sql_schema_species_name">Meleagris gallopavo</li>
+        <li class="sql_schema_species_name">Melopsittacus undulatus</li>
         <li class="sql_schema_species_name">Microcebus murinus</li>
         <li class="sql_schema_species_name">Monodelphis domestica</li>
         <li class="sql_schema_species_name">Mus musculus</li>
@@ -20042,7 +20092,6 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Bos taurus hybrid</li>
         <li class="sql_schema_species_name">Bubo bubo</li>
         <li class="sql_schema_species_name">Buteo japonicus</li>
-        <li class="sql_schema_species_name">Caenorhabditis elegans</li>
         <li class="sql_schema_species_name">Cairina moschata domestica</li>
         <li class="sql_schema_species_name">Calidris pugnax</li>
         <li class="sql_schema_species_name">Calidris pygmaea</li>
@@ -20064,6 +20113,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Cavia aperea</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Cervus hanglu yarkandensis</li>
         <li class="sql_schema_species_name">Chelonoidis abingdonii</li>
@@ -20379,11 +20429,13 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Bos taurus</li>
         <li class="sql_schema_species_name">Callithrix jacchus</li>
+        <li class="sql_schema_species_name">Camarhynchus parvulus</li>
         <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Ciona intestinalis</li>
         <li class="sql_schema_species_name">Ciona savignyi</li>
+        <li class="sql_schema_species_name">Corvus moneduloides</li>
         <li class="sql_schema_species_name">Cyprinus carpio carpio</li>
         <li class="sql_schema_species_name">Danio rerio</li>
         <li class="sql_schema_species_name">Dasypus novemcinctus</li>
@@ -20407,6 +20459,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Macaca mulatta</li>
         <li class="sql_schema_species_name">Mastacembelus armatus</li>
         <li class="sql_schema_species_name">Meleagris gallopavo</li>
+        <li class="sql_schema_species_name">Melopsittacus undulatus</li>
         <li class="sql_schema_species_name">Microcebus murinus</li>
         <li class="sql_schema_species_name">Monodelphis domestica</li>
         <li class="sql_schema_species_name">Mus musculus</li>
@@ -20607,14 +20660,17 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Astyanax mexicanus</li>
         <li class="sql_schema_species_name">Bos taurus</li>
         <li class="sql_schema_species_name">Callithrix jacchus</li>
+        <li class="sql_schema_species_name">Camarhynchus parvulus</li>
         <li class="sql_schema_species_name">Canis lupus familiarisboxer</li>
         <li class="sql_schema_species_name">Carlito syrichta</li>
         <li class="sql_schema_species_name">Cavia porcellus</li>
         <li class="sql_schema_species_name">Cebus capucinus</li>
+        <li class="sql_schema_species_name">Cebus imitator</li>
         <li class="sql_schema_species_name">Cercocebus atys</li>
         <li class="sql_schema_species_name">Choloepus hoffmanni</li>
         <li class="sql_schema_species_name">Ciona intestinalis</li>
         <li class="sql_schema_species_name">Ciona savignyi</li>
+        <li class="sql_schema_species_name">Corvus moneduloides</li>
         <li class="sql_schema_species_name">Cyprinus carpio carpio</li>
         <li class="sql_schema_species_name">Danio rerio</li>
         <li class="sql_schema_species_name">Dasypus novemcinctus</li>
@@ -20642,6 +20698,7 @@ The overall diagram can be found <a target="_blank" href="./diagrams/Core.svg">h
         <li class="sql_schema_species_name">Macaca nemestrina</li>
         <li class="sql_schema_species_name">Mastacembelus armatus</li>
         <li class="sql_schema_species_name">Meleagris gallopavo</li>
+        <li class="sql_schema_species_name">Melopsittacus undulatus</li>
         <li class="sql_schema_species_name">Microcebus murinus</li>
         <li class="sql_schema_species_name">Monodelphis domestica</li>
         <li class="sql_schema_species_name">Mus musculus</li>


### PR DESCRIPTION
The species list has been updated for Release 108. PR done on behalf of Infrastructure Team, task A6 (https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?spaceKey=ENSCORE&title=Core+release+coordination#CoreReleaseCoordination-UpdateSchemaDiagrams-A6).