### PR TITLE
Web VEP: fix UniProt URLs (e109)

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -37,14 +37,19 @@ use parent qw(EnsEMBL::Web::Component::Tools::VEP);
 our $MAX_FILTERS = 50;
 
 our %PROTEIN_DOMAIN_LABELS = (
-  'Pfam_domain'         => 'PFAM',
-  'Prints_domain'       => 'PRINTS',
-  'TIGRFAM_domain'      => 'TIGRFAM',
-  'SMART_domains'       => 'SMART',
-  'Superfamily_domains' => 'SUPERFAMILY',
-  'hmmpanther'          => 'PANTHERDB',
+  'CDD'                 => 'CDD',
+  'Gene3D'              => 'GENE3D',
+  'PANTHER'             => 'PANTHERDB',
+  'Pfam'                => 'PFAM',
+  'Prints'              => 'PRINTS',
   'PROSITE_profiles'    => 'PROSITE_PROFILES',
   'PROSITE_patterns'    => 'PROSITE_PATTERNS',
+  'SMART'               => 'SMART',
+  'Superfamily'         => 'SUPERFAMILY',
+  'TIGRFAM'             => 'TIGRFAM',
+  'PIRSF'               => 'PIRSF',
+  'HAMAP'               => 'HAMAP',
+  'SFLD'                => 'SFLD'
 );
 
 sub content {
@@ -1293,13 +1298,12 @@ sub get_items_in_list {
         my $go_description = $parts[2];
         $item_url = $hub->get_ExtURL_link($go_term, 'GO', $go_term) . " $go_description";
       }
-      else {
-        foreach my $label (keys(%PROTEIN_DOMAIN_LABELS)) {
-          if ($item =~ /^$label:(.+)$/) {
-            $item_url = "$label:&nbsp;".$hub->get_ExtURL_link($1, $PROTEIN_DOMAIN_LABELS{$label}, $1);
-            last;
-          }
-        }
+      elsif ($type eq 'domains') {
+        my ($domain_label, $value) = split(":", $item, 2);
+        my $key = $PROTEIN_DOMAIN_LABELS{$domain_label};
+        my $value_url = $value;
+        $value_url = "G3DSA:$value" if $domain_label eq "Gene3D" and $value !~ /^G3DSA:/;
+        $item_url = "$domain_label:&nbsp;" . $hub->get_ExtURL_link($value, $key, $value_url);
       }
       push(@items_with_url, $item_url);
     }

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -1157,7 +1157,7 @@ sub linkify {
   }
 
   # UniProtKB/Swiss-Prot | UniProtKB/TrEMBL | UniParc
-  elsif(($field eq 'SWISSPROT' || $field eq 'TREMBL') && $value =~ /\w+/) {
+  elsif(($field eq 'SWISSPROT' || $field eq 'TREMBL' || $field eq 'UNIPROT_ISOFORM') && $value =~ /\w+/) {
     my $query = $value;
     $query =~ s/\.[\d]+$//g;
     $new_value = $hub->get_ExtURL_link($value, 'UNIPROT', $query);

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -1157,8 +1157,15 @@ sub linkify {
   }
 
   # UniProtKB/Swiss-Prot | UniProtKB/TrEMBL | UniParc
-  elsif(($field eq 'SWISSPROT' || $field eq 'TREMBL' || $field eq 'UNIPARC') && $value =~ /\w+/) {
-    $new_value = $hub->get_ExtURL_link($value, 'UNIPROT', $value);
+  elsif(($field eq 'SWISSPROT' || $field eq 'TREMBL') && $value =~ /\w+/) {
+    my $query = $value;
+    $query =~ s/\.[\d]+$//g;
+    $new_value = $hub->get_ExtURL_link($value, 'UNIPROT', $query);
+  }
+
+  # UniParc
+  elsif(($field eq 'UNIPARC') && $value =~ /\w+/) {
+    $new_value = $hub->get_ExtURL_link($value, 'UNIPARC', $value);
   }
 
   else {


### PR DESCRIPTION
* [ENSVAR-4019](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4019):
  * Strip protein version from UniProt links (otherwise, it directs users to a protein version page, instead of showing protein information).
  * UniParc links were showing 404 error. Now the links correctly direct to UniProt.
* [ENSVAR-4020](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4020):
  * Added links to UniProt Isoform entries.
* [ENSVAR-3396](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-3396):
  * Added links to protein domains from CDD, Gene3D, PANTHER, Pfam, Prints, SMART, Superfamily, TIGRFAM, PIRSF, HAMAP and SFLD.
  * For Gene3D protein domains, prefix the ID with G3DSA (otherwise, the URL returns an error).
  * Requires code from [ensembl-webcode#926](https://github.com/Ensembl/ensembl-webcode/pull/926).

### Testing

**UniProt-related columns** (SWISSPROT, TREMBL, UNIPARC and UNIPROT ISOFORM):
* Select the "UniProt" checkbox before running web VEP
* Example: http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=bsuvhBteVQmNcCPS-61

**Protein domains**

Example variant | Protein domain source | Sandbox link
-- | -- | --
rs754673626 | CDD, Gene3D, PANTHER, Pfam, PROSITE_profiles, SMART, Superfamily | http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=HyX4RaU5nPrngalS-89
rs1216830090 | SFLD | http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=aNPnJqaikyOrLSeN-84
rs766926945 | HAMAP | http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=djHTMU4RH2RZdtcJ-79
rs780980629 | TIGRFAM, PIRSF | http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=z83wKZEkYdo3nC07-81
rs748536692 | Prints | http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=Jhfkd0i4oa5KPvRV-82