### PR TITLE
Add missing perl library dependencies needed to run VEP (e114)

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_download.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_download.html
@@ -1393,7 +1393,7 @@ echo 'export PERL5LIB=${PERL5LIB}:##PATH_TO##/bioperl-1.6.924' >> ~/.bash_profil
 
   <p>Installing the following Perl modules with cpanm will allow for full VEP functionality:</p>
 
-  <pre class="code sh_sh">cpanm Test::Differences Test::Exception Test::Perl::Critic Archive::Zip PadWalker Error Devel::Cycle Role::Tiny::With Module::Build
+  <pre class="code sh_sh">cpanm Test::Differences Test::Exception Test::Perl::Critic Archive::Zip PadWalker Error Devel::Cycle Role::Tiny::With Module::Build LWP List::MoreUtils
 
 export DYLD_LIBRARY_PATH=/usr/local/mysql/lib/:$DYLD_LIBRARY_PATH</pre>
 


### PR DESCRIPTION
We have added the following libraries in our API code at some point is previous releases -
-[ LWP::Simple](https://github.com/Ensembl/ensembl-vep/blob/31a3581b84495b617b2f3980da6c6313ca6d238f/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm#L73)
-[ List::MoreUtils](https://github.com/Ensembl/ensembl-vep/blob/31a3581b84495b617b2f3980da6c6313ca6d238f/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm#L82)
We should add them to the dependency list in the installation instruction in the public docs