### PR TITLE
Show appropriate error text when Alphafold api doesn't have a model file

### DIFF
--- a/widgets/htdocs/alphafold/controllers/molstarController.js
+++ b/widgets/htdocs/alphafold/controllers/molstarController.js
@@ -1,4 +1,5 @@
 import { getRGBFromHex } from '../colorHelpers.js';
+import { MissingAlphafoldModelError } from '../dataFetchers.js';
 
 export class MolstarController {
 
@@ -32,7 +33,13 @@ export class MolstarController {
     const uniprotId = alphafoldId.match(parsingRegex)[1];
     const url = `${alphafoldPredictionEndpoint}/${uniprotId}`;
 
-    const alphafoldPredictionEntries = await fetch(url).then(response => response.json());
+    const alphafoldPredictionEntriesResponse = await fetch(url);
+    if (alphafoldPredictionEntriesResponse.status === 404) {
+      // no alphafold model files found
+      throw new MissingAlphafoldModelError();
+    } else if (!alphafoldPredictionEntriesResponse.ok) {
+      throw new Error('Something wrong with Alphafold prediction api');
+    }
 
     // alphafold's api will respond with an array of entries; we are interested in the first one
     const alphafoldEntry = alphafoldPredictionEntries[0];


### PR DESCRIPTION
This PR is for showing the appropriate message ("There is no Alphafold model for this molecule" rather than "An error occurred while loading the 3D protein viewer") if the alphafold api can't provide any data for a given id that we are sending.

Sandbox example:
http://wp-np2-1e.ebi.ac.uk:8410//Homo_sapiens/Transcript/AFDB?db=core;g=ENSG00000139618;r=13:32315086-32400268;t=ENST00000380152

_(As a sidenote, the reason this is even happening is because our rest api reports Alphafold analyses for large proteins that have been split into "fragments" (see [example query to our rest server](https://rest.ensembl.org/overlap/translation/ENSP00000369497?feature=protein_feature;type=alphafold))), whereas Alphafold is currently hiding them and [pretends](https://alphafold.ebi.ac.uk/api/prediction/P51587) that there are no models available for them. Which is why we are querying the Alphafold api with an id for which we think data exists, but the Alphafold api thinks otherwise)_


See [this Slack discussion](https://genomes-ebi.slack.com/archives/C0MUF0C3Y/p1664529478819519) for more context.