### PR TITLE
Remove references to abinitio DBs from MULTI.ini

### DIFF
--- a/tools/conf/ini-files/MULTI.ini
+++ b/tools/conf/ini-files/MULTI.ini
@@ -42,18 +42,16 @@ TBLASTN   = [peptide dna ensembl_wutblastn]
 TBLASTX   = [dna dna ensembl_wutblastx]
 
 [ENSEMBL_BLAST_DATASOURCES_ALL]
-ORDER           = [LATESTGP LATESTGP_MASKED LATESTGP_SOFT CDNA_ALL CDNA_ABINITIO NCRNA PEP_ALL PEP_ABINITIO] ; order preserved
+ORDER           = [LATESTGP LATESTGP_MASKED LATESTGP_SOFT CDNA_ALL NCRNA PEP_ALL] ; order preserved
 LATESTGP        = dna Genomic sequence
 LATESTGP_MASKED = dna Genomic sequence (hard masked)
 LATESTGP_SOFT   = dna Genomic sequence (soft masked)
 CDNA_ALL        = dna cDNAs (transcripts/splice variants)
-CDNA_ABINITIO   = dna Ab-initio cDNAs (Genscan/SNAP)
 NCRNA           = dna Ensembl Non-coding RNA genes
 PEP_ALL         = peptide Proteins (Ensembl)
-PEP_ABINITIO    = peptide Ab-initio Peptides (Genscan/SNAP)
 
 [ENSEMBL_BLAST_DATASOURCES_BY_TYPE] ; datasources that are valid for all species (modify this in species.ini to remove any invalid datasource)
-NCBIBLAST       = [LATESTGP LATESTGP_MASKED LATESTGP_SOFT CDNA_ALL CDNA_ABINITIO NCRNA PEP_ALL PEP_ABINITIO] ; order not preserved
+NCBIBLAST       = [LATESTGP LATESTGP_MASKED LATESTGP_SOFT CDNA_ALL NCRNA PEP_ALL] ; order not preserved
 BLAT            = [LATESTGP]
 #WUBLAST
 


### PR DESCRIPTION
This PR removes the options in the blast submission for that allow the user to search against databases of abinitio genes. These genesets are no longer generated and when the user chooses that option for a species that doesn't have them, the website reports an error. 

See [ENSWEB-6914](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6914) for more details.
