### PR TITLE
Add name field validation

### DIFF
--- a/users/modules/EnsEMBL/Users/Component/Account.pm
+++ b/users/modules/EnsEMBL/Users/Component/Account.pm
@@ -122,7 +122,7 @@ sub add_user_details_fields {
   my @lists     = $params->{'no_list'} ? () : @{$self->hub->species_defs->SUBSCRIPTION_EMAIL_LISTS};
   my $countries = $self->object->list_of_countries;
 
-  $form->add_field({'label' => 'Name', 'class' => '_name',  'name' => 'name', 'type' => 'string', 'value' => $params->{'name'}          || '',  'required' => 'yes' });
+  $form->add_field({'label' => 'Name',  'name' => 'name', 'type' => 'name', 'value' => $params->{'name'}          || '',  'required' => 1 });
   $form->add_field({'label' => 'Email Address', 'name' => 'email',        'type' => 'email',    'value' => $params->{'email'}         || '',  'required' => 1, $params->{'email_notes'} ? ('notes' => $params->{'email_notes'}) : () }) unless $params->{'no_email'};
   $form->add_field({'label' => 'Organisation',  'name' => 'organisation', 'type' => 'string' ,  'value' => $params->{'organisation'}  || '' });
   $form->add_field({'label' => 'Country',       'name' => 'country',      'type' => 'dropdown', 'value' => $params->{'country'}       || '', 'values' => [ {'value' => '', 'caption' => ''}, sort {$a->{'caption'} cmp $b->{'caption'}} map {'value' => $_, 'caption' => $countries->{$_}}, keys %$countries ] });

--- a/users/modules/EnsEMBL/Users/Component/Account.pm
+++ b/users/modules/EnsEMBL/Users/Component/Account.pm
@@ -122,7 +122,7 @@ sub add_user_details_fields {
   my @lists     = $params->{'no_list'} ? () : @{$self->hub->species_defs->SUBSCRIPTION_EMAIL_LISTS};
   my $countries = $self->object->list_of_countries;
 
-  $form->add_field({'label' => 'Name',          'name' => 'name',         'type' => 'string',   'value' => $params->{'name'}          || '',  'required' => 1 });
+  $form->add_field({'label' => 'Name', 'class' => '_name',  'name' => 'name', 'type' => 'string', 'value' => $params->{'name'}          || '',  'required' => 'yes' });
   $form->add_field({'label' => 'Email Address', 'name' => 'email',        'type' => 'email',    'value' => $params->{'email'}         || '',  'required' => 1, $params->{'email_notes'} ? ('notes' => $params->{'email_notes'}) : () }) unless $params->{'no_email'};
   $form->add_field({'label' => 'Organisation',  'name' => 'organisation', 'type' => 'string' ,  'value' => $params->{'organisation'}  || '' });
   $form->add_field({'label' => 'Country',       'name' => 'country',      'type' => 'dropdown', 'value' => $params->{'country'}       || '', 'values' => [ {'value' => '', 'caption' => ''}, sort {$a->{'caption'} cmp $b->{'caption'}} map {'value' => $_, 'caption' => $countries->{$_}}, keys %$countries ] });


### PR DESCRIPTION

## Description

Add validation to the name field of registration for to prevent users from using non-ascii characters. 

## Views affected
https://www.ensembl.org/Multi/Account/Register
http://wp-np2-1e:8788/Multi/Account/Register

## Possible complications
Since field type "Name" is added in this process it shouldn't affect other fields.

## Merge conflicts



## Related JIRA Issues (EBI developers only)

[ENSWEB-6907](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6907)