### PR TITLE
Web VEP: Add REVEL and ClinPred plugins

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/online/input.html
+++ b/docs/htdocs/info/docs/tools/vep/online/input.html
@@ -611,6 +611,24 @@ enter your data and alter various options.</p>
                   </p>
                 </li>
 
+                <li><b>REVEL</b>
+                  <p>
+                    <a rel="external" href="https://sites.google.com/site/revelgenomics">Rare Exome Variant Ensemble Learner (REVEL)</a> is an ensemble method for predicting the pathogenicity of missense variants based on a combination of scores from multiple individual tools. REVEL is only available here for
+                    non-commercial use.
+                    Equivalent to the VEP plugin <a rel="external" 
+                  href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/REVEL.pm">REVEL</a>.
+                  </p>
+                </li>
+
+                <li><b>ClinPred</b>
+                  <p>
+                    <a rel="external" href="https://sites.google.com/site/clinpred">ClinPred</a> is a prediction tool to identify disease-relevant nonsynonymous single nucleotide variants. The predictor incorporates existing pathogenicity scores and benefits from normal population allele frequencies. ClinPred is only available here for
+                    non-commercial use.
+                    Equivalent to the VEP plugin <a rel="external" 
+                  href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/ClinPred.pm">ClinPred</a>.
+                  </p>
+                </li>
+
                 <li><b>EVE</b>
                   <p>Adds information from <a rel="external"
                   href="https://evemodel.org/">EVE</a> (evolutionary model of variant effect).
@@ -683,6 +701,8 @@ enter your data and alter various options.</p>
               <div class="_stt_Homo_sapiens form-field"><label class="ff-label"><span class="_ht ht">dbNSFP</span>:</label><div class="ff-right"><p class="ff-checklist"><input class="_stt plugin_enable" type="radio" checked="checked"><label class="ff-checklist-label">Disabled</label></p><p class="ff-checklist"><input type="radio" class="plugin_enable _stt"><label class="ff-checklist-label">Enabled</label></p></div></div><div class="_stt_plugin_dbNSFP ff-multi form-field" style="display: none;"><label class="ff-label"><span class="_ht ht">Fields to include</span>:</label><div class="ff-right"><select class="fselect" multiple="multiple" style="height:150px;"><option>aapos</option></select></div><div class="ff-notes">Field descriptions in <a rel="external" href="#">dbNSFP README</a></div></div><div class="form-field _stt_plugin_dbNSFP" style="display: none;"><label class="ff-label"><span class="_ht ht">Transcript match</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox"></p></div></div>
               <div class="form-field _stt_Homo_sapiens"><label class="ff-label"><span class="_ht ht">AlphaMissense</span>:</label><div class="ff-right"><p class="ff-checklist"><input class="plugin_enable _stt" type="checkbox"></p></div></div>
               <div class="form-field _stt_Homo_sapiens"><label class="ff-label"><span class="_ht ht">CADD</span>:</label><div class="ff-right"><p class="ff-checklist"><input class="plugin_enable _stt" type="checkbox"></p></div></div>
+              <div class="form-field _stt_Homo_sapiens"><label class="ff-label"><span class="_ht ht">REVEL</span>:</label><div class="ff-right"><p class="ff-checklist"><input class="plugin_enable _stt" type="checkbox"></p></div></div>
+              <div class="form-field _stt_Homo_sapiens"><label class="ff-label"><span class="_ht ht">ClinPred</span>:</label><div class="ff-right"><p class="ff-checklist"><input class="plugin_enable _stt" type="checkbox"></p></div></div>
               <div class="_stt_Homo_sapiens form-field"><label class="ff-label"><span class="ht _ht">EVE</span>:</label><div class="ff-right"><p class="ff-checklist"><input class="plugin_enable _stt" type="checkbox"></p></div></div>
             </fieldset>
             <fieldset class="_stt_Homo_sapiens">

--- a/tools/conf/vep_plugins_web_config.txt
+++ b/tools/conf/vep_plugins_web_config.txt
@@ -94,4 +94,10 @@
   AlphaMissense => {
     "available" => 1
   },
+  REVEL => {
+    "available" => 1
+  },
+  ClinPred => {
+    "available" => 1
+  },
 }

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -148,4 +148,14 @@
       "file=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/AlphaMissense_hg38.tsv.gz"
     ]
   },
+  REVEL => {
+    "params" => [
+      "file=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/REVEL/new_tabbed_revel_grch38.tsv.gz"
+    ]
+  },
+  ClinPred => {
+    "params" => [
+      "file=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/ClinPred/ClinPred_hg38_sorted_tabbed.tsv.gz"
+    ]
+  },
 }


### PR DESCRIPTION
[ENSVAR-6395](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6395): add ClinPred plugin to web VEP + REST
[ENSVAR-6396](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6396): add REVEL plugin to web VEP + REST

Requires https://github.com/Ensembl/VEP_plugins/pull/729

## Testing

Test in my [sandbox](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=YdC3TIKeMhDHfy3s-1) with these examples:

```
11 168962 168962 T A
20 68351 87710 A C
22 15690303 15690303 C A
22 17071770 16590880 G C
```

Check documentation updates in http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/online/input.html