### PR TITLE
Fix VEP input form showing unsupported plugin options in wrong divisions (e111)

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -669,21 +669,7 @@ sub _build_additional_annotations {
 
   $self->_end_section(\@fieldsets, $fieldset, $current_section);
 
-
-  ## FUNCTIONAL EFFECT
-  $current_section = 'Functional effect';
-  my @func_species = map { ucfirst $_ } uniq map { @{$_->{'species'}} } @{$self->_get_plugins_by_section($current_section)};
-
-  if (@func_species) {
-    my @func_species_classes = map { "_stt_".$_ } @func_species;
-
-    my $func_class = (scalar(@func_species_classes)) ? join(' ',@func_species_classes) : '';
-
-    $fieldset = $form->add_fieldset({'legend' => $current_section, 'no_required_notes' => 1, class => $func_class });
-
-    $self->_end_section(\@fieldsets, $fieldset, $current_section);
-  }
-
+  $self->_add_plugin_sections($form, \@fieldsets, "Functional effect");
 
   ## REGULATORY DATA
   $current_section = 'Regulatory data';

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 
 use List::Util qw(first uniq);
+use List::MoreUtils qw(duplicates);
 
 use EnsEMBL::Web::VEPConstants qw(INPUT_FORMATS CONFIG_SECTIONS);
 use HTML::Entities qw(encode_entities);
@@ -529,6 +530,34 @@ sub _build_variants_frequency_data {
   return @fieldsets;
 }
 
+sub _get_valid_plugin_species {
+  my $self = shift;
+  my $current_section = shift;
+
+  my $species_list = $self->object->species_list;
+  my $plugins = $self->_get_plugins_by_section($current_section);
+  my @species = map { ucfirst $_ } uniq map { @{$_->{'species'}} } @$plugins;
+  return duplicates(@species, map { $_->{'value'} } @$species_list);
+}
+
+sub _add_plugin_sections {
+  my ($self, $form, $fieldsets, $filter) = @_;
+
+  my @sections = grep {!$self->{_done_sections}->{$_}} @{$self->_get_all_plugin_sections};
+     @sections = grep(/$filter/, @sections) if defined $filter;
+
+  foreach my $current_section (@sections) {
+    # Avoid showing sections if no supported species are valid
+    my $plugins = $self->_get_plugins_by_section($current_section);
+    unless ( grep { ! $_->{'species'} } @$plugins ) {
+      next unless $self->_get_valid_plugin_species($current_section);
+    }
+
+    my $fieldset_options = {'legend' => $current_section, 'no_required_notes' => 1};
+    my $fieldset = $form->add_fieldset($fieldset_options);
+    $self->_end_section($fieldsets, $fieldset, $current_section);
+  }
+}
 
 sub _build_additional_annotations {
   my ($self, $form) = @_;
@@ -779,14 +808,8 @@ sub _build_predictions {
     $self->_end_section(\@fieldsets, $fieldset, $current_section);
   }
 
-
   ## ANY OTHER SECTIONS CONFIGURED BY PLUGINS
-  foreach my $current_section (grep {!$self->{_done_sections}->{$_}} @{$self->_get_all_plugin_sections}) {
-    my $fieldset_options = {'legend' => $current_section, 'no_required_notes' => 1};
-    $fieldset_options->{'class'} = '_stt_Homo_sapiens' if ($current_section eq 'Splicing predictions');
-    my $fieldset = $form->add_fieldset($fieldset_options);
-    $self->_end_section(\@fieldsets, $fieldset, $current_section);
-  }
+  $self->_add_plugin_sections($form, \@fieldsets);
 
   return @fieldsets;
 }
@@ -930,7 +953,14 @@ sub _add_plugins {
     #   }
     # }
 
-    my $field_class = (!$plugin->{species} || $plugin->{species} eq '*') ? [] : [map {"_stt_".ucfirst($_)} @{$plugin->{species} || []}];
+    my $field_class;
+    if (!$plugin->{species} || $plugin->{species} eq '*') {
+      $field_class = [];
+    } else {
+      # Avoid showing specific plugins if supported species are not available
+      $field_class = [map {"_stt_".ucfirst($_)} @{$plugin->{species} || []}];
+      next unless duplicates @{$plugin->{species}}, map { lc $_->{value} } @$species;
+    }
 
     if($plugin->{form}) {
 

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -670,6 +670,7 @@ sub _build_additional_annotations {
   $self->_end_section(\@fieldsets, $fieldset, $current_section);
 
   $self->_add_plugin_sections($form, \@fieldsets, "Functional effect");
+  $self->_add_plugin_sections($form, \@fieldsets, "Variant data");
 
   ## REGULATORY DATA
   $current_section = 'Regulatory data';

--- a/tools/modules/EnsEMBL/Web/VEPConstants.pm
+++ b/tools/modules/EnsEMBL/Web/VEPConstants.pm
@@ -52,7 +52,7 @@ sub CONFIG_SECTIONS {
   }, {
     'id'            => 'predictions',
     'title'         => 'Predictions',
-    'caption'       => 'Variant predictions, e.g. SIFT, PolyPhen'
+    'caption'       => 'Variant deleteriousness predictions, e.g. SIFT, PolyPhen'
   }, {
     'id'            => 'filters',
     'title'         => 'Filtering options',


### PR DESCRIPTION
[ENSVAR-5913](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5913)

For species-specific plugins, we currently add a `_stt_[Species_name]` class to the plugin option elements (such as `_stt_Homo_sapiens`) so that the option is only shown if that species is currently selected.

However, when using a different division of Ensembl (e.g., plants), if the species is not present in `$self->object->species_list`, the class is ignored and the plugin options are displayed for all species in that division.

This PR solves this issue by checking if any of the supported species is available in the species list for this division. If the species is not in the list, then we don't add the plugin options.

### Other changes

- **Splicing predictions** are hard-coded to be only available for human. This was fixed by stating the supported species in the plugin configuration: https://github.com/Ensembl/VEP_plugins/pull/623
- [Fix caption of VEP Predictions section](https://github.com/Ensembl/public-plugins/pull/716/commits/c019b9d1f2762d65d5fbed6b0f0239ecadb4fc0c)

### Testing
- Vertebrates: http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP
- Plants: http://wp-np2-1e:8786/Oryza_sativa/Tools/VEP