### PR TITLE
Fix link to VEP Alphafold page

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -265,6 +265,7 @@ sub content {
           $self->render_protein_matches(
             $row,
             $row_id,
+            $gene_id, # note that $row->{'Gene'} is no longer reliable, since it was mutated by linkify above
             $feature_id,
             $consequence,
             $species
@@ -1275,7 +1276,7 @@ sub get_items_in_list {
         $item_url = $hub->get_ExtURL_link($item, 'MASTERMIND', $item);
       }
       elsif ($type eq 'IntAct_interaction_ac') {
-	$item =~ s/^\s+|\s+$//;
+      	$item =~ s/^\s+|\s+$//;
         $item_url = $hub->get_ExtURL_link($item, 'INTACT', $item);
       }
       elsif ($type eq 'IntAct_pmid') {
@@ -1319,13 +1320,13 @@ sub render_protein_matches {
     $self,
     $row_data,
     $row_id,
+    $gene_id,
     $feature_id,
     $consequence,
     $species
   ) = @_;
 
   my $hub = $self->hub;
-  my $gene_id = $row_data->{'Gene'};
   my $domain_ids = $row_data->{'DOMAINS'};
 
   my $should_add_pdb_view_button = $domain_ids =~ /PDB-ENSP/i;


### PR DESCRIPTION
As we read the VEP file row by row, we generate a `$row` hash ([link](https://github.com/Ensembl/public-plugins/blob/88a5a1a840f70fe7ec9af11b6f0a43854acd3db2/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm#L235)), but then, counterintuitively, mutate it ([link](https://github.com/Ensembl/public-plugins/blob/88a5a1a840f70fe7ec9af11b6f0a43854acd3db2/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm#L247)), so that the `Gene` field of the hash that used to contain a gene id is replaced with a string of an html link. For example, before the mutation, $row->{Gene} is `Os01g0100100`, but after the mutation it becomes `<a class="_zmenu" href="/Oryza_sativa/Gene/Summary?db=core;g=Os01g0100100;tl=BroHokEyP7tQRoxJ-2146">Os01g0100100</a><a class="hidden _zmenu_link" href="/Oryza_sativa/ZMenu/Gene?db=cor
e;g=Os01g0100100;tl=BroHokEyP7tQRoxJ-2146"></a>`. We then passed this string to a link generator, believing that we were passing gene id, and created such monstrosities as `http://plants.ensembl.org/Oryza_sativa/Tools/VEP/AFDB?cons=missense_variant;g=%3Ca%20class%3D%22_zmenu%22%20href%3D%22/Oryza_sativa/Gene/Summary%3Fdb%3Dcore%3Bg%3DOs01g0100100%3Btl%3DLuQl4lI72dUTUw6b-22234553%22%3EOs01g0100100%3C/a%3E%3Ca%20class%3D%22hidden%20_zmenu_link%22%20href%3D%22/Oryza_sativa/ZMenu/Gene%3Fdb%3Dcore%3Bg%3DOs01g0100100%3Btl%3DLuQl4lI72dUTUw6b-22234553%22%3E%3C/a%3E;pos=2;t=Os01t0100100-01.;tl=LuQl4lI72dUTUw6b-22234553;var=.`.

This PR fixes the url. The PR that actually fixes the issue of an unavailable Alphafold page is in eg-web-common repo: https://github.com/EnsemblGenomes/eg-web-common/pull/112

Related Jira ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6840

Sandbox: http://wp-np2-1e.ebi.ac.uk:8450

Example VEP input to try:
```
1 3452 . T A . . .
3 5087 . C G . . .
2 630 . CA C . . .
```