### PR TITLE
Update regulation docs for 112

### DIFF
--- a/ensembl/htdocs/info/genome/funcgen/data/accessing-regulation.html
+++ b/ensembl/htdocs/info/genome/funcgen/data/accessing-regulation.html
@@ -27,11 +27,8 @@ Regulation data can be accessed in the browser from various angles:
 <p>
 You can configure the Region in detail panel to display tracks linked to regulation. The Regulation tracks are grouped into subdivisions:
 <ul>
-	<li><b>Regulatory Features:</b> these can be visualised using the 'Regulatory Build' track.</li>
-  <li><b>Activity Levels:</b> select the cell type/line of interest and display the activity levels for each regulatory feature defined in the Regulatory Build.</li>
-  <li><b>Segmentation Features:</b> select the cell type/line of interest and display the genomic state assignment in the region.</li>
-	<li><b>Open Chromatin and Transcription Factor Binding Sites (TFBS):</b> display of signal or peaks from  assays measuring open chromatin (DNAse-seq) or transcription factor binding (ChIP-seq) in various cell types/lines.</li>
-	<li><b>Histones and Polymerases:</b> display of signal or peaks from experimental ChIP-seq assays measuring histone marks/modifications or binding of RNA Polymerases II and III.</li>
+	<li><b>Regulatory Features:</b> these can be visualised using the 'Regulatory features' track.</li>
+  <li><b>Activity by Cell/Tissue:</b> select the tissue or cell type (epigenome) of interest and display peaks, signals and regulatory feature activity across the genome.</li>
   <li><b>DNA Methylation:</b> RRBS and WGBS methylation tracks.</li>
 	<li><b>Other regulatory regions:</b> imported tracks from external databases.</li>
 </ul>
@@ -42,13 +39,11 @@ You can configure the Region in detail panel to display tracks linked to regulat
 Click on the Regulation link in the left hand side menu to view the <a href="/Homo_sapiens/Gene/Regulation?g=ENSG00000139618;r=13:32889611-32973805">regulatory features and eQTLs in the vicinity of your gene</a>.
 </p>
 
-<h3><a href="/Homo_sapiens/Regulation/Summary?db=funcgen;fdb=funcgen;r=13:32314000-32317601;rf=ENSR00000060894">Regulation tab</a></h3>
+<h3>Regulation tab</a></h3>
 <p>
 Clicking on a regulatory feature will open a Regulation tab with information about the evidence supporting that regulatory feature as well as cell-specific activity estimates. Different views can be selected:
 <ul>
-	<li><b>Summary:</b> this view displays the selected regulatory feature and a summary of its regulatory activity across cell types.</li>
-	<li><b>Details by cell type:</b> this view displays activity tracks for the regulatory feature in selected cell types. You can display more cell types by clicking on the <i>Configure this page</i> button above the image.</li>
-	<li><b>Feature Context:</b> this view displays regulatory features in a wider context around the chosen regulatory feature.</li>
+	<li><b>Activity:</b> this view displays the selected regulatory feature and a summary of its regulatory activity across cell types.</li>
 	<li><b>Source Data:</b> this view displays the list of source data for the chosen regulatory feature.</li>
 </ul>
 </p>

--- a/ensembl/htdocs/info/genome/funcgen/data/accessing-regulation.html
+++ b/ensembl/htdocs/info/genome/funcgen/data/accessing-regulation.html
@@ -28,7 +28,7 @@ Regulation data can be accessed in the browser from various angles:
 You can configure the Region in detail panel to display tracks linked to regulation. The Regulation tracks are grouped into subdivisions:
 <ul>
 	<li><b>Regulatory Features:</b> these can be visualised using the 'Regulatory features' track.</li>
-  <li><b>Activity by Cell/Tissue:</b> select the tissue or cell type (epigenome) of interest and display peaks, signals and regulatory feature activity across the genome.</li>
+  <li><b>Activity by Cell/Tissue:</b> select the tissue or cell type (epigenome) of interest and display peaks, signal and regulatory feature activity across the genome.</li>
   <li><b>DNA Methylation:</b> RRBS and WGBS methylation tracks.</li>
 	<li><b>Other regulatory regions:</b> imported tracks from external databases.</li>
 </ul>

--- a/ensembl/htdocs/info/genome/funcgen/data/accessing-regulation.html
+++ b/ensembl/htdocs/info/genome/funcgen/data/accessing-regulation.html
@@ -39,7 +39,7 @@ You can configure the Region in detail panel to display tracks linked to regulat
 Click on the Regulation link in the left hand side menu to view the <a href="/Homo_sapiens/Gene/Regulation?g=ENSG00000139618;r=13:32889611-32973805">regulatory features and eQTLs in the vicinity of your gene</a>.
 </p>
 
-<h3>Regulation tab</a></h3>
+<h3>Regulation tab</h3>
 <p>
 Clicking on a regulatory feature will open a Regulation tab with information about the evidence supporting that regulatory feature as well as cell-specific activity estimates. Different views can be selected:
 <ul>

--- a/ensembl/htdocs/info/genome/funcgen/process/humanandmouse/segmentation.html
+++ b/ensembl/htdocs/info/genome/funcgen/process/humanandmouse/segmentation.html
@@ -12,7 +12,8 @@
 <h1>Regulatory Segmentation</h1>
 
 <p>
-Segmentation algorithms partition the genome into regions with distinct epigenomic profiles. These are genomic regions of similar signal pattern over a selected number of assays.
+Segmentation algorithms partition the genome into regions with distinct epigenomic profiles. These are genomic regions of similar signal pattern over a selected number of assays. 
+These have been used to produce our current regulatory feature annotation for human and mouse. 
 </p>
 
 <p>
@@ -44,8 +45,7 @@ To segment the genome for each cell type we currently use either <b><a href="htt
 <h4>Regulatory Segmentation in the Browser</h4>
 
 
-<p>There is one segmentation track available for each of the cell types in the Ensembl Regulatory Build. These tracks are off by default. 
-To turn on the Segmentation tracks, you need to add them using "Configure this page". They can be found in the Regulation section of "Configure this page" under <em>Features by Cell/Tissue.</em>, and then by selecting the <em>Configure Track Display</em>.
+<p>We are no longer updating our segmentation tracks as we migrate our regulatory annotation pipeline over the next few releases. Segmentation tracks can be viewed in the archive sites of release 111 and earlier. 
 </p>
 
 </body>


### PR DESCRIPTION
Documentation has been updated to reflect the removal of segmentation tracks in 112, as well as other updates, including label changes.

Sandbox URL:
Documentation is currently available on http://wp-np2-11.ebi.ac.uk:6010/info/genome/funcgen/index.html.