### PR TITLE
Display VEP data version in web VEP (109)

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP.pm
@@ -46,4 +46,14 @@ sub job_statistics {
   return $stats;
 }
 
+sub vep_data_version {
+  ## Gets VCF output header with VEP data versions
+  my $self         = shift;
+  my $file_output  = $self->object->result_files->{'output_file'};
+  my @output       = (split /\n/, $file_output->content);
+  my $version_info = (grep { /^\#\#VEP/ } @output)[0];
+  $version_info    =~ s/(^\#\#)//g;
+  return split /="|" |"/, $version_info;
+}
+
 1;

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/TicketDetails.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/TicketDetails.pm
@@ -119,6 +119,30 @@ sub job_details_table {
     $opt_two_col->render.($have_plugins ? '<p class="small"><sup style="color:grey">(p)</sup> = functionality from <a target="_blank" href="/info/docs/tools/vep/script/vep_plugins.html">VEP plugin</a></p>' : '')
   );
 
+  ## add table with VEP data versions
+  my $version_table = $self->new_twocol({striped => 1});
+  $version_table->set_attribute('class', 'vep-job');
+
+  my %version_info = $self->vep_data_version;
+  # sort keys in case-insensitive order
+  my @keys = sort {uc($a) cmp uc($b)} keys %version_info;
+  for my $key (@keys) {
+    my $value = $version_info{$key};
+    if ($key eq 'db') {
+      # remove internal database name
+      $value =~ s/@.*//g;
+      $key = 'database';
+    } elsif ($key eq 'cache') {
+      # strip internal path
+      $value =~ s|(/[\w-]+?)+/||g;
+    } elsif ($key =~ 'sift|gencode') {
+      $key = uc $key;
+    }
+    $key = ucfirst $key unless $key =~ /[A-Z]/;
+    $version_table->add_row($key, $value);
+  }
+  $two_col->add_row('VEP and data version', $version_table->render);
+
   ## create command line that users can cut and paste
   my $command_string = './vep';
 


### PR DESCRIPTION
[ENSVAR-5208](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5208)

This PR adds a table containing VEP data versions in web VEP results (located in **Job Details** section). The information to create this table is retrieved from the line of VEP's VCF output that starts with `##VEP`, e.g.:

```
##VEP="v108" time="2022-10-24 16:50:52" cache="/net/isilonP/public/ro/ensweb-data/latest/tools/www/e108/vep/cache/homo_sapiens/108_GRCh38" db="homo_sapiens_core_108_38@hh-mysql-ens-species-web-1" 1000genomes="phase3" COSMIC="96" ClinVar="202205" HGMD-PUBLIC="20204" assembly="GRCh38.p13" dbSNP="154" gencode="GENCODE 42" genebuild="2014-07" gnomADe="r2.1.1" gnomADg="v3.1.2" polyphen="2.2.2" regbuild="1.0" sift="sift5.2.2"
```

### Testing

Check if the following sandbox links show the expected information compared to their VCF output:
* [Human](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=T0NPTCjG4mPld5zb-90)
* [Salmon](http://wp-np2-11.ebi.ac.uk:6070/Salmo_salar/Tools/VEP/Results?tl=Hw91dGjLKxiakH6p-42)