### PR TITLE
VEP cached jobdata - refrain submitting plugin/custom unless matched species (e113)

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -499,7 +499,7 @@ sub _build_variants_frequency_data {
 
     foreach my $sp (keys %{$frequency_species_data}) {
       if (lc($sp) eq 'homo_sapiens'){
-        $human_frequency_from_custom = $frequency_species_data->{$sp};
+        push @{$human_frequency_from_custom}, $frequency_species_data->{$sp};
         next;
       }
 

--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -166,6 +166,7 @@ sub _configure_plugins {
     $pl_key =~ s/^plugin\_//;
     my $plugin = $plugin_config{$pl_key};
     next unless $plugin;
+    next if $plugin->{species} && !grep(/^$job_data->{'species'}$/, map { ucfirst $_ } @{$plugin->{species}});
     
     my @params;
     
@@ -290,6 +291,7 @@ sub _configure_custom_annotations {
     $cu_key =~ s/^custom\_//;
     my $custom_ann = $custom_config{$cu_key};
     next unless $custom_ann;
+    next if $custom_ann->{species} && !grep(/^$job_data->{'species'}$/, map { ucfirst $_ } @{ref $custom_ann->{species} eq 'ARRAY' ? $custom_ann->{species} : [$custom_ann->{species}]});
 
     my $params = $custom_ann->{params};
 

--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -166,7 +166,7 @@ sub _configure_plugins {
     $pl_key =~ s/^plugin\_//;
     my $plugin = $plugin_config{$pl_key};
     next unless $plugin;
-    next if $plugin->{species} && !grep(/^$job_data->{'species'}$/, map { ucfirst $_ } @{$plugin->{species}});
+    next if $plugin->{species} && !grep(/^$job_data->{'species'}$/i, @{$plugin->{species}});
     
     my @params;
     

--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -291,7 +291,7 @@ sub _configure_custom_annotations {
     $cu_key =~ s/^custom\_//;
     my $custom_ann = $custom_config{$cu_key};
     next unless $custom_ann;
-    next if $custom_ann->{species} && !grep(/^$job_data->{'species'}$/, map { ucfirst $_ } @{ref $custom_ann->{species} eq 'ARRAY' ? $custom_ann->{species} : [$custom_ann->{species}]});
+    next if $custom_ann->{species} && !grep(/^$job_data->{'species'}$/i, @{ref $custom_ann->{species} eq 'ARRAY' ? $custom_ann->{species} : [$custom_ann->{species}]});
 
     my $params = $custom_ann->{params};
 


### PR DESCRIPTION
### Background

Subsequent VEP job retains job data from previous job in the same session. It probably is an old business rule to retain the options the user selected previously to give better experience.

It becomes a problem if the subsequent job is run on different species. The job data can retain information about features that the species does not have. For example in the following run on rainbow tout -
http://www.ensembl.org/Oncorhynchus_mykiss/Tools/VEP/Results?tl=bpeS1USpYURvU7l3-10317182 

the job data retained information about frequency options used in previous run using goat. That is why we are seeing frequency headers in the output even though user did not select any frequency option (in fact there was no frequency option).

This is an old issue, and also affects the _**plugins**_.

### Fix
Check if species match using the plugins and custom config before adding config options when parsing the job data. 

### Test
sandbox url - http://wp-np2-11.ebi.ac.uk:7070/

- Run a species with some features on (plugins / custom options), e.g. - frequency in goat.
- Run another species which does not have those options and make sure those options does not appear in the command and in the header, e.g. - frequency in rainbow, trout.


NB:
Added a bugfix for human custom frequency. It does have any use case currently as we do not have any custom frequency data set for human.