### PR TITLE
VEP plugin: Update to dbNSFP 4.5c data (e112)

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_example.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_example.html
@@ -183,38 +183,49 @@
   
   
   <h2 id="dbNSFP">dbNSFP</h2>
-  
+
   <p> dbNSFP - <a href="http://www.ncbi.nlm.nih.gov/pubmed/21520341"
   rel="external">&quot;a lightweight database of human nonsynonymous SNPs and
   their functional predictions&quot;</a> - provides pathogenicity predictions
   from many tools (including SIFT, PolyPhen, LRT, MutationTaster, FATHMM) across
-  every possible missense substitution in the human proteome. The data is
-  available to <a href="https://sites.google.com/site/jpopgen/dbNSFP"
-  rel="external">download</a>, and while it cannot be immediately used by the
-  VEP it is simple to process the data into a format that the dbNSFP.pm plugin
-  can use. </p>
+  every possible missense substitution in the human proteome. </p>
+
+  <p> Plugins in VEP sometimes require data processed in specific ways as
+  arguments. Any requirements and usage instructions for each plugin can be
+  found in the <a href="vep_plugins.html">plugin documentation</a>. </p>
+
+  <p> In the case of the dbNSFP.pm plugin, the data needs to be
+  <a href="https://sites.google.com/site/jpopgen/dbNSFP" rel="external">downloaded</a>
+  and then processed into a format that the plugin can use. Note that there are
+  two distinct branches of the files provided for academic and commercial usage;
+  please use the appropriate files for your use case. </p>
   
   <p> After downloading the file, you will need to process it so that tabix can
   index it correctly. This will take a while as the file is very large! Note
   that you will need the <a href="http://samtools.sourceforge.net/tabix.shtml"
-  rel="external">tabix</a> utility in your path to use dbNSFP.</p>
+  rel="external">tabix</a> utility in your path to use dbNSFP. </p>
 
-  <pre class="code sh_sh">unzip dbNSFP4.0b2a.zip
-head -n1 dbNSFP4.0b2a_variant.chr1 > dbNSFP4.0b2a.txt
-cat dbNSFP4.0b2a_variant.chr* | grep -v "#" >> dbNSFP4.0b2a.txt
-rm dbNSFP4.0b2a_variant.chr*
-bgzip dbNSFP4.0b2a.txt
-tabix -s 1 -b 2 -e 2 dbNSFP4.0b2a.txt.gz</pre>
-  
+  <pre class="code sh_sh">version=4.5c
+unzip dbNSFP${version}.zip
+zcat dbNSFP${version}_variant.chr1.gz | head -n1 > h
+
+# GRCh38/hg38 data
+zgrep -h -v "^#chr" dbNSFP${version}_variant.chr* | sort -k1,1 -k2,2n - | cat h - | bgzip -c > dbNSFP${version}_grch38.gz
+tabix -s 1 -b 2 -e 2 dbNSFP${version}_grch38.gz
+
+# GRCh37/hg19 data
+zgrep -h -v "^#chr" dbNSFP${version}_variant.chr* | awk '$8 != "." ' | sort -k8,8 -k9,9n - | cat h - | bgzip -c > dbNSFP${version}_grch37.gz
+tabix -s 8 -b 9 -e 9 dbNSFP${version}_grch37.gz</pre>
+
   <p> Then simply download the <a
   href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/dbNSFP.pm"
-  rel="external">dbNSFP VEP plugin</a> and place it either in
+  rel="external">dbNSFP.pm plugin</a> and place it either in
   <b>$HOME/.vep/Plugins/</b> or a path in your <b>$PERL5LIB</b>. When you run
   VEP with the plugin, you will need to select some of the columns that you
   wish to retrieve; to list them run VEP with the plugin and the path to the
   dbNSFP file and no further parameters: </p>
   
-  <pre class="code sh_sh">./vep --cache --force --plugin dbNSFP,dbNSFP4.0b2a.txt.gz
+  <pre class="code sh_sh">./vep --cache --force --plugin dbNSFP,dbNSFP4.5c_grch38.txt.gz
 2014-04-04 11:27:05 - Read existing cache info
 2014-04-04 11:27:05 - Auto-detected FASTA file in cache directory
 2014-04-04 11:27:05 - Checking/creating FASTA index
