### PR TITLE
Add MaveDB plugin to web VEP (110)

### DIFF
--- a/tools/conf/vep_plugins_web_config.txt
+++ b/tools/conf/vep_plugins_web_config.txt
@@ -59,6 +59,10 @@
     "available" => 1
   },
 
+  MaveDB => {
+    "available" => 1
+  },
+
   mutfunc => {
     "available" => 1
   },

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -22,7 +22,7 @@ package EnsEMBL::Web::Component::Tools::VEP::InputForm;
 use strict;
 use warnings;
 
-use List::Util qw(first);
+use List::Util qw(first uniq);
 
 use EnsEMBL::Web::VEPConstants qw(INPUT_FORMATS CONFIG_SECTIONS);
 use HTML::Entities qw(encode_entities);
@@ -639,6 +639,21 @@ sub _build_additional_annotations {
   });
 
   $self->_end_section(\@fieldsets, $fieldset, $current_section);
+
+
+  ## FUNCTIONAL EFFECT
+  $current_section = 'Functional effect';
+  my @func_species = map { ucfirst $_ } uniq map { @{$_->{'species'}} } @{$self->_get_plugins_by_section($current_section)};
+
+  if (@func_species) {
+    my @func_species_classes = map { "_stt_".$_ } @func_species;
+
+    my $func_class = (scalar(@func_species_classes)) ? join(' ',@func_species_classes) : '';
+
+    $fieldset = $form->add_fieldset({'legend' => $current_section, 'no_required_notes' => 1, class => $func_class });
+
+    $self->_end_section(\@fieldsets, $fieldset, $current_section);
+  }
 
 
   ## REGULATORY DATA

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -227,8 +227,8 @@ sub content {
     'IntAct_interaction_ac'	=> 'IntAct interaction AC',
     'IntAct_pmid'	 	=> 'IntAct pubmed',
     'GO'                        => 'GO terms',
-    'MaveDB_hgvs_nt'            => 'MaveDB nucleotide change',
-    'MaveDB_hgvs_pro'           => 'MaveDB protein change',
+    'MaveDB_nt'                 => 'MaveDB nucleotide change',
+    'MaveDB_pro'                => 'MaveDB protein change',
     'MaveDB_score'              => 'MaveDB score',
     'MaveDB_urn'                => 'MaveDB URN',
   );
