### PR TITLE
Add plugin RiboseqORFs to web VEP (e112)

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/online/input.html
+++ b/docs/htdocs/info/docs/tools/vep/online/input.html
@@ -342,6 +342,12 @@ enter your data and alter various options.</p>
                   <a href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/UTRAnnotator.pm">UTRAnnotator</a> plugin.</p>
                 </li>
 
+                <li><b>RiboseqORFs</b>
+                  <p>Annotates the consequences of variants overlapping Ribo-seq ORFs.
+                  This functionality is provided by the
+                  <a href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/RiboseqORFs.pm">RiboseqORFs</a> plugin.</p>
+                </li>
+
                 <hr />
                 
                 <li><b>Protein matches</b>
@@ -465,24 +471,21 @@ enter your data and alter various options.</p>
       <div class="column-right" style="padding-left:2em">
         <form style="scale: 0.8; transform-origin: top left; pointer-events: none; width: 150%" class="_tool_form _check check vep-form bgcolour"><fieldset class="extra-options-fieldset" style="margin: 0; padding: 8px">
           <div class="extra_configs_wrapper" style="margin: 0">
-            <div class="extra_configs_button"><a class="toggle _slide_toggle set_cookie open" rel="__togg_Additional_annotations" href="#Additional_annotations">Additional annotations</a><span class="extra_configs_info">Addtional transcript, protein and regulatory annotations</span></div><div class="hidden toggleable extra_configs __togg_Additional_annotations" style="display: block;"><fieldset><h2>Transcript annotation</h2><div class="form-field"><label class="ff-label"><span class="ht _ht">Transcript biotype</span>:</label><div class="ff-right"><p class="ff-checklist"><input checked="checked" type="checkbox"></p></div></div><div class="form-field"><label class="ff-label"><span class="ht _ht">Exon and intron numbers</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox"></p></div></div><div class="form-field" style="display: block;"><label class="ff-label">Transcript support level:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" checked="checked"></p></div></div>
-            <div class="form-field" style="display: block;">
-              <label class="ff-label"><span class="_ht ht">APPRIS</span>:</label>
-              <div class="ff-right">
-                <p class="ff-checklist">
-                  <input type="checkbox" checked="checked">
-                </p>
-              </div>
-            </div>
-            <div class="form-field" style="display: block;">
-            <label class="ff-label"><span class="_ht ht">MANE</span>:</label>
-            <div class="ff-right">
-              <p class="ff-checklist">
-                <input type="checkbox" checked="checked">
-              </p>
-            </div>
-          </div>
-            <div class="_stt_merged form-field _stt_core _stt_gencode_basic" style="display: block;"><label class="ff-label">Identify canonical transcripts:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox"></p></div></div><div class="form-field"><label class="ff-label"><span class="ht _ht">Upstream/Downstream distance (bp)</span>:</label><div class="ff-right"><input value="5000" class="optional _string ftext" type="text"></div></div><div class="form-field"><label class="ff-label"><span class="_ht ht">miRNA structure</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" ></p></div></div><div class="form-field"><label class="ff-label"><span class="ht _ht">NMD</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" class="_stt plugin_enable"></p></div></div><div class="form-field"><label class="ff-label"><span class="ht _ht">UTRAnnotator</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" class="plugin_enable _stt"></p></div></div></fieldset>
+            <div class="extra_configs_button"><a class="toggle _slide_toggle set_cookie open" rel="__togg_Additional_annotations" href="#Additional_annotations">Additional annotations</a><span class="extra_configs_info">Addtional transcript, protein and regulatory annotations</span></div>
+            <div class="hidden toggleable extra_configs __togg_Additional_annotations" style="display: block;">
+            <fieldset><h2>Transcript annotation</h2>
+              <div class="form-field"><label class="ff-label"><span class="ht _ht">Transcript biotype</span>:</label><div class="ff-right"><p class="ff-checklist"><input checked="checked" type="checkbox"></p></div></div>
+              <div class="form-field"><label class="ff-label"><span class="ht _ht">Exon and intron numbers</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox"></p></div></div>
+              <div class="form-field" style="display: block;"><label class="ff-label">Transcript support level:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" checked="checked"></p></div></div>
+              <div class="form-field" style="display: block;"><label class="ff-label"><span class="_ht ht">APPRIS</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" checked="checked"></p></div></div>
+              <div class="form-field" style="display: block;"><label class="ff-label"><span class="_ht ht">MANE</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" checked="checked"></p></div></div>
+              <div class="_stt_merged form-field _stt_core _stt_gencode_basic" style="display: block;"><label class="ff-label">Identify canonical transcripts:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox"></p></div></div>
+              <div class="form-field"><label class="ff-label"><span class="ht _ht">Upstream/Downstream distance (bp)</span>:</label><div class="ff-right"><input value="5000" class="optional _string ftext" type="text"></div></div>
+              <div class="form-field"><label class="ff-label"><span class="_ht ht">miRNA structure</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" ></p></div></div>
+              <div class="form-field"><label class="ff-label"><span class="ht _ht">NMD</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" class="_stt plugin_enable"></p></div></div>
+              <div class="form-field"><label class="ff-label"><span class="ht _ht">UTRAnnotator</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" class="plugin_enable _stt"></p></div></div>
+              <div class="form-field"><label class="ff-label"><span class="ht _ht">RiboseqORFs</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" class="plugin_enable _stt"></p></div></div>
+            </fieldset>
             <fieldset>
               <h2>Protein annotation</h2><div class="_stt_merged form-field _stt_core _stt_gencode_basic" style="display: block;"><label class="ff-label"><span class="ht _ht">Protein matches</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox"></p></div></div><div class="_stt_Mus_musculus form-field _stt_Homo_sapiens" style="display: block;"><label class="ff-label"><span class="_ht ht">mutfunc</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="radio" checked="checked" class="_stt plugin_enable"><label class="ff-checklist-label">Disabled</label></p><p class="ff-checklist"><input type="radio" class="plugin_enable _stt"><label class="ff-checklist-label">Enabled</label></p></div></div>
             </fieldset>

--- a/tools/conf/vep_plugins_web_config.txt
+++ b/tools/conf/vep_plugins_web_config.txt
@@ -85,5 +85,9 @@
 
   OpenTargets => {
     "available" => 1
-  }
+  },
+
+  RiboseqORFs => {
+    "available" => 1
+  },
 }

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -136,4 +136,11 @@
       "file=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/OTGenetics.tsv.gz"
     ]
   },
+
+  RiboseqORFs => {
+    "params" => [
+      "file=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/Ribo-seq_ORFs.bed.gz"
+    ]
+  },
+
 }


### PR DESCRIPTION
[ENSVAR-6046](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6046)

Plugin disabled in GRCh37: https://github.com/Ensembl/ebi-plugins/pull/168

## Testing

- Documentation update: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/online/input.html
- Web VEP: http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=6RmHUye4v10akm1c-115

Example of variant for RiboseqORFs:
```
1 119140608 rs139548132 A C,G,T
```