### PR TITLE
Remove sheep texel from web VEP

### DIFF
--- a/tools/modules/EnsEMBL/Web/JSONServer/Tools/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/JSONServer/Tools/VEP.pm
@@ -31,6 +31,8 @@ sub json_fetch_species {
   my $self = shift;
   my $hub = $self->hub;
   $self->{species_selector_data} = $self->getSpeciesSelectorData();
+  # temp fix added in e113 to remove sheep texel from VEP tool in web
+  $self->{species_selector_data}->{'available_species'}->{'Ovis_aries_texel'} = 0;
   $self->{species_selector_data}->{internal_node_select} = 0;
   my @dyna_tree = $self->create_tree();
   return { json => \@dyna_tree };


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/ENSINT-2018

sandbox url - http://wp-np2-11.ebi.ac.uk:7070/Tools/VEP - check sheep texel not available in species list.
