### PR TITLE
Update Pfam URLs

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/online/input.html
+++ b/docs/htdocs/info/docs/tools/vep/online/input.html
@@ -298,7 +298,7 @@ enter your data and alter various options.</p>
                 <li><b>Protein matches</b>
                   <p>Shows the variant location on PDBe and AlphaFold protein structures in interactive 3d displays, where available.
                   Report <a href="/Help/Glossary?id=18">protein domains</a> from <a href="https://www.ebi.ac.uk/pdbe/" rel="external">PDBe</a>, <a
-                  href="http://pfam.xfam.org" rel="external">Pfam</a>, <a
+                  href="https://www.ebi.ac.uk/interpro" rel="external">Pfam</a>, <a
                   href="http://prosite.expasy.org/" rel="external">Prosite</a> and
                   <a href="http://www.ebi.ac.uk/interpro/"
                   rel="external">InterPro</a> that overlap input variants.

--- a/widgets/htdocs/alphafold/components/proteinFeaturesControlPanel.js
+++ b/widgets/htdocs/alphafold/components/proteinFeaturesControlPanel.js
@@ -261,7 +261,7 @@ customElements.define('protein-features-control-panel', ProteinFeaturesControlPa
 const featureTypeToUrlPatternMap = new Map([
   [ 'Gene3D', 'http://gene3d.biochem.ucl.ac.uk/Gene3D/search?mode=protein&sterm=' ],
   [ 'PANTHER', 'http://www.pantherdb.org/panther/family.do?clsAccession=' ],
-  [ 'Pfam', 'https://pfam.xfam.org/family/' ],
+  [ 'Pfam', 'https://www.ebi.ac.uk/interpro/entry/pfam/' ],
   [ 'Smart', 'http://smart.embl-heidelberg.de/smart/do_annotation.pl?DOMAIN=' ],
   [ 'PRINTS', 'https://www.ebi.ac.uk/interpro/signature/' ],
 ]);

--- a/widgets/htdocs/alphafold/controllers/molstarController.js
+++ b/widgets/htdocs/alphafold/controllers/molstarController.js
@@ -40,6 +40,7 @@ export class MolstarController {
     } else if (!alphafoldPredictionEntriesResponse.ok) {
       throw new Error('Something wrong with Alphafold prediction api');
     }
+    const alphafoldPredictionEntries = await alphafoldPredictionEntriesResponse.json();
 
     // alphafold's api will respond with an array of entries; we are interested in the first one
     const alphafoldEntry = alphafoldPredictionEntries[0];

--- a/widgets/htdocs/components/95_PDB.js
+++ b/widgets/htdocs/components/95_PDB.js
@@ -41,7 +41,7 @@ Ensembl.Panel.PDB = Ensembl.Panel.Content.extend({
 
     // Setup external links   
     this.protein_sources = { 
-                             'Pfam'    : 'http://pfam.xfam.org/family/',
+                             'Pfam'    : 'https://www.ebi.ac.uk/interpro/entry/pfam/',
                              'PRINTS'  : 'https://www.ebi.ac.uk/interpro/signature/',
                              'Gene3D'  : 'http://gene3d.biochem.ucl.ac.uk/Gene3D/search?mode=protein&sterm=',
                              'PANTHER' : 'http://www.pantherdb.org/panther/family.do?clsAccession=',


### PR DESCRIPTION
This PR updates retired Pfam URLs to the new site (InterPro).
Other affected repos listed in the JIRA ticket.

JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6701
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680