### PR TITLE
Fix Mouse strain genome config for e114

### DIFF
--- a/ensembl/conf/ini-files/mus_musculus_lpj.ini
+++ b/ensembl/conf/ini-files/mus_musculus_lpj.ini
@@ -11,7 +11,7 @@
 #################
 [general]
 
-SPECIES_RELEASE_VERSION = 2
+SPECIES_RELEASE_VERSION = 1
 
 # Assembly info
 JAX_ID        = 000676

--- a/ensembl/conf/ini-files/mus_musculus_nzohlltj.ini
+++ b/ensembl/conf/ini-files/mus_musculus_nzohlltj.ini
@@ -14,7 +14,7 @@
 # Assembly info
 JAX_ID        = 002105
 
-SPECIES_RELEASE_VERSION = 2
+SPECIES_RELEASE_VERSION = 1
 
 DEFAULT_XREFS = [MGI_transcript_name CCDS Ensembl_Human_Transcript UniProtKB/Swiss-Prot RefSeq_peptide Fantom PDB]
 


### PR DESCRIPTION
This PR comes with my apologies.

[public-plugins PR 838](https://github.com/Ensembl/public-plugins/pull/838) included two errors: one in the configuration of Mouse strain LP/J, the other in the configuration of Mouse strain NZO/HlLtJ.

This PR would fix both configuration errors.

Examples:
- Mouse LP/J: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus_LP_J/Info/Index) vs [staging](https://staging.ensembl.org/Mus_musculus_LP_J/Info/Index)
- Mouse NZO/HlLtJ: [sandbox](http://wp-np2-25.ebi.ac.uk:5092/Mus_musculus_NZO_HlLtJ/Info/Index) vs [staging](https://staging.ensembl.org/Mus_musculus_NZO_HlLtJ/Info/Index)


