### PR TITLE
VEP docs: update VEP input format examples

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/vep_formats.html
+++ b/docs/htdocs/info/docs/tools/vep/vep_formats.html
@@ -27,38 +27,38 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <table class="ss">
       <tr>
         <th>Format</th>
-        <th><a href="#sv">Structural variant support</a></th>
-        <th>Example</th>
+        <th>Variant example</th>
+        <th><a href="#sv">Structural variant example</a></th>
       </tr>
       <tr>
         <td><a href="#default">Default VEP input</a></td>
-        <td>Yes</td>
-        <td><kbd>1   881907    881906    -/C   +</kbd></td>
+        <td><kbd>1 881907 881906 -/C +</kbd></td>
+        <td><kbd>1 160283 471362 DUP +</kbd></td>
       </tr>
       <tr>
         <td><a href="#vcf">VCF</a></td>
-        <td>Yes</td>
-        <td><kbd>1       65568      .       A    C              .     .       .     .</kbd></td>
+        <td><kbd>1 65568 . A C . . .</kbd></td>
+        <td><kbd>1 7936271 . N N[12:58877476[ . . .</kbd></td>
       </tr>
       <tr>
         <td><a href="#hgvs">HGVS identifiers</a></td>
-        <td></td>
         <td><kbd>ENST00000207771.3:c.344+626A>T</kbd></td>
+        <td style="text-align: center"><font style="color: darkgray">&#10007; Not supported</font></td>
       </tr>
       <tr>
         <td><a href="#id">Variant identifiers</a></td>
-        <td></td>
         <td><kbd>rs699</kbd></td>
+        <td><kbd>nsv1000164</kbd></td>
       </tr>
       <tr>
         <td><a href="#spdi">Genomic SPDI notation</a></td>
-        <td></td>
         <td><kbd>NC_000016.10:68684738:G:A</kbd></td>
+        <td style="text-align: center"><font style="color: darkgray">&#10007; Not supported</font></td>
       </tr>
       <tr>
         <td><a href="#region">REST-style regions</a></td>
-        <td>Yes</td>
         <td><kbd>14:19584687-19584687:-1/T</kbd></td>
+        <td><kbd>21:25587759-25587769/DEL</kbd></td>
       </tr>
     </table>
 
@@ -275,10 +275,11 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <h3 id="sv"> Structural variant types</h3>
     
     <p>VEP can also call consequences on structural variants using the
-      following formats:</p>
+      following input formats:</p>
     <ul>
       <li><a href="#default">Default VEP input</a></li>
       <li><a href="#region">REST-style regions</a></li>
+      <li> <a href="#id">Variant identifiers</a></li>
       <li> <a href="#vcf">VCF</a></li>
     </ul>
   
@@ -384,16 +385,27 @@ LRG_1:g.10006G>T</pre>
     <hr />
     <h2 id="id"> Variant identifiers</h2>
     
-    <p> These should be e.g. dbSNP rsIDs, or any synonym for a variant present in
-    the Ensembl Variation database. See <a
+    <p> These should be dbSNP rsIDs (such as <kbd>rs699</kbd>), or any synonym for a variant present in
+    the Ensembl Variation database. Structural variant identifiers (like <kbd>nsv1000164</kbd> and
+    <kbd>esv1850194</kbd>) are also supported.</p>
+
+    <p> See <a
     href="/info/genome/variation/species/sources_documentation.html">here</a> for a list of
-    identifier sources in Ensembl.</p>
+    identifier sources in Ensembl. </p>
+
+    <p> Examples: </p>
+
+    <pre class="code sh_sh">rs1156485833
+rs1258750482
+rs867704559
+esv1815690
+nsv1000164</pre>
    
     <div>
       <div class="info" style="float:left">
         <h3>Note</h3>
         <div class="message-pad">
-          <p>VEP is optimised for the analysis of variants in sorted VCF files or other position based formats, so input in these formats is recommended to variant names where possible. Using variant names can take 2-5 times longer.</p>
+          <p>VEP is optimised for the analysis of variants in sorted VCF files or other position-based formats. Using variant identifiers can take 2-5 times longer.</p>
         </div>
       </div>
       <div style="clear:both"></div>

--- a/docs/htdocs/info/docs/tools/vep/vep_formats.html
+++ b/docs/htdocs/info/docs/tools/vep/vep_formats.html
@@ -38,11 +38,11 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
       <tr>
         <td><a href="#vcf">VCF</a></td>
         <td><kbd>1 65568 . A C . . .</kbd></td>
-        <td><kbd>1 7936271 . N N[12:58877476[ . . .</kbd></td>
+        <td><kbd>1 7936271 . N N[12:58877476[ . . SVTYPE=BND</kbd></td>
       </tr>
       <tr>
         <td><a href="#hgvs">HGVS identifiers</a></td>
-        <td><kbd>ENST00000207771.3:c.344+626A>T</kbd></td>
+        <td><kbd>ENST00000618231.3:c.9G>C</kbd></td>
         <td style="text-align: center"><font style="color: darkgray">&#10007; Not supported</font></td>
       </tr>
       <tr>
@@ -118,15 +118,15 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     
     <p>
       Structural variants are also supported by indicating a
-      <a href="#sv">structural variant type</a> in the place of the allele:
+      <a href="#sv">structural variant type</a> instead of the allele:
     </p>
   
     <pre class="code sh_sh">
-1    20000     30000     &lt;CN4&gt;  +  cn4
-1    160283    471362    DUP    +  sv1
-1    1385015   1387562   DEL    +  sv2
-12   1017956   1017956   INV    +  inv1
-21   25587759  25587769  &lt;CN0&gt;  +  del</pre>
+1    20000     30000     CN4  +  cnv4
+1    160283    471362    DUP  +  dup
+1    1385015   1387562   DEL  +  del1
+12   1017956   1017956   INV  +  inv
+21   25587759  25587769  CN0  +  del2</pre>
     
     <br />
     <hr />
@@ -283,10 +283,9 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
       <li> <a href="#vcf">VCF</a></li>
     </ul>
   
-    <p> To recognise a
-      variant as a structural variant, the allele string (or <code>SVTYPE</code>
-      in the INFO column of the VCF format) must be set to one of the currently
-      recognised values: </p>
+    <p> To recognise a variant as a structural variant, the allele string
+      (or <code>SVTYPE</code> in the INFO column of the VCF format) must be set
+      to one of the currently supported values: </p>
     
     <ul>
         <li><b>INS</b> - insertion</li>
@@ -307,7 +306,7 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
             In VCF, breakend replacements are inserted into the <code>ALT</code>
             column and need to meet the
             <a rel="external" href="http://samtools.github.io/hts-specs/">HTS specifications</a>,
-            such as <kbd>A[chr22:22893780[,CT[chrX:10932343[</kbd>.
+            such as <kbd>A[22:22893780[,A[X:10932343[</kbd>.
           </li>
         </ul>
     </ul>
@@ -315,10 +314,10 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     <p> Examples of structural variants encoded in VCF format: </p>
     
     <pre class="code sh_sh">
-#CHROM  POS        ID   REF  ALT               QUAL  FILTER  INFO                    FORMAT
-1       160283     dup  .    &lt;DUP&gt;             .     .       SVTYPE=DUP;END=471362   .
-1       1385015    del  .    &lt;DEL&gt;             .     .       SVTYPE=DEL;END=1387562  .
-1       234919885  bnd  A    [chr1:17124942[A  .     .       SVTYPE=BND              .</pre>
+#CHROM  POS        ID   REF  ALT             QUAL  FILTER  INFO
+1       160283     dup  .    &lt;DUP&gt;           .     .       SVTYPE=DUP;END=471362
+1       1385015    del  .    &lt;DEL&gt;           .     .       SVTYPE=DEL;END=1387562
+1       7936271    bnd  N    N[12:58877476[  .     .       SVTYPE=BND</pre>
     
     <p> See the <a
     rel="external" href="http://www.1000genomes.org/wiki/Analysis/Variant%20Call%20Format/VCF%20%28Variant%20Call%20Format%29%20version%204.0/encoding-structural-variants">VCF
@@ -338,10 +337,10 @@ tr:nth-child(odd) {background-color: #f0f0f0;}
     
     <p> Examples: </p>
     
-    <pre class="code sh_sh">ENST00000207771.3:c.344+626A>T
+    <pre class="code sh_sh">ENST00000618231.3:c.9G>C
 ENST00000471631.1:c.28_33delTCGCGG
 ENST00000285667.3:c.1047_1048insC
-5:g.140532T>C</pre>
+5:g.140532G>C</pre>
     
     <p> Examples using RefSeq identifiers (using <a
     href="script/vep_options.html#opt_refseq">--refseq</a> in the VEP script, or select
@@ -349,8 +348,8 @@ ENST00000285667.3:c.1047_1048insC
     HGVS): </p>
     
     <pre class="code sh_sh">NM_153681.2:c.7C>T
-NM_005239.4:c.190G>A
-NM_001025204.1:c.336G>A</pre>
+NM_005239.6:c.190G>A
+NM_001025204.2:c.336G>A</pre>
     
     <p> HGVS protein notations may also be used, provided that they
     unambiguously map to a single genomic change. Due to redundancy in the amino
@@ -359,12 +358,6 @@ NM_001025204.1:c.336G>A</pre>
     is for a permissable protein notation in dog <i>(Canis familiaris)</i>:</p>
     
     <pre class="code sh_sh">ENSCAFP00000040171.1:p.Thr92Asn</pre>
-    
-    <p> HGVS notations may also be given in <a href="https://www.lrg-sequence.org"
-    rel="external">LRG</a> coordinates: </p>
-    
-    <pre class="code sh_sh">LRG_1t1:c.841G>T
-LRG_1:g.10006G>T</pre>
 
     <h4>Ambiguous gene-based descriptions</h4>
     <p>It is possible to use ambiguous descriptions listing only gene symbol or UniProt accession and protein change (e.g. PHF21B:p.Tyr124Cys,  P01019:p.Ala268Val), as seen in the literature, though this is not recommended as it can produce multiple different variants at genomic level. The transcripts for a gene are considered in the following order:


### PR DESCRIPTION
Related with Ensembl/ensembl-vep#1478

- Mention structural variant (SV) support for variant identifiers
- Add examples of SVs in the table at the top
- Update examples (some HGVS ones were not working)
    - Remove mentions to LRG

Check changes in my sandbox: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/vep_formats.html#hgvs