### PR TITLE
HGNC doc fix

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1270,7 +1270,7 @@ host          useastdb.ensembl.org</pre>
       <td><pre>--symbol</pre></td>
       <td>&nbsp;</td>
       <td>
-        Adds the gene symbol (e.g. HGNC) (where available) to the output. Some gene symbol, e.g. HGNC, are only available in merged cache and therefore should be used with <a href="#opt_merged">--merged</a> option while using cache to get result.  
+        Adds the gene symbol (e.g. HGNC) (where available) to the output. Some gene symbol, e.g. HGNC, are only available in merged and Ensembl caches and therefore should therefore <b>not</b> be used with the <a href="#opt_refseq">--refseq</a> cache option.  
         <i>Not used by default</i>
       </td>
       <td>SYMBOL, SYMBOL_SOURCE, HGNC_ID</td>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1270,7 +1270,7 @@ host          useastdb.ensembl.org</pre>
       <td><pre>--symbol</pre></td>
       <td>&nbsp;</td>
       <td>
-        Adds the gene symbol (e.g. HGNC) (where available) to the output. Some gene symbol, e.g. HGNC, are only available in merged and Ensembl caches and therefore should therefore <b>not</b> be used with the <a href="#opt_refseq">--refseq</a> cache option.  
+        Adds the gene symbol (e.g. HGNC) (where available) to the output. Some gene symbol, e.g. HGNC, are only available in merged and Ensembl caches and therefore should <b>not</b> be used with the <a href="#opt_refseq">--refseq</a> cache option.  
         <i>Not used by default</i>
       </td>
       <td>SYMBOL, SYMBOL_SOURCE, HGNC_ID</td>


### PR DESCRIPTION
Some slightly incorrect text for symbols option, expanded to specify that ensembl or merged cache is fine (but not refseq).