### PR TITLE
Add Paralogues plugin to web VEP (e113)

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/online/input.html
+++ b/docs/htdocs/info/docs/tools/vep/online/input.html
@@ -274,6 +274,13 @@ enter your data and alter various options.</p>
                     <p>Variants flagged as failed by the Ensembl Variation quality control.</p>
                 </li>
 
+                <li><b>Paralogue variants</b>
+                  <p>
+                    Retrieves variants that overlap genomic coordinates corresponding to aligned amino acid positions in paralogous proteins. This functionality is provided by the
+                    <a href="https://github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/Paralogues.pm">Paralogues</a> plugin.<br />
+                  </p>
+                </li>
+
                 <li><b>Open Targets Genetics</b>
                   <p>
                     Returns locus-to-gene (L2G) scores to predict causal genes at GWAS loci from
@@ -298,6 +305,7 @@ enter your data and alter various options.</p>
             <div class="_stt_allele _stt_yes form-field"><label class="ff-label">Frequency data for co-located variants:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox" checked="checked"><label class="ff-checklist-label _ht ht">1000 Genomes global minor allele frequency</label></p><p class="ff-checklist"><input type="checkbox"><label class="ff-checklist-label ht _ht">1000 Genomes continental allele frequencies</label></p><p class="ff-checklist"><input type="checkbox"><label class="_ht ht ff-checklist-label">gnomAD (exomes) allele frequencies</label></p><p class="ff-checklist"><input type="checkbox"><label class="_ht ht ff-checklist-label">gnomAD (genomes) allele frequencies</label></p></div></div>
             <div class="form-field _stt_yes _stt_allele"><label class="ff-label"><span class="ht _ht">PubMed IDs for citations of co-located variants</span>:</label><div class="ff-right"><p class="ff-checklist"><input  type="checkbox" checked="checked"></p></div></div></div>
             <div class="form-field"><label class="ff-label"><span class="ht _ht">Include flagged variants</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="checkbox"></p></div></div>
+            <div class="form-field"><label class="ff-label"><span class="_ht ht">Paralogue variants</span>:</label><div class="ff-right"><p class="ff-checklist"><input type="radio" checked="checked" value="no"><label class="ff-checklist-label">Disabled</label></p><p class="ff-checklist"><input class="_stt plugin_enable" value="plugin_Paralogues" type="radio" name="plugin_Paralogues"><label class="ff-checklist-label">Enabled</label></p></div></div>
             <div class="form-field"><label class="ff-label"><span class="_ht ht">Open Targets Genetics</span>:</label><div class="ff-right"><p class="ff-checklist"><input class="plugin_enable _stt" type="checkbox"></p></div></div>
           </fieldset></div></div>
         </fieldset></form>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_download.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_download.html
@@ -139,6 +139,10 @@ cd ensembl-vep-release-[[SPECIESDEFS::ENSEMBL_VERSION]]/</pre>
         <li><a href="//github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/REVEL.pm" rel="external">REVEL</a></li>
         <li><a href="//github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/ClinPred.pm" rel="external">ClinPred</a></li>
       </ul>
+      <li>Plugin support added to Web for: </li>
+      <ul>
+        <li><a href="//github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/Paralogues.pm" rel="external">Paralogues</a></li>
+      </ul>
       <li>Plugin data version updated for CADD (v1.6 to v1.7) and dbNSFP (4.5c to 4.7c).</li>
 
   </ul>

--- a/tools/conf/vep_plugins_web_config.txt
+++ b/tools/conf/vep_plugins_web_config.txt
@@ -100,4 +100,7 @@
   ClinPred => {
     "available" => 1
   },
+  Paralogues => {
+    "available" => 1
+  },
 }

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -161,6 +161,7 @@
   Paralogues => {
     "params" => [
       "matches=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/Paralogues/Paralogues.pm_homo_sapiens_113_ClinVar_20240819.tsv.gz",
+      "fields=identifier:alleles:clinical_significance:chromosome:start",
       "@*"
     ]
   },

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -158,4 +158,10 @@
       "file=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/ClinPred/ClinPred_hg38_sorted_tabbed.tsv.gz"
     ]
   },
+  Paralogues => {
+    "params" => [
+      "matches=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/Paralogues/Paralogues.pm_homo_sapiens_113_ClinVar_20240819.tsv.gz",
+      "@*"
+    ]
+  },
 }


### PR DESCRIPTION
[ENSVAR-6290](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6290)

## Testing

Test in my sandbox:
- Documentation changes:
    - [Web VEP input docs](http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/online/input.html#freq)
    - [What's new in VEP](http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/online/download.html#new)
- [Web VEP](http://wp-np2-11.ebi.ac.uk:6070/Multi/Tools/VEP?db=core)
- [Results example](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?from=1;size=12;tl=NmXCXfSwVTsg7glP-23;to=12)

In web VEP, you can test with the following variants (not all chromosomes are available in my sandbox):
```
1 18108132 . A T
11 99556218 . G C
19 110682 . T G
20 87737 . C G
20 325925 . A T
22 15528369 . T G
22 15528390 . T G
22 15528213 . A C
22 15528195 . T G
X 630901 . A T
X 630907 . T C
X 1190999 . T C
```