### PR TITLE
Improve VEP options table

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1901,7 +1901,7 @@ host          useastdb.ensembl.org</pre>
               </tr>
             </thead>
             <tbody>
-              <tr class="bg1">
+              <tr class="bg2">
                 <td>1KG_ALL</td><td>1000 genomes combined population (global)</td>
               </tr>
               <tr>
@@ -1920,7 +1920,7 @@ host          useastdb.ensembl.org</pre>
                 <td>1KG_SAS</td><td>1000 genomes combined South Asian population</td>
               </tr>
 
-              <tr class="bg1">
+              <tr class="bg2">
                 <td>gnomADe</td><td>gnomAD exomes combined population</td>
               </tr>
               <tr>
@@ -1947,7 +1947,7 @@ host          useastdb.ensembl.org</pre>
               <tr class="bg1">
                 <td>gnomADe_SAS</td><td>gnomAD exomes South Asian population</td>
               </tr>
-              <tr>
+              <tr class="bg2">
                 <td>gnomADg</td><td>gnomAD genomes combined population</td>
               </tr>
               <tr class="bg1">

--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -8,11 +8,16 @@
     
 <style>
 tr:nth-child(odd) {background-color: #f0f0f0;}
-td {line-height: 1.25em;}
+td {
+  line-height: 1.25em;
+  word-wrap: break-word;
+}
+th { word-wrap: break-word; }
+.info {width: inherit !important;}
 pre {
-    overflow-x: auto;
-    white-space: pre-wrap;
-    word-break: break-word;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 </style>
 
@@ -139,7 +144,7 @@ pre {
   <hr/>
   <h2 id="basic">Basic options</h2>
   
-  <table class="ss">
+  <table class="ss" style="table-layout: fixed">
     <tr>
       <th width="20%">Flag</th>
       <th width="8%">Alternate</th>
@@ -369,7 +374,7 @@ host          useastdb.ensembl.org</pre>
     
   <h2 id="cacheopt">Cache options</h2>
   
-  <table class="ss">
+  <table class="ss" style="table-layout: fixed">
     <tr>
       <th width="20%">Flag</th>
       <th width="8%">Alternate</th>
@@ -518,7 +523,7 @@ host          useastdb.ensembl.org</pre>
   <hr/>  
   <h2 id="other">Other annotation sources</h2>
   
-  <table class="ss">
+  <table class="ss" style="table-layout: fixed">
     <tr>
       <th width="20%">Flag</th>
       <th width="10%">Alternate</th>
@@ -611,7 +616,7 @@ host          useastdb.ensembl.org</pre>
   <hr/>
   <h2 id="format">Output format options</h2>
 
-  <table class="ss">
+  <table class="ss" style="table-layout: fixed">
     <tr>
       <th width="20%">Flag</th>
       <th width="10%">Alternate</th>
@@ -727,7 +732,7 @@ host          useastdb.ensembl.org</pre>
   <hr/>
   <h2 id="output">Output options</h2>
   
-  <table class="ss">
+  <table class="ss" style="table-layout: fixed">
     <tr>
       <th width="20%">Flag</th>
       <th width="8%">Alternate</th>
@@ -1050,7 +1055,7 @@ host          useastdb.ensembl.org</pre>
   <hr/>
   <h2 id="ident">Identifiers</h2>
   
-  <table class="ss">
+  <table class="ss" style="table-layout: fixed">
     <tr>
       <th width="20%">Flag</th>
       <th width="8%">Alternate</th>
@@ -1357,7 +1362,7 @@ host          useastdb.ensembl.org</pre>
   <hr/>
   <h2 id="existing">Co-located variants</h2>
   
-  <table class="ss">
+  <table class="ss" style="table-layout: fixed">
     <tr>
       <th width="20%">Flag</th>
       <th width="8%">Alternate</th>
@@ -1569,7 +1574,7 @@ host          useastdb.ensembl.org</pre>
     results and run multiple filter sets on the same results to find different
     data of interest. </p>
   
-  <table class="ss">
+  <table class="ss" style="table-layout: fixed">
     <tr>
       <th width="20%">Flag</th>
       <th width="8%">Alternate</th>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -9,6 +9,11 @@
 <style>
 tr:nth-child(odd) {background-color: #f0f0f0;}
 td {line-height: 1.25em;}
+pre {
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
 </style>
 
 <div>
@@ -1342,6 +1347,7 @@ host          useastdb.ensembl.org</pre>
         input file and any annotation source (cache, database, GFF, custom file, FASTA file).
         <i>Not used by default</i>
       </td>
+      <td>&nbsp;</td>
       <td>&nbsp;</td>
     </tr>
   </table>


### PR DESCRIPTION
Check changes in my sandbox: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_options.html#opt_summary

- Fix table overflow by breaking words in `pre` tags
- Add background colour to distinguish global populations in `--freq_pop`
- Add missing column in `--synonyms`