### PR TITLE
Document VEP flags missing from public docs

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1094,7 +1094,9 @@ host          useastdb.ensembl.org</pre>
       href="#opt_fasta">--fasta</a>. <i>Not used by default</i>
       </td>
       <td>GA4GH_VRS</td>
-      <td>&nbsp;</td>
+      <td>
+        <div style="padding:2px 0px"><a href="#opt_vcf">--vcf</a></div>
+      </td>
     </tr>
     <tr id="opt_shift_hgvs">
       <td><pre>--shift_hgvs [0|1]</pre></td>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1072,6 +1072,15 @@ host          useastdb.ensembl.org</pre>
       <td>HGVSg</td>
       <td>&nbsp;</td>
     </tr>
+    <tr id="opt_ambiguous_hgvs">
+      <td><pre>--ambiguous_hgvs [0|1]</pre></td>
+      <td>&nbsp;</td>
+      <td>
+        Allow input HGVSp to resolve to all genomic locations. Otherwise, most likely transcript will be selected. <i>Default: 0 (most likely transcript selected)</i>
+      </td>
+      <td>&nbsp;</td>
+      <td>&nbsp;</td>
+    </tr>
     <tr id="opt_spdi">
       <td><pre>--spdi</pre></td>
       <td>&nbsp;</td>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1084,6 +1084,18 @@ host          useastdb.ensembl.org</pre>
       <td>SPDI</td>
       <td>&nbsp;</td>
     </tr>
+    <tr id="opt_ga4gh_vrs">
+      <td><pre>--ga4gh_vrs</pre></td>
+      <td>&nbsp;</td>
+      <td>
+      Add genomic <a rel="external" href="https://vrs.ga4gh.org/",
+      target="_blank">GA4GH Variation Representation Specification (VRS)</a> notation. To generate GA4GH VRS when using <a href="#opt_cache">--cache</a> or <a
+      href="#opt_offline">--offline</a> you must use a FASTA file and <a
+      href="#opt_fasta">--fasta</a>. <i>Not used by default</i>
+      </td>
+      <td>GA4GH_VRS</td>
+      <td>&nbsp;</td>
+    </tr>
     <tr id="opt_shift_hgvs">
       <td><pre>--shift_hgvs [0|1]</pre></td>
       <td>&nbsp;</td>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1088,7 +1088,7 @@ host          useastdb.ensembl.org</pre>
       <td><pre>--ga4gh_vrs</pre></td>
       <td>&nbsp;</td>
       <td>
-      Add genomic <a rel="external" href="https://vrs.ga4gh.org/",
+      Add <a rel="external" href="https://vrs.ga4gh.org/",
       target="_blank">GA4GH Variation Representation Specification (VRS)</a> notation. To generate GA4GH VRS when using <a href="#opt_cache">--cache</a> or <a
       href="#opt_offline">--offline</a> you must use a FASTA file and <a
       href="#opt_fasta">--fasta</a>. <i>Not used by default</i>


### PR DESCRIPTION
[ENSVAR-5301](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5301): Documented VEP arguments `--ga4gh_vrs` and `--ambiguous_hgvs`.

Check documentation changes in my [sandbox](http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_options.html#opt_hgvs).