### PR TITLE
Check config tree instead of INI for regulation species (e113)

### DIFF
--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -289,7 +289,7 @@ sub _species_details {
   return {
     'sift'        => $db_config->{'DATABASE_VARIATION'}{'SIFT'},
     'polyphen'    => $db_config->{'DATABASE_VARIATION'}{'POLYPHEN'},
-    'regulatory'  => $sd->get_config($species, 'REGULATORY_BUILD'),
+    'regulatory'  => $db_config->{'DATABASE_FUNCGEN'}{'tables'}{'regulatory_build'}{'analyses'}{'Regulatory_Build'}->{'count'},
     'refseq'      => $db_config->{'DATABASE_OTHERFEATURES'} && $sd->get_config($species, 'VEP_REFSEQ')
   };
 }

--- a/tools/modules/EnsEMBL/Web/Object/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Object/VEP.pm
@@ -502,7 +502,7 @@ sub species_list {
         'variation'   => $db_config->{'DATABASE_VARIATION'} // undef,
         'refseq'      => $db_config->{'DATABASE_OTHERFEATURES'} && $sd->get_config($_, 'VEP_REFSEQ') // undef,
         'assembly'    => $sd->get_config($_, 'ASSEMBLY_NAME') // undef,
-        'regulatory'  => $sd->get_config($_, 'REGULATORY_BUILD') // undef,
+        'regulatory'  => $db_config->{'DATABASE_FUNCGEN'}{'tables'}{'regulatory_build'}{'analyses'}{'Regulatory_Build'}->{'count'} // undef,
         'phenotypes'  => $phenotype_data,
         'example'     => $example_data,
       };


### PR DESCRIPTION
Currently we [update INI files](https://github.com/Ensembl/public-plugins/pull/754) to setup species with regulatory build in web VEP. But it can be directly derived from the species def config tree.

The target of this update is in e113 - regulation will review the [summary data](https://github.com/Ensembl/ensembl-webcode/blob/25c16dc3ff2135b5e3b31e0ad186113bb25194d3/modules/EnsEMBL/Web/ConfigPacker.pm#L699) loaded in the species defs first [confirmed].

test sandbox url - http://wp-np2-11.ebi.ac.uk:7070/Tools/VEP

Test can be done for `turbot`, `european seabass` on example variants.