### PR TITLE
Update VEP plugins docs (109)

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html
@@ -46,7 +46,7 @@
 
   <pre class="code sh_sh">perl INSTALL.pl -a p -g list</pre>
 
-  <p> Some plugins are also available to use via the <a href="/Tools/VEP">VEP web interface</a>. </p>
+  <p> Some plugins are also available to use via the <a href="/Tools/VEP">VEP web</a> and <a href="https://rest.ensembl.org/#VEP">REST</a> interfaces. </p>
 
   <br />	
   <h2 id="plugins_existing">Existing plugins</h2>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html
@@ -46,6 +46,8 @@
 
   <pre class="code sh_sh">perl INSTALL.pl -a p -g list</pre>
 
+  <p> Alternatively, VEP plugins and their dependencies are available in the <a href="https://hub.docker.com/r/ensemblorg/ensembl-vep">Docker image</a>. Read how to use Ensembl VEP in <a href="Tools/VEP/script/vep_download.html#docker">Docker</a> and <a href="Tools/VEP/script/vep_download.html#singularity">Singularity</a>. </p>
+
   <p> Some plugins are also available to use via the <a href="/Tools/VEP">VEP web</a> and <a href="https://rest.ensembl.org/#VEP">REST</a> interfaces. </p>
 
   <br />	

--- a/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html
@@ -145,7 +145,6 @@
 
   <p> There are further published plugins available outside the VEP repository including:
   <li> <a href="https://github.com/konradjk/loftee">LOFTEE </a> a Loss-Of-Function Transcript Effect Estimator (<a href="https://www.nature.com/articles/s41586-020-2308-7">Konrad Karczewski et al,2020</a>)
-  <li> <a href="https://github.com/ImperialCardioGenetics/UTRannotator"> UTRannotator</a> which annotates high-impact five prime UTR variants (<a href="https://academic.oup.com/bioinformatics/advance-article/doi/10.1093/bioinformatics/btaa783/5905476">Xiaolei Zhang et al,2020 </a>)
 
 
 	

--- a/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html
@@ -46,7 +46,7 @@
 
   <pre class="code sh_sh">perl INSTALL.pl -a p -g list</pre>
 
-  <p> Alternatively, VEP plugins and their dependencies are available in the <a href="https://hub.docker.com/r/ensemblorg/ensembl-vep">Docker image</a>. Read how to use Ensembl VEP in <a href="Tools/VEP/script/vep_download.html#docker">Docker</a> and <a href="Tools/VEP/script/vep_download.html#singularity">Singularity</a>. </p>
+  <p> Alternatively, VEP plugins and their dependencies are available in the <a href="https://hub.docker.com/r/ensemblorg/ensembl-vep">Docker image</a>. Read how to use Ensembl VEP in <a href="vep_download.html#docker">Docker</a> and <a href="vep_download.html#singularity">Singularity</a>. </p>
 
   <p> Some plugins are also available to use via the <a href="/Tools/VEP">VEP web</a> and <a href="https://rest.ensembl.org/#VEP">REST</a> interfaces. </p>
 

--- a/tools/conf/vep_plugins_web_config.txt
+++ b/tools/conf/vep_plugins_web_config.txt
@@ -19,6 +19,10 @@
     "available" => 1
   },
 
+  miRNA => {
+    "available" => 1
+  },
+
   AncestralAllele => {
     "available" => 1
   },

--- a/tools/conf/vep_plugins_web_config.txt
+++ b/tools/conf/vep_plugins_web_config.txt
@@ -19,10 +19,6 @@
     "available" => 1
   },
 
-  miRNA => {
-    "available" => 1
-  },
-
   AncestralAllele => {
     "available" => 1
   },


### PR DESCRIPTION
* Mention support for VEP plugins in Docker image
* Mention that some plugins are available in REST
* Remove mention to external UTRannotator plugin (we now include it in VEP_plugins repo)

The changes are reflected in my [sandbox](http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html).