### PR TITLE
Update Alphafold prefix used in VEP cache for e112

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -1331,13 +1331,13 @@ sub get_items_in_list {
       elsif ($item =~ /^(PDB-ENSP_mappings:)((.+)\.\w)$/i) {
         $item_url = "$1&nbsp;".$hub->get_ExtURL_link($2, 'PDB', $3);
       }
-      elsif ($item =~ /^AFDB-ENSP_mappings:(.+)$/i) {
+      elsif ($item =~ /^AlphaFold_DB_import:(.+)$/i) {
         # The format of an AlphaFold id is "AF-uniprot_id-fragment_number".
         # The AlphaFold site uses Uniprot ids as accession ids.
         my $alphafold_id = $1;
         my ( $uniprot_id ) = $alphafold_id =~ /-(.+)-/; # the middle part of an alphafold id
 
-        $item_url = "AFDB-ENSP_mappings:" . "&nbsp" . $hub->get_ExtURL_link($alphafold_id, 'ALPHAFOLD', $uniprot_id);
+        $item_url = "AlphaFold_DB_import:" . "&nbsp" . $hub->get_ExtURL_link($alphafold_id, 'ALPHAFOLD', $uniprot_id);
       }
       elsif ($type eq 'mastermind_mmid3') {
         $item_url = $hub->get_ExtURL_link($item, 'MASTERMIND', $item);
@@ -1404,7 +1404,7 @@ sub render_protein_matches {
 
   my $should_add_pdb_view_button = $domain_ids =~ /PDB-ENSP/i;
   # we are currently only comfortable with showing the alphafold view only in case of missense variants
-  my $should_add_afdb_view_button = $domain_ids =~ /AFDB-ENSP/i && $consequence =~ /missense_variant/i;
+  my $should_add_afdb_view_button = $domain_ids =~ /AlphaFold_DB/i && $consequence =~ /missense_variant/i;
   my $should_add_protein_view_buttons = $should_add_pdb_view_button || $should_add_afdb_view_button;
 
   my $rendered_protein_matches = $self->get_items_in_list($row_id, 'domains', 'Protein matches', $domain_ids, $species);


### PR DESCRIPTION
Update the alphafold prefix that will be included in VEP results in 112.

The reason the prefix changed from `AFDB-ENSP_mappings` to `AlphaFold_DB_import` is because it was hard-coded this way in the pipeline updated by the Infrastructure team. The correct behaviour should be for the pipeline to get the analysis name from a production database. This should be corrected in e113. Meanwhile, since the `AlphaFold_DB_import` string has now been saved into VEP caches, the simplest thing to do for e112 is to change the string that web code matches.

This change is intended to only go into the 112 release branch, and should then be pushed to www and plants sites that have VEP with Alphafold.

Sandbox: http://wp-np2-1e.ebi.ac.uk:8410/Homo_sapiens/Tools/VEP/Results?tl=o7aod5zBdFqdsi65-25