@@ -309,11 +309,11 @@ sub content {
         elsif ($header eq 'GO'){
           $row->{$header} = $self->get_items_in_list($row_id, 'GO', 'GO terms', $row->{$header}, $species);
         }
-        elsif ($header eq 'MaveDB_hgvs_nt'){
-          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_hgvs_nt', 'MaveDB nucleotide change', $row->{$header}, $species);
+        elsif ($header eq 'MaveDB_nt'){
+          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_nt', 'MaveDB nucleotide change', $row->{$header}, $species);
         }
-        elsif ($header eq 'MaveDB_hgvs_pro'){
-          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_hgvs_pro', 'MaveDB protein change', $row->{$header}, $species);
+        elsif ($header eq 'MaveDB_pro'){
+          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_pro', 'MaveDB protein change', $row->{$header}, $species);
         }
         elsif ($header eq 'MaveDB_score'){
           $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_score', 'MaveDB score', $row->{$header}, $species);

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -161,6 +161,12 @@ sub content {
     $header_extra_descriptions->{'DisGeNET'} =~ s/ Each value is separated.*//;
   }
 
+  # Overwrite header description
+  for (keys %{$header_extra_descriptions}) {
+    # MaveDB columns: remove filename
+    $header_extra_descriptions->{$_} =~ s/; .*// if $_ =~ /^MaveDB/;
+  }
+
   my $actual_to = $from - 1 + ($line_count || 0);
   my $row_count = scalar @$rows;
 

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -176,11 +176,6 @@ sub content {
   $skip_colums{"5UTR_annotation"} = 1; # UTRAnnotator
   $skip_colums{'Geno2MP_URL'} = 1; # URL added to Geno2MP HPO counts column
 
-  # hide MaveDB columns except for URN
-  $skip_colums{'MaveDB_hgvs_nt'} = 1;
-  $skip_colums{'MaveDB_hgvs_pro'} = 1;
-  $skip_colums{'MaveDB_score'} = 1;
-
   if (%skip_colums) {
     my @tmp_headers;
     foreach my $header (@$headers) {
@@ -226,7 +221,10 @@ sub content {
     'IntAct_interaction_ac'	=> 'IntAct interaction AC',
     'IntAct_pmid'	 	=> 'IntAct pubmed',
     'GO'                        => 'GO terms',
-    'MaveDB_urn'                => 'MaveDB URN'
+    'MaveDB_hgvs_nt'            => 'MaveDB HGVS (nucleotide)',
+    'MaveDB_hgvs_pro'           => 'MaveDB HGVS (protein)',
+    'MaveDB_score'              => 'MaveDB score',
+    'MaveDB_urn'                => 'MaveDB URN',
   );
   for (grep {/\_/} @$headers) {
     $header_titles{$_} ||= $_ =~ s/\_/ /gr;
@@ -305,11 +303,16 @@ sub content {
         elsif ($header eq 'GO'){
           $row->{$header} = $self->get_items_in_list($row_id, 'GO', 'GO terms', $row->{$header}, $species);
         }
+        elsif ($header eq 'MaveDB_hgvs_nt'){
+          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_hgvs_nt', 'MaveDB HGVS (nucleotide)', $row->{$header}, $species);
+        }
+        elsif ($header eq 'MaveDB_hgvs_pro'){
+          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_hgvs_pro', 'MaveDB HGVS (protein)', $row->{$header}, $species);
+        }
+        elsif ($header eq 'MaveDB_score'){
+          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_score', 'MaveDB score', $row->{$header}, $species);
+        }
         elsif ($header eq 'MaveDB_urn'){
-          # Only show unique MaveDB URN items
-          my @items = split(", ", $row->{$header});
-          @items = do { my %seen; grep { !$seen{$_}++ } @items };
-          $row->{$header} = join(", ", @items);
           $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_urn', 'MaveDB URN', $row->{$header}, $species);
         }
         elsif ($header eq 'Geno2MP_HPO_count') {

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -227,8 +227,8 @@ sub content {
     'IntAct_interaction_ac'	=> 'IntAct interaction AC',
     'IntAct_pmid'	 	=> 'IntAct pubmed',
     'GO'                        => 'GO terms',
-    'MaveDB_hgvs_nt'            => 'MaveDB HGVS (nucleotide)',
-    'MaveDB_hgvs_pro'           => 'MaveDB HGVS (protein)',
+    'MaveDB_hgvs_nt'            => 'MaveDB nucleotide change',
+    'MaveDB_hgvs_pro'           => 'MaveDB protein change',
     'MaveDB_score'              => 'MaveDB score',
     'MaveDB_urn'                => 'MaveDB URN',
   );
@@ -310,16 +310,17 @@ sub content {
           $row->{$header} = $self->get_items_in_list($row_id, 'GO', 'GO terms', $row->{$header}, $species);
         }
         elsif ($header eq 'MaveDB_hgvs_nt'){
-          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_hgvs_nt', 'MaveDB HGVS (nucleotide)', $row->{$header}, $species);
+          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_hgvs_nt', 'MaveDB nucleotide change', $row->{$header}, $species);
         }
         elsif ($header eq 'MaveDB_hgvs_pro'){
-          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_hgvs_pro', 'MaveDB HGVS (protein)', $row->{$header}, $species);
+          $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_hgvs_pro', 'MaveDB protein change', $row->{$header}, $species);
         }
         elsif ($header eq 'MaveDB_score'){
           $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_score', 'MaveDB score', $row->{$header}, $species);
         }
         elsif ($header eq 'MaveDB_urn'){
           $row->{$header} = $self->get_items_in_list($row_id, 'MaveDB_urn', 'MaveDB URN', $row->{$header}, $species);
+
         }
         elsif ($header eq 'Geno2MP_HPO_count') {
           my $data = $row->{'Geno2MP_HPO_count'} . ":" . $row->{'Geno2MP_URL'};

--- a/tools/modules/EnsEMBL/Web/VEPConstants.pm
+++ b/tools/modules/EnsEMBL/Web/VEPConstants.pm
@@ -48,7 +48,7 @@ sub CONFIG_SECTIONS {
   }, {
     'id'            => 'additional_annotations',
     'title'         => 'Additional annotations',
-    'caption'       => 'Addtional transcript, protein and regulatory annotations'
+    'caption'       => 'Additional transcript, protein and regulatory annotations'
   }, {
     'id'            => 'predictions',
     'title'         => 'Predictions',

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -104,6 +104,12 @@
     ]
   },
 
+  MaveDB => {
+    "params" => [
+      "file=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/MaveDB_variants.tsv.gz"
+    ]
+  },
+
   mutfunc => {
     "params" => [
       "db=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/mutfunc_data.db",


### PR DESCRIPTION
[ENSVAR-5485](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5485): add functionality of [MaveDB plugin](https://github.com/Ensembl/VEP_plugins/pull/604) to web VEP and properly format web VEP results

We decided to only show unique links to MaveDB for now, in contrast with the results from using VEP in CLI or REST that show more detailed information. This is most likely subject to change in future Ensembl releases.

## Dependencies

- Ensembl/VEP_plugins#604
- https://github.com/Ensembl/ensembl-webcode/pull/967

## Testing

You can test the following variants in [my dev sandbox](http://wp-np2-11.ebi.ac.uk:6070/Tools/VEP) by enabling MaveDB plugin:
```
16      1314031 .       A       T
16      1314056 .       T       A
16      1324785 .       CCC     TTT
```