### PR TITLE
Display MANE select option only for human in Variant Recorder (duplicate)

### DIFF
--- a/tools/htdocs/components/20_ToolsSpeciesList.js
+++ b/tools/htdocs/components/20_ToolsSpeciesList.js
@@ -52,9 +52,11 @@ Ensembl.Panel.ToolsSpeciesList = Ensembl.Panel.extend({
       //adding human and hence show grch37 message
       if(item.title === "Homo_sapiens" || item.title === "Human") {
         panel.el.find('div.assembly_msg').show();
+        $('._stt_mane_select').show();
       }
       else {
         panel.el.find('div.assembly_msg').hide();
+        $('._stt_mane_select').hide();
       }
 
 

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VR/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VR/InputForm.pm
@@ -221,19 +221,18 @@ sub get_cacheable_form_node {
     }]
   });
 
-  if ($current_species eq 'Homo_sapiens') {
-    $input_fieldset->add_field({
+  # Add Mane Select option separately with a different classname for ease of toggling
+  $input_fieldset->add_field({
     'type'        => 'checklist',
-    'field_class' => [qw(_stt_yes _stt_allele _stt_Homo_sapiens)],
+    'field_class' => [qw(_stt_yes _stt_allele _stt_mane_select)],
     'name'        => 'mane_select',
     'values'      => [{
       'caption'     => $fd->{mane_select}->{label},
       'helptip'     => $fd->{mane_select}->{helptip},
       'value'       => 'yes',
       'checked'     => 0
-      }]
-    });
-  }
+    }]
+  });
 
   # Run button
   $self->add_buttons_fieldset($form);


### PR DESCRIPTION
MANE select option in Variant Recorder was being displayed for all species, despite it only being available for human in the data. This was fixed in the code in both Perl and JavaScript side.

Related PR: #605 
Sandbox link: http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Tools/VR