### PR TITLE
Fixing miRNA docs

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/online/input.html
+++ b/docs/htdocs/info/docs/tools/vep/online/input.html
@@ -361,7 +361,7 @@ enter your data and alter various options.</p>
                 </li>
 
                 <li><b>miRNA structure</b>
-                  <p>Determines where in the secondary structure of a miRNA a variant falls.
+                  <p>Determines where in the secondary structure of a miRNA a variant falls (only for Ensembl/GENCODE transcripts).
                   Equivalent to <a
                   href="/info/docs/tools/vep/script/vep_options.html#opt_mirna">--mirna</a>.</p>
 		            </li>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1015,7 +1015,7 @@ host          useastdb.ensembl.org</pre>
       <td><pre>--mirna</pre></td>
       <td>&nbsp;</td>
       <td>
-        Reports where the variant lies in the miRNA secondary structure. <i>Not used by default</i>
+        Reports where the variant lies in the miRNA secondary structure (only for Ensembl/GENCODE transcripts). <i>Not used by default</i>
       </td>
       <td>&nbsp;</td>
       <td>&nbsp;</td>


### PR DESCRIPTION
The mirna flag doesn't work for refseq transcripts and no trivial way to add this functionality, so we will indicate that it's only suported for Ensembl/genocde