### PR TITLE
Added docs for uploaded_allele flag (e110)

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -922,10 +922,19 @@ host          useastdb.ensembl.org</pre>
       <td><pre>--show_ref_allele</pre></td>
       <td>&nbsp;</td>
       <td>
-        Adds the reference allele in the output. Mainly useful for the VEP "default" and tab-delimited output formats.
+        Adds the reference allele in the output (after minimisation). Mainly useful for the VEP "default" and tab-delimited output formats.
         <i>Not used by default</i>
       </td>
       <td>REF_ALLELE</td>
+      <td>&nbsp;</td>
+    </tr> 
+    <tr id="opt_uploaded_allele">
+      <td><pre>--uploaded_allele</pre></td>
+      <td>&nbsp;</td>
+      <td>
+        Adds the uploaded allele string in the output (before minimisation). 
+      </td>
+      <td>UPLOADED_ALLELE</td>
       <td>&nbsp;</td>
     </tr> 
     <tr id="opt_total_length">

--- a/docs/htdocs/info/docs/tools/vep/vep_formats.html
+++ b/docs/htdocs/info/docs/tools/vep/vep_formats.html
@@ -500,8 +500,8 @@ NC_000016.10:68644746:AA:GTA
 
     <div id="div_other_fields" >
       <ul>
-        <li><b>REF_ALLELE</b> - the reference allele</li>
-        <li><b>UPLOADED_ALLELE</b> - the uploaded allele before minimisation</li>
+        <li><b>REF_ALLELE</b> - the reference allele (after minimisation)</li>
+        <li><b>UPLOADED_ALLELE</b> - the uploaded allele string (before minimisation)</li>
         <li><b>IMPACT</b> - the impact modifier for the consequence type</li>
         <li><b>VARIANT_CLASS</b> - Sequence Ontology <a href="/info/genome/variation/prediction/classification.html#classes">variant class</a></li>
         <li><b>SYMBOL</b> - the gene symbol</li>

--- a/docs/htdocs/info/docs/tools/vep/vep_formats.html
+++ b/docs/htdocs/info/docs/tools/vep/vep_formats.html
@@ -501,6 +501,7 @@ NC_000016.10:68644746:AA:GTA
     <div id="div_other_fields" >
       <ul>
         <li><b>REF_ALLELE</b> - the reference allele</li>
+        <li><b>UPLOADED_ALLELE</b> - the uploaded allele before minimisation</li>
         <li><b>IMPACT</b> - the impact modifier for the consequence type</li>
         <li><b>VARIANT_CLASS</b> - Sequence Ontology <a href="/info/genome/variation/prediction/classification.html#classes">variant class</a></li>
         <li><b>SYMBOL</b> - the gene symbol</li>


### PR DESCRIPTION
Added a flag for `--uploaded_allele` and an output column `UPLOADED_ALLELE`
Updated description for `--show_ref_allele` and `REF_ALLELE` output column 

VEP options: http://wp-np2-25.ebi.ac.uk:6080/info/docs/tools/vep/script/vep_options.html
VEP format: http://wp-np2-25.ebi.ac.uk:6080/info/docs/tools/vep/vep_formats.html#output
