### PR TITLE
Add LOEUF plugin update in vep what's new (e113)

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_download.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_download.html
@@ -143,6 +143,10 @@ cd ensembl-vep-release-[[SPECIESDEFS::ENSEMBL_VERSION]]/</pre>
       <ul>
         <li><a href="//github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/Paralogues.pm" rel="external">Paralogues</a></li>
       </ul>
+      <li>Plugin support added to REST for: </li>
+      <ul>
+        <li><a href="//github.com/Ensembl/VEP_plugins/blob/release/[[SPECIESDEFS::ENSEMBL_VERSION]]/LOEUF.pm" rel="external">LOEUF</a></li>
+      </ul>
       <li>Plugin data version updated for CADD (v1.6 to v1.7) and dbNSFP (4.5c to 4.7c).</li>
 
   </ul>


### PR DESCRIPTION
link: http://wp-np2-11.ebi.ac.uk:7070/info/docs/tools/vep/script/vep_download.html#new (ignore the version)