### PR TITLE
Fixed broken link in Compara API tutorial

### DIFF
--- a/docs/htdocs/info/docs/api/compara/compara_tutorial.html
+++ b/docs/htdocs/info/docs/api/compara/compara_tutorial.html
@@ -619,7 +619,7 @@ foreach my $homology (@homologies) {
     <span style="padding-left:0.9em">Adaptor objects</span>
     <ul style="margin-bottom:0px">
       <li><a style="text-decoration:none" href="/info/docs/Doxygen/compara-api/classBio_1_1EnsEMBL_1_1Compara_1_1DBSQL_1_1GeneMemberAdaptor.html">GeneMemberAdaptor</a></li>
-      <li><a style="text-decoration:none" href="/info/docs/Doxygen/compara-api/classBio_1_1EnsEMBL_1_1Compara_1_1DBSQL_1_1Homology.html">HomologyAdaptor</a></li>
+      <li><a style="text-decoration:none" href="/info/docs/Doxygen/compara-api/classBio_1_1EnsEMBL_1_1Compara_1_1DBSQL_1_1HomologyAdaptor.html">HomologyAdaptor</a></li>
     </ul>
   </div>
   <div style="float:left;margin-left:10px;border-left:1px dotted #CCC">


### PR DESCRIPTION
Fixed a broken link reported by a user in the Compara API tutorial.