### PR TITLE
ENSWEB-6682 - Removed database availability statement

### DIFF
--- a/ensembl/htdocs/info/website/archives/ssi/about.html
+++ b/ensembl/htdocs/info/website/archives/ssi/about.html
@@ -8,7 +8,7 @@
 <li>Annotation on the <strong>mouse NCBIm37 assembly</strong> is available at our <a href="http://may2012.archive.ensembl.org//Mus_musculus/Info/Index">Ensembl 67 archive</a> site.</li>  
 <li>As from August 2014 we are supporting the <strong>human GRCh37 assembly</strong> at our dedicated <a href="http://grch37.ensembl.org/index.html">GRCh37 human</a> site. Unlike the other Ensembl archive sites, this will be updated to the latest web interface every Ensembl release and there may be occasional data updates to human.</li>
 </ul>
-Archived databases are also maintained for at least 10 years. Currently all databases are available from 2004. More information is available from our <a href="/info/data/mysql.html">MySQL database documentation</a>. We also maintain data archives from 2004 available from our <a href="https://ftp.ensembl.org/pub/">FTP site</a>.
+Archived databases are also maintained for at least 10 years. More information is available from our <a href="/info/data/mysql.html">MySQL database documentation</a>. We also maintain data archives from 2004 available from our <a href="https://ftp.ensembl.org/pub/">FTP site</a>.
 </p>
 
 <p>For all enquiries, please <a href="/Help/Contact" class="popup">contact the Ensembl HelpDesk</a>.</p>


### PR DESCRIPTION
This change is to remove the statement "Currently all databases are available from 2004." from the archive page as described in https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6682

The change can be viewed here http://wp-np2-1f.ebi.ac.uk:10000/info/website/archives/index.html
