### PR TITLE
Fix some copy-paste errors in Bamei Pig breed info

### DIFF
--- a/ensembl/htdocs/ssi/species/Sus_scrofa_bamei_annotation.html
+++ b/ensembl/htdocs/ssi/species/Sus_scrofa_bamei_annotation.html
@@ -1,6 +1,6 @@
 <p>For information on this genebuild, please see the PDF document below.</p>
 <ul>
-  9   <li><a href="/info/genome/genebuild/2019_09_pigs_gene_annotation.pdf">Detailed information on pig breed genebuild</a> (PDF    )</li>
- 10 </ul>
- 11 
- 12 <p>In accordance with the <a href="https://en.wikipedia.org/wiki/Fort_Lauderdale_Agreement">Fort Lauderdale Agreement </a>, please     check the publication status of the genome/assembly before publishing any genome-wide analyses using these data.</p>
+  <li><a href="/info/genome/genebuild/2019_09_pigs_gene_annotation.pdf">Detailed information on pig breed genebuild</a> (PDF)</li>
+</ul>
+
+<p>In accordance with the <a href="https://en.wikipedia.org/wiki/Fort_Lauderdale_Agreement">Fort Lauderdale Agreement</a>, please check the publication status of the genome/assembly before publishing any genome-wide analyses using these data.</p>


### PR DESCRIPTION
There are some copy-paste errors in the Bamei Pig breed info text.

This PR applies a similar fix to the Bamei Pig breed as was previously applied to other affected Pig breeds ([commit a1c23bd](https://github.com/Ensembl/public-plugins/commit/a1c23bdcf6b32318a6fe77268644caa6de037eef)).

Example on sandbox: http://wp-np2-25.ebi.ac.uk:5092/Sus_scrofa_bamei/Info/Annotation
Example on staging: https://staging.ensembl.org/Sus_scrofa_bamei/Info/Annotation


