### PR TITLE
feat: Add UTRAnnotator to web VEP

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/online/input.html
+++ b/docs/htdocs/info/docs/tools/vep/online/input.html
@@ -287,12 +287,6 @@ enter your data and alter various options.</p>
                   <a href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/NMD.pm">NMD</a> plugin.</p>
                 </li>
 
-                <li><b>UTRAnnotator</b>
-                  <p>A VEP plugin that annotates the effect of 5' UTR variant especially for variant
-                    creating/disrupting upstream ORFs. This functionality is provided by the 
-                  <a href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/UTRAnnotatorpm">NMD</a> plugin.</p>
-                </li>
-
                 <li><b>miRNA structure</b>
                   <p>Determines where in the secondary structure of a miRNA a variant falls.
                   Equivalent to <a

--- a/docs/htdocs/info/docs/tools/vep/online/input.html
+++ b/docs/htdocs/info/docs/tools/vep/online/input.html
@@ -287,6 +287,12 @@ enter your data and alter various options.</p>
                   <a href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/NMD.pm">NMD</a> plugin.</p>
                 </li>
 
+                <li><b>UTRAnnotator</b>
+                  <p>A VEP plugin that annotates the effect of 5' UTR variant especially for variant
+                    creating/disrupting upstream ORFs. This functionality is provided by the 
+                  <a href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/UTRAnnotatorpm">NMD</a> plugin.</p>
+                </li>
+
                 <li><b>miRNA structure</b>
                   <p>Determines where in the secondary structure of a miRNA a variant falls.
                   Equivalent to <a

--- a/tools/conf/vep_plugins_web_config.txt
+++ b/tools/conf/vep_plugins_web_config.txt
@@ -69,5 +69,5 @@
 
   UTRAnnotator => {
     "available" => 1
-  },
+  }
 }

--- a/tools/conf/vep_plugins_web_config.txt
+++ b/tools/conf/vep_plugins_web_config.txt
@@ -65,5 +65,9 @@
 
   NMD => {
     "available" => 1
-  }
+  },
+
+  UTRAnnotator => {
+    "available" => 1
+  },
 }


### PR DESCRIPTION
## Description

This PR is meant to add refactored plugin UTRAnnotator to web.

## Test

1) Use [sandbox](http://wp-np2-11.ebi.ac.uk:6070/Multi/Tools/VEP) with UTRAnnotator tagged in small VCF example:

![image](https://user-images.githubusercontent.com/10541523/195063081-99905064-c440-4a04-a17f-3937ccfae19a.png)

VCF:

```sh
5       36876937        .       CC      A       .       .       .
8       22130707        .       A       G       .       .       .
1       112956192       .       C       T       .       .       .
11      31806913        .       TAA     T       .       .       .
4       153204530       .       G       GATGC   .       .       .
```

Also give a look at https://github.com/Ensembl/ebi-plugins/pull/137