### PR TITLE
Update indexed VEP cache links (bacteria)

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_cache.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_cache.html
@@ -122,27 +122,27 @@ tar xzf homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz</pre>
     </li>
   </ul>
 
-  <p><img src="/i/16/download.png" style="vertical-align:bottom"/> <b>FTP directories by species grouping:</b></p>
+  <p><img src="/i/16/download.png" style="vertical-align:bottom"/> <b>FTP directories to indexed VEP cacha data by species grouping:</b></p>
 
   <table class="ss" style="width:auto">
     <tr>
       <th style="border-bottom:1px solid #f0f0f0">Ensembl: </th>
       <td>
-        <a href="[[SPECIESDEFS::ENSEMBL_FTP_URL]]/current_variation/indexed_vep_cache/">Vertebrates</a> <small>(indexed)</small>
+        <a href="[[SPECIESDEFS::ENSEMBL_FTP_URL]]/current_variation/indexed_vep_cache/">Vertebrates</a>
       </td>
     </tr>
     <tr>
       <th style="padding-right:10px">Ensembl Genomes: </th>
       <td>
-        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/bacteria/current/variation/vep/">Bacteria</a>
+        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/bacteria/current/variation/indexed_vep_cache/">Bacteria</a>
         <span style="padding:0px 4px">|</span>
-        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/fungi/current/variation/indexed_vep_cache/">Fungi</a> <small>(indexed)</small>
+        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/fungi/current/variation/indexed_vep_cache/">Fungi</a>
         <span style="padding:0px 4px">|</span>
-        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/metazoa/current/variation/indexed_vep_cache/">Metazoa</a> <small>(indexed)</small>
+        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/metazoa/current/variation/indexed_vep_cache/">Metazoa</a>
         <span style="padding:0px 4px">|</span>
-        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/plants/current/variation/indexed_vep_cache/">Plants</a> <small>(indexed)</small>
+        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/plants/current/variation/indexed_vep_cache/">Plants</a>
         <span style="padding:0px 4px">|</span>
-        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/protists/current/variation/indexed_vep_cache/">Protists</a> <small>(indexed)</small>
+        <a href="[[SPECIESDEFS::ENSEMBL_GENOMES_FTP_URL]]/protists/current/variation/indexed_vep_cache/">Protists</a>
       </td>
     </tr>
   </table>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_cache.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_cache.html
@@ -122,7 +122,7 @@ tar xzf homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz</pre>
     </li>
   </ul>
 
-  <p><img src="/i/16/download.png" style="vertical-align:bottom"/> <b>FTP directories to indexed VEP cacha data by species grouping:</b></p>
+  <p><img src="/i/16/download.png" style="vertical-align:bottom"/> <b>FTP directories with indexed VEP cacha data by species grouping:</b></p>
 
   <table class="ss" style="width:auto">
     <tr>


### PR DESCRIPTION
Update bacterial VEP cache link to point to indexed cache

## Testing

Check changes in my sandbox: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_cache.html#cache