### PR TITLE
Variant Recoder fix HGMD url

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VR/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VR/Results.pm
@@ -495,7 +495,7 @@ sub get_items_in_list {
       if($item =~ /^COS/) {
         $item_url = $hub->get_ExtURL_link($item, 'COSMIC', $item);
       }
-      if($item =~ /^CM|CD/g) {
+      if($item =~ /^(B|C|H)[A-Z]\d+/) {
         $item_url = $hub->get_ExtURL_link($item, 'HGMD-PUBLIC', $item);
       }
       push(@items_with_url, $item_url);


### PR DESCRIPTION
Add URL to all HGMD variants (release 109).

Sandbox: http://wp-np2-11.ebi.ac.uk:7040/Homo_sapiens/Tools/VR
Variant to test: rs138742754
HGMD in output is `BM1115006`