### PR TITLE
Fetch EVA variants for Gibbon and Prairie vole (e110)

### DIFF
--- a/ensembl/conf/ini-files/nomascus_leucogenys.ini
+++ b/ensembl/conf/ini-files/nomascus_leucogenys.ini
@@ -65,7 +65,7 @@ ENSEMBL_SEARCH_IDXS = [ Domain Family Gene GenomicAlignment Sequence ]
 SEARCH_TEXT       = DICER1
 
 
-VARIATION_PARAM   = rs795617155
+VARIATION_PARAM   = rs795617155;vf=1a:38928:C_T:EVA
 VARIATION_TEXT    = rs795617155
 
 ENSEMBL_SOUND     = waohooo waooo ... ... wwwa hoo wa

--- a/ensembl/conf/json/microtus_ochrogaster_vcf.json
+++ b/ensembl/conf/json/microtus_ochrogaster_vcf.json
@@ -1,19 +1,17 @@
 {
     "collections": [
       {
-        "id": "prairie_vole_EVA",
-        "source_name": "EVA",
+        "id": "eva_microtus_ochrogaster_gca000317375v1",
         "description": "Variants from EVA",
         "species": "microtus_ochrogaster",
         "assembly": "MicOch1.0",
         "type": "remote",
+        "filename_template": "https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_4/by_species/microtus_ochrogaster/GCA_000317375.1/GCA_000317375.1_current_ids.vcf.gz",
         "use_as_source" : 1,
-        "filename_template": "https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_3/by_species/microtus_ochrogaster/GCA_000317375.1/GCA_000317375.1_current_ids.vcf.gz",
-        "chromosomes": [
-          "1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
-          "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
-          "21", "22", "23", "24", "25", "26", "X"
-        ]
+        "use_seq_region_synonyms": 0,
+        "strict_name_match": 0,
+        "source_name": "EVA",
+        "source_version": 4
       },
       {
         "id": "90_mammals.gerp_conservation_score",

--- a/ensembl/conf/json/nomascus_leucogenys_vcf.json
+++ b/ensembl/conf/json/nomascus_leucogenys_vcf.json
@@ -1,6 +1,18 @@
 {
   "collections": [
     {
+      "id": "eva_nomascus_leucogenys_gca000146795v3",
+      "description": "Variants from EVA",
+      "species": "nomascus_leucogenys",
+      "assembly": "Nleu_3.0",
+      "type": "remote",
+      "filename_template": "http://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_4/by_species/nomascus_leucogenys/GCA_000146795.3/GCA_000146795.3_current_ids.vcf.gz",
+      "use_as_source": 1,
+      "use_seq_region_synonyms": 0,
+      "source_name": "EVA",
+      "source_version": 4
+    },
+    {
       "id": "90_mammals.gerp_conservation_score",
       "species": "nomascus_leucogenys",
       "assembly": "Nleu_3.0",


### PR DESCRIPTION
[ENSVAR-5465](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5465): Configure VCF for Gibbon
[ENSVAR-5432](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5432): Configure VCF for Prairie vole

Related with https://github.com/Ensembl/ensembl-variation/pull/952

Test in my sandbox:
* Gibbon:
    * [Track with EVA variants](http://wp-np2-11.ebi.ac.uk:6070/Nomascus_leucogenys/Location/View?r=22a%3A10991516-11060966)
    * [Variant example in species page](http://wp-np2-11.ebi.ac.uk:6070/Nomascus_leucogenys/Info/Index)
* Prairie vole:
    * [Track with EVA variants](http://wp-np2-11.ebi.ac.uk:6070/Microtus_ochrogaster/Location/View?r=1:14087750-14088900;db=core)
    * [Variant example in species page](http://wp-np2-11.ebi.ac.uk:6070/Microtus_ochrogaster/Info/Index)