### PR TITLE
Added missense support to alphafold

### DIFF
--- a/widgets/htdocs/alphafold/components/confidenceMissenseToggle.js
+++ b/widgets/htdocs/alphafold/components/confidenceMissenseToggle.js
@@ -1,0 +1,63 @@
+import { html, css, LitElement } from 'https://unpkg.com/lit@2.2.5/index.js?module';
+
+export class ConfidenceMissenseToggle extends LitElement {
+
+  static get styles() {
+
+    return css`
+    .panel-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        background-color: var(--main-dark);
+        color: white;
+        font-weight: bold;
+        padding: 4px 28px 4px 4px;
+      }
+    `
+  }
+  
+  static get properties() {
+    return {
+      isConfidenceSelected: { attribute: false }
+    }
+  }
+  
+  createOption(id,label,isChecked)
+  {
+    if(isChecked)
+    {
+    return html`
+      <input type="radio" name="toggleConfidenceMissense" @change=${this.onToggleChanged}
+      id=${id} checked /><label for=${id}>${label}</label>
+    `;
+    }
+    else
+    {
+      return html`
+      <input type="radio" name="toggleConfidenceMissense" @change=${this.onToggleChanged}
+      id=${id} /><label for=${id}>${label}</label>
+    `;
+    }
+  }
+  
+  render() {
+    
+    let confidenceChecked = this.createOption('tconfidence','Model Confidence',this.isConfidenceSelected);
+    let missenseChecked = this.createOption('tmissense','AlphaMissense Pathogenicity',!this.isConfidenceSelected);
+    
+    return html`
+    <div class="panel-title">
+    <span>Toggle</span>
+    </div>
+      <div class="body">
+        <div class="row">
+          
+          ${confidenceChecked}
+          ${missenseChecked}
+          
+        </div>
+    `};
+};
+
+customElements.define('confidence-missense-toggle', ConfidenceMissenseToggle);

--- a/widgets/htdocs/alphafold/components/ensemblAlphafoldMissense.js
+++ b/widgets/htdocs/alphafold/components/ensemblAlphafoldMissense.js
@@ -1,0 +1,112 @@
+const COLOR_MAP = {
+    min: { r: 0, g: 0, b: 187 },
+    center: { r: 255, g: 255, b: 255 },
+    max: { r: 255, g: 0, b: 0 },
+}
+
+const BASE_COLOR = { r: 100, g: 100, b: 100 };
+
+export class EnsemblAlphafoldMissense
+{
+  constructor() {
+    this.sequenceColors = [];
+    this.hasMissenseLoaded = false;
+    this.missenseSelection = {
+      data: [
+      { struct_asym_id: 'A', color: BASE_COLOR }
+      ]
+    }
+  }
+  
+  getSelection() {
+    return this.missenseSelection;
+  }
+  
+  hasMissense()
+  {
+    return this.hasMissenseLoaded;
+  }
+  
+  async loadMissense(annotationCSVUrl) {
+    
+    const missenseCSVResponse = await fetch(annotationCSVUrl);
+    
+    if (!missenseCSVResponse.ok) {
+      this.hasMissenseLoaded = false; 
+      console.log("Unable to load missense");
+      return;
+    }
+    
+    //process file
+    this.hasMissenseLoaded = this.extractColors(await missenseCSVResponse.text());
+  }
+
+  extractColors(data){
+    const DELIMITER = ',';
+    const MUTATION_COLUMN = 0;
+    const SCORE_COLUMN = 1;
+    const N_HEADER_ROWS = 1;
+  
+    const lines = data.split('\n').filter(line => line.trim() !== '' && !line.trim().startsWith('#'));
+    if (N_HEADER_ROWS > 0) lines.splice(0, N_HEADER_ROWS);
+    const rows = lines.map(line => line.split(DELIMITER));
+    
+    //const scores = { [seq_id: number]: number[] } = {};
+    const scores = {};
+    for (const row of rows) {
+      const mutation = row[MUTATION_COLUMN];
+      const score = Number(row[SCORE_COLUMN]);
+      const match = mutation.match(/([A-Za-z]+)([0-9]+)([A-Za-z]+)/);
+      if (!match) 
+      {
+        console.log("Missense CSV parse error!");
+        console(row);
+        throw new Error(`FormatError: cannot parse "${mutation}" as a mutation (should look like Y123A)`);
+      }
+      const seq_id = match[2];
+
+      if(!scores[seq_id])
+      {
+        scores[seq_id] = []
+      }
+      scores[seq_id].push(Number(score));
+      
+    }
+
+    for (const seq_id in scores) {
+      const aggrScore = this.mean(scores[seq_id]); // The original paper also uses mean (https://www.science.org/doi/10.1126/science.adg7492)
+      const color = this.assignColor(aggrScore);
+      this.sequenceColors.push([Number(seq_id), color]);
+    }
+
+    this.missenseSelection.data.push(
+      ...this.sequenceColors.map((rc) =>  ({ 'struct_asym_id': 'A', 'residue_number': rc[0], 'color': rc[1]}))
+    ) // TODO here I assume the model is always chain A, is it correct?
+
+    return true;
+  }
+  
+  mean(values) {
+    return values.reduce((a, b) => a + b, 0) / values.length;
+  }
+  
+  /** Map a score within [0, 1] to a color (0 -> COLOR_MAP.min, 0.5 -> COLOR_MAP.center, 1 -> COLOR_MAP.max) */
+  assignColor(score) {
+    if (score <= 0.5) {
+      return this.mixColor(COLOR_MAP.min, COLOR_MAP.center, 2 * score);
+    }
+    else {
+      return this.mixColor(COLOR_MAP.center, COLOR_MAP.max, 2 * score - 1);
+    }
+  }
+  
+  mixColor(color0, color1, q) {
+    return {
+      r: color0.r * (1 - q) + color1.r * q,
+      g: color0.g * (1 - q) + color1.g * q,
+      b: color0.b * (1 - q) + color1.b * q,
+    };
+  }
+
+}
+

