### PR TITLE
Fix impact for a consequence (e109)

### DIFF
--- a/ensembl/modules/EnsEMBL/Web/Document/HTML/ConsequenceTable.pm
+++ b/ensembl/modules/EnsEMBL/Web/Document/HTML/ConsequenceTable.pm
@@ -284,7 +284,7 @@ sub render {
       'colour'  => 'a52a2a', 
       'desc'    => 'A feature ablation whereby the deleted region includes a regulatory region', 
       'acc'     => '0001894', 
-      'impact'  => 'MODERATE',
+      'impact'  => 'MODIFIER',
     },
     {
       'term'    => 'regulatory_region_amplification', 


### PR DESCRIPTION
The impact of '**regulatory_region_ablation**' should be **MODIFIER** instead if **MODERATE**.

http://wp-np2-11.ebi.ac.uk:7070/info/genome/variation/prediction/predicted_data.html 