@@ -237,7 +248,7 @@ codonpos,fold-degenerate,Ancestral_allele,Ensembl_geneid,Ensembl_transcriptid,
   <p> To select fields, just add them as a comma-separated list to your command
   line:</p>
   
-  <pre class="code sh_sh">./vep --cache --force --plugin dbNSFP,dbNSFP4.0b2a.txt.gz,LRT_score,FATHM_score,MutationTaster_score</pre>
+  <pre class="code sh_sh">./vep --cache --force --plugin dbNSFP,dbNSFP4.5c_grch38.txt.gz,LRT_score,FATHM_score,MutationTaster_score</pre>
   
   <p> One final point to note is that the dbNSFP scores are frozen on a
   particular Ensembl release's transcript set; check the readme file on their

--- a/docs/htdocs/info/docs/tools/vep/script/vep_example.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_example.html
@@ -187,7 +187,7 @@
   <p> dbNSFP - <a href="http://www.ncbi.nlm.nih.gov/pubmed/21520341"
   rel="external">&quot;a lightweight database of human nonsynonymous SNPs and
   their functional predictions&quot;</a> - provides pathogenicity predictions
-  from many tools (including SIFT, PolyPhen, LRT, MutationTaster, FATHMM) across
+  from many tools (including SIFT, LRT, MutationTaster, FATHMM) across
   every possible missense substitution in the human proteome. </p>
 
   <p> Plugins in VEP sometimes require data processed in specific ways as
@@ -236,8 +236,7 @@ codonpos,fold-degenerate,Ancestral_allele,Ensembl_geneid,Ensembl_transcriptid,
 ...</pre>
   
   <p> Note that some of these fields are replicates of those produced by the
-  core VEP code (e.g. <a href="vep_options.html#opt_sift">SIFT</a>, <a
-  href="vep_options.html#opt_polyphen">PolyPhen</a>, the <a
+  core VEP code (e.g. <a href="vep_options.html#opt_sift">SIFT</a>, the <a
   href="vep_options.html#opt_af_1kg">1000 Genomes</a> and <a
   href="vep_options.html#opt_af_esp">ESP</a> frequencies) - you should use the
   options to enable these from the VEP code in place of the annotations from

--- a/ensembl/htdocs/info/genome/variation/prediction/protein_function.html
+++ b/ensembl/htdocs/info/genome/variation/prediction/protein_function.html
@@ -43,7 +43,7 @@ from at least one tool for over 95% of the human proteins in Ensembl.
 <p>
 Pathogenicity scores from <a href="#REVEL">REVEL</a>, <a href="#MutationAssessor"> MutationAssessor</a> 
 and <a href="#MetaLR">MetaLR</a> are also available for human missense variants.
-To improve compatibility with other resources, these scores are taken from dbNSFP (version 4.4a).
+To improve compatibility with other resources, these scores are taken from dbNSFP (version 4.5c).
 </p>
 
 <p>

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -1,7 +1,7 @@
 {
   dbNSFP => {
     "params"  => [
-      "[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/dbNSFP4.4a_grch38.gz",
+      "[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/dbNSFP4.5c_grch38.gz",
       "@*"
     ]
   },

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -37,7 +37,7 @@
     "params" => [
       "snv=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD_GRCh38_1.6_whole_genome_SNVs.tsv.gz",
       "indels=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD_GRCh38_1.6_InDels.tsv.gz",
-      "snv_pig=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/ALL_pCADD-PHRED-scores.tsv.gz"
+      "snv_pig=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/ALL_pCADD-PHRED-scores.tsv.gz",
       "sv=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD_prescored_variants.tsv.gz"
     ]
   },


### PR DESCRIPTION
[ENSVAR-6120](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6120)

- Update dbNSFP data version in public docs
- Update file path
- Update dbNSFP example docs


## Testing

- Check publics docs changes in [vep_example.html#dbNSFP](http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_example.html#dbNSFP)
- Test VEP in my [sandbox](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=ca60xPCVe96wi7ZG-109); only supports dbNSFP variants in chromosome 18, such as:

```
rs1208893863
rs1243334743
rs1276354422
rs1318597724
rs1348242192
rs1441742077
rs1477215563
rs1489182805
rs1905642714
rs1905645225
rs1905647878
rs529943330
rs543847261
rs562842438
```