--- a/widgets/htdocs/alphafold/components/ensemblAlphafoldProtein.js
+++ b/widgets/htdocs/alphafold/components/ensemblAlphafoldProtein.js
@@ -129,7 +129,7 @@ export class EnsemblAlphafoldProtein extends LitElement {
 
   render() {
     return html`
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/pdbe-molstar@dev/build/pdbe-molstar-light.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/pdbe-molstar@3.2.0/build/pdbe-molstar-light.css">
       <div class="container">
         <div class="molstar-canvas"></div>
         <div class="controls">

--- a/widgets/htdocs/alphafold/components/ensemblAlphafoldVep.js
+++ b/widgets/htdocs/alphafold/components/ensemblAlphafoldVep.js
@@ -137,7 +137,7 @@ export class EnsemblAlphafoldVEP extends LitElement {
 
   render() {
     return html`
-      <link rel="stylesheet" type="text/css" href="https://www.ebi.ac.uk/pdbe/pdb-component-library/css/pdbe-molstar-light-3.0.0.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/pdbe-molstar@3.2.0/build/pdbe-molstar-light.css">
       <div class="container">
         <div class="molstar-canvas"></div>
         <div class="controls">

--- a/widgets/htdocs/alphafold/components/ensemblAlphafoldVep.js
+++ b/widgets/htdocs/alphafold/components/ensemblAlphafoldVep.js
@@ -1,10 +1,12 @@
-import { html, LitElement } from 'https://unpkg.com/lit@2.2.5/index.js?module';
+import { html, nothing, LitElement } from 'https://unpkg.com/lit@2.2.5/index.js?module';
 
 import { MolstarController } from '../controllers/molstarController.js';
 import { ExonsController } from '../controllers/exonsController.js';
 import { ProteinFeaturesController } from '../controllers/proteinFeaturesController.js';
 import { VepVariantController } from '../controllers/vepVariantController.js';
 import { ConfidenceColorsController } from '../controllers/confidenceColorsController.js';
+import { MissenseController } from '../controllers/missenseController.js';
+import { ConfidenceMissenseColorsController} from '../controllers/confidenceMissenseController.js'
 
 import {
   fetchAlphaFoldId,
@@ -15,7 +17,8 @@ import './exonsControlPanel.js';
 import './vepVariantControlPanel.js';
 import './defaultColorsPanel.js';
 import './proteinFeaturesControlPanel.js';
-
+import './missenseColorsPanel.js';
+import './confidenceMissenseToggle.js';
 
 const alphafoldEbiRootUrl = 'https://alphafold.ebi.ac.uk';
 
@@ -42,6 +45,10 @@ export class EnsemblAlphafoldVEP extends LitElement {
       host: this,
       visible: false
     });
+    this.confidenceMissenseColorsController = new ConfidenceMissenseColorsController({
+      host: this
+    })
+    this.missenseController = new MissenseController({host:this});
   }
 
   // prevent the component from rendering into the shadow DOM, see README.md for explanation
@@ -58,11 +65,15 @@ export class EnsemblAlphafoldVEP extends LitElement {
       fetchAlphaFoldId({ rootUrl: restUrlRoot, enspId }),
       this.molstarController.loadScript(),
       this.exonsController.load({ rootUrl: restUrlRoot, enspId }),
-      this.proteinFeaturesController.load({ rootUrl: restUrlRoot, enspId }),
-    ]).then(([alphafoldId]) => {
+      this.proteinFeaturesController.load({ rootUrl: restUrlRoot, enspId })
+    ]).then(this.molstarController.getModelFileAndAnnotationUrl
+    ).then((alphafoldData) => {
+      this.missenseController.load(alphafoldData.annotation);
+      return alphafoldData;
+    }).then((alphafoldData)=> {
       // below is a promise; make sure it gets returned
       return this.molstarController.renderAlphafoldStructure({
-        moleculeId: alphafoldId,
+        modelFileUrl: alphafoldData.cif,
         urlRoot: alphafoldEbiRootUrl,
         canvasContainer: molstarContainer
       });
@@ -86,11 +97,19 @@ export class EnsemblAlphafoldVEP extends LitElement {
       this.proteinFeaturesController.getSelectedFeatures(),
       this.vepVariantController.getSelection()
     ].flat();
-
-    this.molstarController.updateSelections({
+    
+    let updateData = {
       selections,
-      showConfidence: this.confidenceColorsController.visible
-    });
+      showConfidence: this.confidenceColorsController.visible,
+    }
+    
+    if(this.confidenceColorsController.visible && !this.confidenceMissenseColorsController.showConfidence)
+    {
+      updateData.altSelection = this.missenseController.getSelection();
+      updateData.showConfidence = false;
+    }
+
+    this.molstarController.updateSelections(updateData);
   }
 
   onLoadComplete() {
@@ -158,10 +177,25 @@ export class EnsemblAlphafoldVEP extends LitElement {
           ></protein-features-control-panel>
         `
       }
-      <default-colors-panel
+      
+      ${this.missenseController.hasMissense() ? html`
+       <confidence-missense-toggle
+        .onToggleChanged=${this.confidenceMissenseColorsController.toggle}
+        .isConfidenceSelected=${this.confidenceMissenseColorsController.getShowConfidence()}
+       ></confidence-missense-toggle>
+      ` : nothing }
+      
+      ${this.confidenceMissenseColorsController.showConfidence ? html`
+        <default-colors-panel
         .visible=${this.confidenceColorsController.visible}
         .onVisibilityToggle=${this.confidenceColorsController.toggleVisibility}
-      ></default-colors-panel>
+      ></default-colors-panel>` : 
+      html`
+        <missense-colors-panel
+        .visible=${this.confidenceColorsController.visible}
+        .onVisibilityToggle=${this.confidenceColorsController.toggleVisibility}
+        </missense-colors-panel>`
+      }
     `;
   }
 }

--- a/widgets/htdocs/alphafold/components/missenseColorsPanel.js
+++ b/widgets/htdocs/alphafold/components/missenseColorsPanel.js
@@ -1,0 +1,138 @@
+
+import { html, css, LitElement } from 'https://unpkg.com/lit@2.2.5/index.js?module';
+
+import './controlPanel.js';
+
+
+export class MissenseColorsPanel extends LitElement {
+
+  static get styles() {
+
+    return css`
+      :host {
+        display: block;
+        border: 1px solid #ccc;
+        min-width: max-content;
+      }
+
+      .panel-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        background-color: var(--main-dark);
+        color: white;
+        font-weight: bold;
+        padding: 4px 28px 4px 4px;
+      }
+
+      .body {
+        padding: 8px 6px;
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+      }
+
+      .row:not(:last-child) {
+        margin-bottom: 16px;
+      }
+
+      .color-sample {
+        width: 20px;
+        height: 20px;
+        margin-right: 1ch;
+      }
+      
+      .min {
+        background-color: #3753A1;
+      }
+      
+      .center {
+        background-color: #A9A8A8;
+      }
+      
+      .max {
+        background-color: #A60B14;
+      }
+
+      .explainer {
+        margin-top: 1rem;
+        width: 40ch;
+        line-height: 1.5;
+      }
+
+      .show-feature {
+        width: 16px;
+        height: 16px;
+        border: none;
+        outline: none;
+        cursor: pointer;
+        filter: brightness(0) invert(1);
+      }
+
+      .show-feature_hidden {
+        background: url(/i/16/eye_no.png);
+      }
+
+      .show-feature_visible {
+        background: url(/i/16/eye.png);
+      }
+    `;
+  }
+
+  static get properties() {
+    return {
+      visible: { attribute: false }
+    }
+  }
+
+  constructor() {
+    super();
+    this.visible = true;
+  }
+
+  render() {
+    return html`
+      <div class="panel-title">
+        <span>AlphaMissense Pathogenicity</span>
+        ${
+          this.onVisibilityToggle ? this.renderVisibilityToggle() : null
+        }
+      </div>
+      <div class="body">
+        <div class="row">
+          <span class="color-sample max"></span>
+          <span class="label">Pathogenic</span>
+        </div>
+        <div class="row">
+          <span class="color-sample center"></span>
+          <span class="label">Uncertain</span>
+        </div>
+        <div class="row">
+          <span class="color-sample min"></span>
+          <span class="label">Benign</span>
+        </div>
+        <div class="explainer">
+          The displayed color for each residue is the average AlphaMissense pathogenicity 
+          score across all possible amino acid substitutions at that position
+        </div>
+      </div>
+    `;
+  }
+
+  renderVisibilityToggle() {
+    const classes = this.visible
+      ? 'show-feature show-feature_visible'
+      : 'show-feature show-feature_hidden'
+
+    return html`
+      <button
+        class=${classes}
+        @click=${this.onVisibilityToggle}
+      ></button>
+    `;
+  }
+};
+
+customElements.define('missense-colors-panel', MissenseColorsPanel);

--- a/widgets/htdocs/alphafold/controllers/confidenceMissenseController.js
+++ b/widgets/htdocs/alphafold/controllers/confidenceMissenseController.js
@@ -1,0 +1,20 @@
+export class ConfidenceMissenseColorsController {
+
+  constructor({ host, showConfidence = true }) {
+    this.host = host;
+    this.showConfidence = showConfidence;
+    this.host.addController(this);
+    this.toggle = this.toggle.bind(this);
+  }
+  
+  getShowConfidence() 
+  {
+    return this.showConfidence;
+  }
+
+  toggle() {
+    this.showConfidence = !this.showConfidence;
+    this.host.requestUpdate();
+  }
+
+}

--- a/widgets/htdocs/alphafold/controllers/missenseController.js
+++ b/widgets/htdocs/alphafold/controllers/missenseController.js
@@ -1,0 +1,130 @@
+const COLOR_MAP = {
+    min: { r: 0, g: 0, b: 187 },
+    center: { r: 255, g: 255, b: 255 },
+    max: { r: 255, g: 0, b: 0 },
+}
+
+const BASE_COLOR = { r: 100, g: 100, b: 100 };
+
+export class MissenseController {
+
+  constructor({ host, showConfidence = true,  }) {
+    this.host = host;
+    this.showConfidence = showConfidence;
+
+    this.host.addController(this);
+
+    this.toggleBetweenConfidenceAndMissense = this.toggleBetweenConfidenceAndMissense.bind(this);
+    
+    this.sequenceColors = [];
+    this.hasMissenseLoaded = false;
+    this.missenseSelection = {
+      data: [
+      { struct_asym_id: 'A', color: BASE_COLOR }
+      ]
+    }
+    this.missenseSelection.nonSelectedColor = { r: 255, g: 255, b: 255 };
+  }
+
+  toggleBetweenConfidenceAndMissense() {
+    this.showConfidence = !this.showConfidence;
+    this.host.requestUpdate();
+  }
+  
+  getSelection() {
+    return this.missenseSelection;
+  }
+  
+  hasMissense()
+  {
+    return this.hasMissenseLoaded;
+  }
+  
+  
+  //CSV and color handling sections
+  async load(annotationCSVUrl) {
+    
+    if(!annotationCSVUrl)
+    {
+      return;
+    }
+    
+    const missenseCSVResponse = await fetch(annotationCSVUrl);
+    
+    if (!missenseCSVResponse.ok) {
+      this.hasMissenseLoaded = false; 
+      console.log("Unable to load missense");
+      return;
+    }
+    
+    //process file
+    this.hasMissenseLoaded = this.extractColors(await missenseCSVResponse.text());
+  }
+
+  extractColors(data){
+    const DELIMITER = ',';
+    const MUTATION_COLUMN = 0;
+    const SCORE_COLUMN = 1;
+    const N_HEADER_ROWS = 1;
+  
+    const lines = data.split('\n').filter(line => line.trim() !== '' && !line.trim().startsWith('#'));
+    if (N_HEADER_ROWS > 0) lines.splice(0, N_HEADER_ROWS);
+    const rows = lines.map(line => line.split(DELIMITER));
+
+    //const scores = { [seq_id: number]: number[] } = {};
+    const scores = {};
+    for (const row of rows) {
+      const mutation = row[MUTATION_COLUMN];
+      const score = Number(row[SCORE_COLUMN]);
+      const match = mutation.match(/([A-Za-z]+)([0-9]+)([A-Za-z]+)/);
+      if (!match) 
+      {
+        console.log("Missense CSV parse error!");
+        console.log(data);
+        throw new Error(`FormatError: cannot parse "${mutation}" as a mutation (should look like Y123A)`);
+      }
+      const seq_id = match[2];
+
+      if(!scores[seq_id])
+      {
+        scores[seq_id] = []
+      }
+      scores[seq_id].push(Number(score));
+      
+    }
+
+    for (const seq_id in scores) {
+      const aggrScore = this.mean(scores[seq_id]); // The original paper also uses mean (https://www.science.org/doi/10.1126/science.adg7492)
+      const color = this.assignColor(aggrScore);
+      this.sequenceColors.push([Number(seq_id), color]);
+    }
+    
+    this.missenseSelection.data.push(
+      ...this.sequenceColors.map((rc) =>  ({ 'struct_asym_id': 'A', 'residue_number': rc[0], 'color': rc[1]}))
+    ) // TODO here I assume the model is always chain A, is it correct?
+    
+    return true;
+  }
+  
+  mean(values) {
+    return values.reduce((a, b) => a + b, 0) / values.length;
+  }
+  
+  /** Map a score within [0, 1] to a color (0 -> COLOR_MAP.min, 0.5 -> COLOR_MAP.center, 1 -> COLOR_MAP.max) */
+  assignColor(score) {
+    if (score <= 0.5) {
+      return this.mixColor(COLOR_MAP.min, COLOR_MAP.center, 2 * score);
+    }
+    else {
+      return this.mixColor(COLOR_MAP.center, COLOR_MAP.max, 2 * score - 1);
+    }
+  }
+  
+  mixColor(color0, color1, q) {
+    return {
+      r: color0.r * (1 - q) + color1.r * q,
+      g: color0.g * (1 - q) + color1.g * q,
+      b: color0.b * (1 - q) + color1.b * q,
+    };
+  }
+};

--- a/widgets/htdocs/alphafold/controllers/molstarController.js
+++ b/widgets/htdocs/alphafold/controllers/molstarController.js
@@ -1,6 +1,5 @@
 import { getRGBFromHex } from '../colorHelpers.js';
 import { MissingAlphafoldModelError } from '../dataFetchers.js';
-
 export class MolstarController {
 
   constructor(host) {
@@ -11,26 +10,30 @@ export class MolstarController {
     this.renderAlphafoldStructure = this.renderAlphafoldStructure.bind(this);
     this.updateSelections = this.updateSelections.bind(this);
     this.focus = this.focus.bind(this);
+    this.missenseUrl = null; // set during load
+
   }
 
   async loadScript() {
     await new Promise((resolve, reject) => {
       const script = document.createElement('script');
       script.type = 'text/javascript';
-      script.src= 'https://www.ebi.ac.uk/pdbe/pdb-component-library/js/pdbe-molstar-plugin-3.0.0.js';
+      //script.src= 'https://www.ebi.ac.uk/pdbe/pdb-component-library/js/pdbe-molstar-plugin-3.0.0.js';
+      script.src = 'https://cdn.jsdelivr.net/npm/pdbe-molstar@3.2.0/build/pdbe-molstar-plugin.js'
       script.onload = resolve;
       script.onerror = reject;
       document.head.appendChild(script);
     });
     this.molstarInstance = new PDBeMolstarPlugin();
   }
-
+  
   // Alphafold ids are formatted as AF-<uniprot_id>-F1
   // We need the uniprot id to talk to AF apis
-  getModelFileUrl = async (alphafoldId) => {
+  getModelFileAndAnnotationUrl = async (alphafoldId) => {
+    
     const alphafoldPredictionEndpoint = 'https://alphafold.ebi.ac.uk/api/prediction';
     const parsingRegex = /-(.+)-/;
-    const uniprotId = alphafoldId.match(parsingRegex)[1];
+    const uniprotId = alphafoldId[0].match(parsingRegex)[1];
     const url = `${alphafoldPredictionEndpoint}/${uniprotId}`;
 
     const alphafoldPredictionEntriesResponse = await fetch(url);
@@ -44,12 +47,13 @@ export class MolstarController {
 
     // alphafold's api will respond with an array of entries; we are interested in the first one
     const alphafoldEntry = alphafoldPredictionEntries[0];
-    return alphafoldEntry.cifUrl;
+    return {
+      cif:alphafoldEntry.cifUrl,
+      annotation:alphafoldEntry.amAnnotationsUrl
+    };
   }
 
-  async renderAlphafoldStructure({ moleculeId, canvasContainer }) {
-    const modelFileUrl = await this.getModelFileUrl(moleculeId);
-
+  async renderAlphafoldStructure({ modelFileUrl, canvasContainer }) {
     const options = {
       customData: {
         url: modelFileUrl,
@@ -57,11 +61,18 @@ export class MolstarController {
       },
       bgColor: { r: 255, g: 255, b: 255 },
       alphafoldView: true,
+      sequencePanel:true,
       hideCanvasControls: ['selection', 'animation', 'controlToggle', 'controlInfo'],
       subscribeEvents: console.l
     };
 
-    this.molstarInstance.render(canvasContainer, options);
+    this.molstarInstance.render(canvasContainer, options).then(() =>
+      {
+        //hide structure tools
+        this.molstarInstance.plugin.layout.updateProps({
+          regionState: {left:'hidden', right:'hidden', bottom:'hidden',top:'full'}
+        })
+      });
 
     return new Promise(resolve => {
       this.molstarInstance.events.loadComplete.subscribe(resolve);
@@ -69,18 +80,27 @@ export class MolstarController {
 
   }
 
-  updateSelections({ selections, showConfidence = false }) {
+  updateSelections({ selections, showConfidence = false, altSelection=undefined }) {
+    
     selections = selections.map(item => ({
       start_residue_number: item.start,
       end_residue_number: item.end,
       color: getRGBFromHex(item.color)
     }));
+    
+    if(altSelection)
+    {
+      let altSelect = altSelection.data;
+      altSelect.push(...selections)
+      selections = altSelect;
+    }
 
-    const params = {
+    let params = {
       data: selections
     };
-
-    if (!showConfidence) {
+    
+    if(!showConfidence)
+    {
       params.nonSelectedColor = { r: 255, g: 255, b: 255 }; // color the rest of the molecule white
     }
 


### PR DESCRIPTION
This PR adds a missense visualisation to the transcript and vep mol* protein view.

Transcript view of missense
http://wp-np2-1f.ebi.ac.uk:10000/Homo_sapiens/Transcript/AFDB?g=ENSG00000113282;r=5:157785747-157859145;t=ENST00000411809

Vep view of missense
http://wp-np2-1f.ebi.ac.uk:10000/Homo_sapiens/Tools/VEP/AFDB?cons=missense_variant;g=ENSG00000162551;pos=123;r=1:21509397-21578410;t=ENST00000374840;tl=oC7nwlZwvyXywnvd-20;var=rs1188506084

Vep view where missese is not available 
http://wp-np2-1f.ebi.ac.uk:10000/Homo_sapiens/Tools/VEP/AFDB?cons=missense_variant;g=ENSG00000186092;pos=2;r=1:65419-71585;t=ENST00000641515;tl=4OC8idHwqqeHacfV-18;var=.