### PR TITLE
Display MANE select option only for human in Variant Recorder

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VR/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VR/InputForm.pm
@@ -221,8 +221,7 @@ sub get_cacheable_form_node {
     }]
   });
 
-  if ($current_species eq 'Homo_sapiens') {
-    $input_fieldset->add_field({
+  $input_fieldset->add_field({
     'type'        => 'checklist',
     'field_class' => [qw(_stt_yes _stt_allele _stt_Homo_sapiens)],
     'name'        => 'mane_select',
@@ -231,9 +230,8 @@ sub get_cacheable_form_node {
       'helptip'     => $fd->{mane_select}->{helptip},
       'value'       => 'yes',
       'checked'     => 0
-      }]
-    });
-  }
+    }]
+  });
 
   # Run button
   $self->add_buttons_fieldset($form);


### PR DESCRIPTION
MANE select option in Variant Recoder was being displayed for all species, despite it only being available for human in the data. An initial attempt was made at fixing this in #655. However, @jyobhai identified that the issue could break other parts of the site and is not the right solution. Hence, another attempt at fixing this.

On the Perl side, the reason why MANE select option was not toggleable was because it gets added only when homo sapiens is selected by default for Variant Recoder. This has been fixed in this pull request.

On the JavaScript side, the escape code for the species class names was escaping them where not necessary as well. This was breaking the code and not showing/toggling the relevant options in tools forms. This has been fixed in a pull request for ensembl-webcode.

Related PR in ensembl-webcode: https://github.com/Ensembl/ensembl-webcode/pull/950
Sandbox link: http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Tools/VR
Jira ticket: [ENSWEB-6716](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6716)