### PR TITLE
Update refseq version to match the db

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_cache.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_cache.html
@@ -174,7 +174,7 @@ tar xzf homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz</pre>
       </tr>
       <tr>
         <td><b>RefSeq</b></td>
-        <td>2022-04-06<br />(GCF_000001405.40_GRCh38.p14_genomic.gff)</td>
+        <td>110<br />(GCF_000001405.40_GRCh38.p14_genomic.gff)</td>
         <td>2020-10-26<br />(GCF_000001405.25_GRCh37.p13_genomic.gff)</td>
       </tr>
       <tr>


### PR DESCRIPTION
We were using date format for refseq version. But we really should be matching what core DB have because it also matches with the NCBI FTP and more accurate.