### PR TITLE
Tools hive: LSF to Slurm migration

### DIFF
--- a/tools_hive/conf/SiteDefs.pm
+++ b/tools_hive/conf/SiteDefs.pm
@@ -102,7 +102,7 @@ sub update_conf {
   # VEP configs
   $SiteDefs::ENSEMBL_VEP_RUN_LOCAL              = 1;                                                # Flag if on, will run VEP jobs on LOCAL meadow
   $SiteDefs::ENSEMBL_VEP_QUEUE                  = 'highpri';                                        # farm or LOCAL queue for VEP jobs
-  $SiteDefs::ENSEMBL_VEP_FARM_TIMEOUT           = '3:00';                                           # Max timelimit a VEP job is allowed to run on farm
+  $SiteDefs::ENSEMBL_VEP_FARM_TIMEOUT           = '03:00:00';                                       # Max timelimit a VEP job is allowed to run on farm in HH::MM::SS
   $SiteDefs::ENSEMBL_VEP_MEMORY_USAGE           = 8;                                                # Memory in GBs required for VEP jobs
   $SiteDefs::ENSEMBL_VEP_ANALYSIS_CAPACITY      = 500;                                              # Number of jobs that can be run parallel in the VEP queue (farm or LOCAL)
   $SiteDefs::ENSEMBL_VEP_CACHE_DIR              = "/path/to/vep/cache";                             # path to vep cache files

--- a/tools_hive/conf/SiteDefs.pm
+++ b/tools_hive/conf/SiteDefs.pm
@@ -22,7 +22,7 @@ package EnsEMBL::Tools_hive::SiteDefs;
 ### tools_hive plugin is a backend for running the ensembl tools jobs (BLAST, BLAT, VEP etc) using ensembl-hive.
 ### With this plugin, the jobs that are submitted by the website (via the tools plugin) are saved in the
 ### ENSEMBL_WEB_HIVE db and another process called 'beekeeper' (that could possibly be running on a different
-### machine) continually looks at that database, runs the newly submitted jobs on LSF farm or on
+### machine) continually looks at that database, runs the newly submitted jobs on the farm or on
 ### the local machine (LOCAL) where this process itself is running.
 
 use strict;
@@ -52,7 +52,7 @@ sub update_conf {
                                                     'VR'                => 'Hive',
                                                   };                                                # Overriding tools plugin variable
   $SiteDefs::ENSEMBL_HIVE_HOSTS                 = [];                                               # For LOCAL, the machine that runs the beekeeper unless it's same as the web server
-                                                                                                    # For LSF, list of hosts corresponding to the queues for all jobs plus the machine where
+                                                                                                    # For farm, list of hosts corresponding to the queues for all jobs plus the machine where
                                                                                                     # beekeeper is running unless it's same as the web server
                                                                                                     # Leave it blank if code is located on a shared disk to share between the web server and the machine(s)
                                                                                                     # running beekeeper
@@ -81,30 +81,30 @@ sub update_conf {
 
   # BLAST configs
   $SiteDefs::ENSEMBL_BLAST_RUN_LOCAL            = 1;                                                # Flag if on, will run blast jobs on LOCAL meadow
-  $SiteDefs::ENSEMBL_BLAST_QUEUE                = 'highpri';                                        # LSF or LOCAL queue for blast jobs
-  $SiteDefs::ENSEMBL_BLAST_LSF_TIMEOUT          = undef;                                            # Max timelimit a blast job is allowed to run on LSF
+  $SiteDefs::ENSEMBL_BLAST_QUEUE                = 'highpri';                                        # farm or LOCAL queue for blast jobs
+  $SiteDefs::ENSEMBL_BLAST_FARM_TIMEOUT         = undef;                                            # Max timelimit a blast job is allowed to run on farm
   $SiteDefs::ENSEMBL_BLAST_MEMORY_USAGE         = 8;                                                # Memory in GBs required for Blast jobs
-  $SiteDefs::ENSEMBL_BLAST_ANALYSIS_CAPACITY    = 500;                                              # Number of jobs that can be run parallel in the blast queue (LSF or LOCAL)
-  $SiteDefs::ENSEMBL_NCBIBLAST_BIN_PATH         = '/path/to/ncbi-blast/bin';                        # path to blast executables on the LSF host (or local machine if job running locally)
-  $SiteDefs::ENSEMBL_NCBIBLAST_DATA_PATH        = "/path/to/genes";                                 # path for the blast index files (other than DNA) on the LSF host (or local machine if job running locally)
-  $SiteDefs::ENSEMBL_NCBIBLAST_DATA_PATH_DNA    = "/path/to/blast/dna";                             # path for the blast DNA index files on the LSF host (or local machine if job running locally)
-  $SiteDefs::ENSEMBL_REPEATMASK_BIN_PATH        = '/path/to/RepeatMasker';                          # path to RepeatMasker executable on the  LSF host (or local machine if job running locally)
+  $SiteDefs::ENSEMBL_BLAST_ANALYSIS_CAPACITY    = 500;                                              # Number of jobs that can be run parallel in the blast queue (farm or LOCAL)
+  $SiteDefs::ENSEMBL_NCBIBLAST_BIN_PATH         = '/path/to/ncbi-blast/bin';                        # path to blast executables on the farm host (or local machine if job running locally)
+  $SiteDefs::ENSEMBL_NCBIBLAST_DATA_PATH        = "/path/to/genes";                                 # path for the blast index files (other than DNA) on the farm host (or local machine if job running locally)
+  $SiteDefs::ENSEMBL_NCBIBLAST_DATA_PATH_DNA    = "/path/to/blast/dna";                             # path for the blast DNA index files on the farm host (or local machine if job running locally)
+  $SiteDefs::ENSEMBL_REPEATMASK_BIN_PATH        = '/path/to/RepeatMasker';                          # path to RepeatMasker executable on the  farm host (or local machine if job running locally)
 
   # BLAT configs
   $SiteDefs::ENSEMBL_BLAT_RUN_LOCAL             = 1;                                                # Flag if on, will run blat jobs on LOCAL meadow
-  $SiteDefs::ENSEMBL_BLAT_QUEUE                 = 'highpri';                                        # LSF or LOCAL queue for blat jobs
-  $SiteDefs::ENSEMBL_BLAT_LSF_TIMEOUT           = undef;                                            # Max timelimit a blat job is allowed to run on LSF
-  $SiteDefs::ENSEMBL_BLAT_MEMORY_USAGE          = undef;                                            # Memory in GBs required for Blat jobs (undef for default LSF limit)
-  $SiteDefs::ENSEMBL_BLAT_ANALYSIS_CAPACITY     = 500;                                              # Number of jobs that can be run parallel in the blat queue (LSF or LOCAL)
-  $SiteDefs::ENSEMBL_BLAT_TWOBIT_DIR            = "/path/to/blat/twobit";                           # location where blat twobit files are located on LSF node (or local machine if job running locally)
+  $SiteDefs::ENSEMBL_BLAT_QUEUE                 = 'highpri';                                        # farm or LOCAL queue for blat jobs
+  $SiteDefs::ENSEMBL_BLAT_FARM_TIMEOUT          = undef;                                            # Max timelimit a blat job is allowed to run on farm
+  $SiteDefs::ENSEMBL_BLAT_MEMORY_USAGE          = undef;                                            # Memory in GBs required for Blat jobs (undef for default farm limit)
+  $SiteDefs::ENSEMBL_BLAT_ANALYSIS_CAPACITY     = 500;                                              # Number of jobs that can be run parallel in the blat queue (farm or LOCAL)
+  $SiteDefs::ENSEMBL_BLAT_TWOBIT_DIR            = "/path/to/blat/twobit";                           # location where blat twobit files are located on farm node (or local machine if job running locally)
   $SiteDefs::ENSEMBL_BLAT_QUERY_COMMAND         = '/path/to/command [SPECIES].[ASSEMBLY]';          # optional command line that returns server:port for BLAT server for a given species and assembly
 
   # VEP configs
   $SiteDefs::ENSEMBL_VEP_RUN_LOCAL              = 1;                                                # Flag if on, will run VEP jobs on LOCAL meadow
-  $SiteDefs::ENSEMBL_VEP_QUEUE                  = 'highpri';                                        # LSF or LOCAL queue for VEP jobs
-  $SiteDefs::ENSEMBL_VEP_LSF_TIMEOUT            = '3:00';                                           # Max timelimit a VEP job is allowed to run on LSF
+  $SiteDefs::ENSEMBL_VEP_QUEUE                  = 'highpri';                                        # farm or LOCAL queue for VEP jobs
+  $SiteDefs::ENSEMBL_VEP_FARM_TIMEOUT           = '3:00';                                           # Max timelimit a VEP job is allowed to run on farm
   $SiteDefs::ENSEMBL_VEP_MEMORY_USAGE           = 8;                                                # Memory in GBs required for VEP jobs
-  $SiteDefs::ENSEMBL_VEP_ANALYSIS_CAPACITY      = 500;                                              # Number of jobs that can be run parallel in the VEP queue (LSF or LOCAL)
+  $SiteDefs::ENSEMBL_VEP_ANALYSIS_CAPACITY      = 500;                                              # Number of jobs that can be run parallel in the VEP queue (farm or LOCAL)
   $SiteDefs::ENSEMBL_VEP_CACHE_DIR              = "/path/to/vep/cache";                             # path to vep cache files
   $SiteDefs::ENSEMBL_VEP_FASTA_DIR              = "/path/to/fasta/files";                           # path to bgzipped & indexed FASTA files for use by VEP
   $SiteDefs::ENSEMBL_VEP_SCRIPT_DEFAULT_OPTIONS = {                                                 # Default options for command line vep script (keys with value undef get ignored)
@@ -115,21 +115,21 @@ sub update_conf {
     'fork'        => 4,                                                                             # Enable forking, using 4 forks
   };
 
-  $SiteDefs::ENSEMBL_VEP_PLUGIN_DATA_DIR        = "/path/to/vep/plugin_data";                       # path to vep plugin data files on the LSF host (or local machine if job running locally)
+  $SiteDefs::ENSEMBL_VEP_PLUGIN_DATA_DIR        = "/path/to/vep/plugin_data";                       # path to vep plugin data files on the farm host (or local machine if job running locally)
   $SiteDefs::ENSEMBL_VEP_PLUGIN_DIR             = "VEP_plugins";                                    # path to vep plugin code (if does not start with '/', it's treated relative to ENSEMBL_HIVE_HOSTS_CODE_LOCATION)
 
   push @{$SiteDefs::ENSEMBL_VEP_PLUGIN_CONFIG_FILES}, $SiteDefs::ENSEMBL_SERVERROOT.'/public-plugins/tools_hive/conf/vep_plugins_hive_config.txt';
                                                                                                     # add extra hive specific configs required to run vep plugins
   # LD configs
   $SiteDefs::ENSEMBL_LD_RUN_LOCAL              = 1;                                                # Flag if on, will run LD jobs on LOCAL meadow
-  $SiteDefs::ENSEMBL_LD_QUEUE                  = 'highpri';                                        # LSF or LOCAL queue for LD jobs
-  $SiteDefs::ENSEMBL_LD_LSF_TIMEOUT            = undef;                                            # Max timelimit a LD job is allowed to run on LSF
-  $SiteDefs::ENSEMBL_LD_ANALYSIS_CAPACITY      = 500;                                              # Number of jobs that can be run parallel in the LD queue (LSF or LOCAL)
+  $SiteDefs::ENSEMBL_LD_QUEUE                  = 'highpri';                                        # farm or LOCAL queue for LD jobs
+  $SiteDefs::ENSEMBL_LD_FARM_TIMEOUT           = undef;                                            # Max timelimit a LD job is allowed to run on farm
+  $SiteDefs::ENSEMBL_LD_ANALYSIS_CAPACITY      = 500;                                              # Number of jobs that can be run parallel in the LD queue (farm or LOCAL)
 
   # Variant Recoder configs
   $SiteDefs::ENSEMBL_VR_RUN_LOCAL              = 1;
   $SiteDefs::ENSEMBL_VR_QUEUE                  = 'highpri';
-  $SiteDefs::ENSEMBL_VR_LSF_TIMEOUT            = undef;
+  $SiteDefs::ENSEMBL_VR_FARM_TIMEOUT           = undef;
   $SiteDefs::ENSEMBL_VR_ANALYSIS_CAPACITY      = 500;
   $SiteDefs::ENSEMBL_VR_SCRIPT_DEFAULT_OPTIONS = {
     'host'        => undef,
@@ -140,9 +140,9 @@ sub update_conf {
 
   # Assembly Converter configs
   $SiteDefs::ENSEMBL_AC_RUN_LOCAL               = 1;                                                # Flag if on, will run AC jobs on LOCAL meadow
-  $SiteDefs::ENSEMBL_AC_QUEUE                   = 'highpri';                                        # LSF or LOCAL queue for AC jobs
-  $SiteDefs::ENSEMBL_AC_LSF_TIMEOUT             = undef;                                            # Max timelimit an AC job is allowed to run on LSF
-  $SiteDefs::ENSEMBL_AC_ANALYSIS_CAPACITY       = 500;                                              # Number of jobs that can be run parallel in the queue (LSF or LOCAL)
+  $SiteDefs::ENSEMBL_AC_QUEUE                   = 'highpri';                                        # farm or LOCAL queue for AC jobs
+  $SiteDefs::ENSEMBL_AC_FARM_TIMEOUT            = undef;                                            # Max timelimit an AC job is allowed to run on farm
+  $SiteDefs::ENSEMBL_AC_ANALYSIS_CAPACITY       = 500;                                              # Number of jobs that can be run parallel in the queue (farm or LOCAL)
   $SiteDefs::ENSEMBL_CHAIN_FILE_DIR             = '/path/to/assembly_converter/chain_files';        # path to chain files as required by assembly converter
   $SiteDefs::ASSEMBLY_CONVERTER_BIN_PATH        = '/path/to/CrossMap.py';                           # path to CrossMap
   $SiteDefs::WIGTOBIGWIG_BIN_PATH               = '/path/to/wigToBigWig';                           # path to wigToBigWig (required by CrossMap)
@@ -150,17 +150,17 @@ sub update_conf {
 
   # ID History converter configs
   $SiteDefs::ENSEMBL_IDM_RUN_LOCAL              = 1;                                                # Flag if on, will run ID mapper jobs on LOCAL meadow
-  $SiteDefs::ENSEMBL_IDM_QUEUE                  = 'highpri';                                        # LSF or LOCAL queue for ID mapper jobs
-  $SiteDefs::ENSEMBL_IDM_LSF_TIMEOUT            = undef;                                            # Max timelimit an ID mapper job is allowed to run on LSF
+  $SiteDefs::ENSEMBL_IDM_QUEUE                  = 'highpri';                                        # farm or LOCAL queue for ID mapper jobs
+  $SiteDefs::ENSEMBL_IDM_FARM_TIMEOUT           = undef;                                            # Max timelimit an ID mapper job is allowed to run on farm
   $SiteDefs::ENSEMBL_IDM_MEMORY_USAGE           = 6;                                                # Memory in GBs required for IDMapper jobs
-  $SiteDefs::ENSEMBL_IDM_ANALYSIS_CAPACITY      = 500;                                              # Number of jobs that can be run parallel in the queue (LSF or LOCAL)
+  $SiteDefs::ENSEMBL_IDM_ANALYSIS_CAPACITY      = 500;                                              # Number of jobs that can be run parallel in the queue (farm or LOCAL)
   $SiteDefs::IDMAPPER_SCRIPT                    = 'ensembl-tools/scripts/id_history_converter/IDmapper.pl';
                                                                                                     # Path to ID History converter script
 
   # File Chameleon configs
   $SiteDefs::ENSEMBL_FC_RUN_LOCAL              = 1;
   $SiteDefs::ENSEMBL_FC_QUEUE                  = 'highpri';
-  $SiteDefs::ENSEMBL_FC_LSF_TIMEOUT            = undef;                                            
+  $SiteDefs::ENSEMBL_FC_FARM_TIMEOUT           = undef;                                            
   $SiteDefs::ENSEMBL_FC_ANALYSIS_CAPACITY      = 500;
 
   # Allele Frequency configs

--- a/tools_hive/modules/EnsEMBL/Web/JobDispatcher/Hive.pm
+++ b/tools_hive/modules/EnsEMBL/Web/JobDispatcher/Hive.pm
@@ -43,7 +43,7 @@ sub dispatch_job {
     my $hive_dba    = $self->_hive_dba;
     my $job_adaptor = $self->_job_adaptor;
 
-    $self->{'_analysis'}{$logic_name} ||= $hive_dba->get_AnalysisAdaptor->fetch_by_logic_name_or_url($logic_name);
+    $self->{'_analysis'}{$logic_name} ||= $hive_dba->get_AnalysisAdaptor->fetch_by_logic_name($logic_name);
 
     # Submit job to hive db
     my $hive_job = Bio::EnsEMBL::Hive::AnalysisJob->new(
@@ -72,7 +72,7 @@ sub delete_jobs {
 
 #   if (@hive_job_ids) {
 #     $self->_job_adaptor->remove_all(sprintf '`job_id` in (%s)', join(',', @hive_job_ids));
-#     $hive_dba->get_Queen->safe_synchronize_AnalysisStats($hive_dba->get_AnalysisAdaptor->fetch_by_logic_name_or_url($logic_name)->stats);
+#     $hive_dba->get_Queen->safe_synchronize_AnalysisStats($hive_dba->get_AnalysisAdaptor->fetch_by_logic_name($logic_name)->stats);
 #   }
 }
 

--- a/tools_hive/modules/EnsEMBL/Web/RunnableDB/VEP.pm
+++ b/tools_hive/modules/EnsEMBL/Web/RunnableDB/VEP.pm
@@ -45,7 +45,7 @@ sub run {
   my $work_dir        = $self->param('work_dir');
   my $config          = $self->param('config');
   my $options         = $self->param('script_options') || {};
-  my $log_file        = "$work_dir/lsf_log.txt";
+  my $log_file        = "$work_dir/farm_log.txt";
 
   # path for VEP_plugins (gets pushed to INC by VEP::Runner)
   if (my $plugins_path = $self->param('plugins_path')) {

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
@@ -65,13 +65,14 @@ sub _format_resource_class {
   return { 'LOCAL' => '' } unless $class->is_farm;
 
   my $queue   = $class->queue_name;
+  my $partition = $queue ? "--partition=$queue" : "";
   my $timeout = $class->farm_timeout;
   my $memory  = $class->memory_usage;
   my $default_timeout = '1-00:00:00'; # Days-HH::MM::SS
   $timeout ||= $default_timeout;
   $memory  = $memory  ? sprintf('%s', $memory * 1024) : '1600';
 
-  return { 'SLURM' => sprintf(" --time=%s  --mem=%s%s -n 8 -N 1", %timeout, $memory, 'm') };
+  return { 'SLURM' => sprintf("$partition --time=%s  --mem=%s%s -n 8 -N 1", $timeout, $memory, 'm') };
 }
 
 sub _resource_class_name {

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
@@ -67,11 +67,11 @@ sub _format_resource_class {
   my $queue   = $class->queue_name;
   my $timeout = $class->farm_timeout;
   my $memory  = $class->memory_usage;
-  
-  $timeout = $timeout ? " -W $timeout" : '';
+  my $default_timeout = '1-00:00:00'; # Days-HH::MM::SS
+  $timeout ||= $default_timeout;
   $memory  = $memory  ? sprintf('%s', $memory * 1024) : '1600';
 
-  return { 'SLURM' => sprintf(" --time=1-00:00:00  --mem=%s%s -n 8 -N 1", $memory, 'm') };
+  return { 'SLURM' => sprintf(" --time=%s  --mem=%s%s -n 8 -N 1", %timeout, $memory, 'm') };
 }
 
 sub _resource_class_name {

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
@@ -73,7 +73,7 @@ sub _format_resource_class {
 
 # 'SLURM' => ' --partition=standard --time=1-00:00:00  --mem=16000m -n 8 -N 1'},
 
-  return { 'SLURM' => " --partition=standard --time=1-00:00:00  --mem=16000m -n 8 -N 1" };
+  return { 'SLURM' => " --time=1-00:00:00  --mem=16000m -n 8 -N 1" };
 }
 
 sub _resource_class_name {

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
@@ -31,7 +31,7 @@ sub logic_name        :Abstract;
 sub runnable          :Abstract;
 sub queue_name        :Abstract;
 sub is_farm           :Abstract;
-sub lsf_timeout       :Abstract;
+sub farm_timeout       :Abstract;
 sub memory_usage      :Abstract;
 sub analysis_capacity :Abstract;
 
@@ -65,7 +65,7 @@ sub _format_resource_class {
   return { 'LOCAL' => '' } unless $class->is_farm;
 
   my $queue   = $class->queue_name;
-  my $timeout = $class->lsf_timeout;
+  my $timeout = $class->farm_timeout;
   my $memory  = $class->memory_usage;
   
   $timeout = $timeout ? " -W $timeout" : '';
@@ -79,7 +79,7 @@ sub _resource_class_name {
   my $class   = shift;
   my $rc      = $class->_format_resource_class;
   my $queue   = $class->queue_name || '';
-  my $timeout = ($class->lsf_timeout || '') =~ s/\:.+$//r;
+  my $timeout = ($class->farm_timeout || '') =~ s/\:.+$//r;
   my $memory  = $class->memory_usage || '';
   my $str     = sprintf('%s %s%s %s%s ', $queue, $timeout ? 'T' : '', $timeout, $memory ? 'M' : '', $memory) =~ s/\W+/-/gr;
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig.pm
@@ -52,7 +52,7 @@ sub pipeline_analyses {
     '-parameters'           => {},
     '-rc_name'              => $class->_resource_class_name,
     '-analysis_capacity'    => $class->analysis_capacity || 500,
-    '-meadow_type'          => $class->is_lsf ? 'LSF' : 'LOCAL',
+    '-meadow_type'          => $class->is_lsf ? 'SLURM' : 'LOCAL',
     '-max_retry_count'      => 0,
     '-failed_job_tolerance' => 100
   }];
@@ -67,11 +67,13 @@ sub _format_resource_class {
   my $queue   = $class->queue_name;
   my $timeout = $class->lsf_timeout;
   my $memory  = $class->memory_usage;
-
+  
   $timeout = $timeout ? " -W $timeout" : '';
   $memory  = $memory  ? sprintf(' -M %s -R "rusage[mem=%1$s]"', $memory * 1024) : '';
 
-  return { 'LSF' => "-q $queue$timeout$memory" };
+# 'SLURM' => ' --partition=standard --time=1-00:00:00  --mem=16000m -n 8 -N 1'},
+
+  return { 'SLURM' => " --partition=standard --time=1-00:00:00  --mem=16000m -n 8 -N 1" };
 }
 
 sub _resource_class_name {
@@ -81,7 +83,8 @@ sub _resource_class_name {
   my $queue   = $class->queue_name || '';
   my $timeout = ($class->lsf_timeout || '') =~ s/\:.+$//r;
   my $memory  = $class->memory_usage || '';
-  my $str     = sprintf('%s %s%s %s%s ', $queue, $timeout ? 'W' : '', $timeout, $memory ? 'M' : '', $memory) =~ s/\W+/-/gr;
+  # my $str     = sprintf('%s %s%s %s%s ', $queue, $timeout ? 'W' : '', $timeout, $memory ? 'M' : '', $memory) =~ s/\W+/-/gr;
+  my $str     = "standard-T1-M16-";
 
   return sprintf '%s%s', $str, substr(md5_hex(join(' ', %$rc)), 0, 4);
 }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/AlleleFrequency.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/AlleleFrequency.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'AlleleFrequency'                           }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::AlleleFrequency' }
 sub queue_name        { $SiteDefs::ENSEMBL_AF_QUEUE                 }
 sub is_farm           { !$SiteDefs::ENSEMBL_AF_RUN_LOCAL            }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_AF_LSF_TIMEOUT           }
+sub farm_timeout       { $SiteDefs::ENSEMBL_AF_FARM_TIMEOUT          }
 sub memory_usage      { $SiteDefs::ENSEMBL_AF_MEMORY_USAGE          }
 sub analysis_capacity { $SiteDefs::ENSEMBL_AF_ANALYSIS_CAPACITY     }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/AlleleFrequency.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/AlleleFrequency.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'AlleleFrequency'                           }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::AlleleFrequency' }
 sub queue_name        { $SiteDefs::ENSEMBL_AF_QUEUE                 }
-sub is_lsf            { !$SiteDefs::ENSEMBL_AF_RUN_LOCAL            }
+sub is_farm           { !$SiteDefs::ENSEMBL_AF_RUN_LOCAL            }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_AF_LSF_TIMEOUT           }
 sub memory_usage      { $SiteDefs::ENSEMBL_AF_MEMORY_USAGE          }
 sub analysis_capacity { $SiteDefs::ENSEMBL_AF_ANALYSIS_CAPACITY     }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/AssemblyConverter.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/AssemblyConverter.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'AssemblyConverter'                           }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::AssemblyConverter' }
 sub queue_name        { $SiteDefs::ENSEMBL_AC_QUEUE                   }
-sub is_lsf            { !$SiteDefs::ENSEMBL_AC_RUN_LOCAL              }
+sub is_farm           { !$SiteDefs::ENSEMBL_AC_RUN_LOCAL              }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_AC_LSF_TIMEOUT             }
 sub memory_usage      { $SiteDefs::ENSEMBL_AC_MEMORY_USAGE            }
 sub analysis_capacity { $SiteDefs::ENSEMBL_AC_ANALYSIS_CAPACITY       }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/AssemblyConverter.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/AssemblyConverter.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'AssemblyConverter'                           }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::AssemblyConverter' }
 sub queue_name        { $SiteDefs::ENSEMBL_AC_QUEUE                   }
 sub is_farm           { !$SiteDefs::ENSEMBL_AC_RUN_LOCAL              }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_AC_LSF_TIMEOUT             }
+sub farm_timeout       { $SiteDefs::ENSEMBL_AC_FARM_TIMEOUT             }
 sub memory_usage      { $SiteDefs::ENSEMBL_AC_MEMORY_USAGE            }
 sub analysis_capacity { $SiteDefs::ENSEMBL_AC_ANALYSIS_CAPACITY       }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/Blast.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/Blast.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'Blast'                                     }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::Blast'           }
 sub queue_name        { $SiteDefs::ENSEMBL_BLAST_QUEUE              }
-sub is_lsf            { !$SiteDefs::ENSEMBL_BLAST_RUN_LOCAL         }
+sub is_farm           { !$SiteDefs::ENSEMBL_BLAST_RUN_LOCAL         }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_BLAST_LSF_TIMEOUT        }
 sub memory_usage      { $SiteDefs::ENSEMBL_BLAST_MEMORY_USAGE       }
 sub analysis_capacity { $SiteDefs::ENSEMBL_BLAST_ANALYSIS_CAPACITY  }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/Blast.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/Blast.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'Blast'                                     }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::Blast'           }
 sub queue_name        { $SiteDefs::ENSEMBL_BLAST_QUEUE              }
 sub is_farm           { !$SiteDefs::ENSEMBL_BLAST_RUN_LOCAL         }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_BLAST_LSF_TIMEOUT        }
+sub farm_timeout       { $SiteDefs::ENSEMBL_BLAST_FARM_TIMEOUT        }
 sub memory_usage      { $SiteDefs::ENSEMBL_BLAST_MEMORY_USAGE       }
 sub analysis_capacity { $SiteDefs::ENSEMBL_BLAST_ANALYSIS_CAPACITY  }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/Blat.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/Blat.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'Blat'                                    }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::Blat'          }
 sub queue_name        { $SiteDefs::ENSEMBL_BLAT_QUEUE             }
 sub is_farm           { !$SiteDefs::ENSEMBL_BLAT_RUN_LOCAL        }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_BLAT_LSF_TIMEOUT       }
+sub farm_timeout       { $SiteDefs::ENSEMBL_BLAT_FARM_TIMEOUT       }
 sub memory_usage      { $SiteDefs::ENSEMBL_BLAT_MEMORY_USAGE      }
 sub analysis_capacity { $SiteDefs::ENSEMBL_BLAT_ANALYSIS_CAPACITY }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/Blat.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/Blat.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'Blat'                                    }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::Blat'          }
 sub queue_name        { $SiteDefs::ENSEMBL_BLAT_QUEUE             }
-sub is_lsf            { !$SiteDefs::ENSEMBL_BLAT_RUN_LOCAL        }
+sub is_farm           { !$SiteDefs::ENSEMBL_BLAT_RUN_LOCAL        }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_BLAT_LSF_TIMEOUT       }
 sub memory_usage      { $SiteDefs::ENSEMBL_BLAT_MEMORY_USAGE      }
 sub analysis_capacity { $SiteDefs::ENSEMBL_BLAT_ANALYSIS_CAPACITY }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/DataSlicer.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/DataSlicer.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'DataSlicer'                            }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::DataSlicer'  }
 sub queue_name        { $SiteDefs::ENSEMBL_DS_QUEUE             }
-sub is_lsf            { !$SiteDefs::ENSEMBL_DS_RUN_LOCAL        }
+sub is_farm           { !$SiteDefs::ENSEMBL_DS_RUN_LOCAL        }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_DS_LSF_TIMEOUT       }
 sub memory_usage      { $SiteDefs::ENSEMBL_DS_MEMORY_USAGE      }
 sub analysis_capacity { $SiteDefs::ENSEMBL_DS_ANALYSIS_CAPACITY }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/DataSlicer.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/DataSlicer.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'DataSlicer'                            }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::DataSlicer'  }
 sub queue_name        { $SiteDefs::ENSEMBL_DS_QUEUE             }
 sub is_farm           { !$SiteDefs::ENSEMBL_DS_RUN_LOCAL        }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_DS_LSF_TIMEOUT       }
+sub farm_timeout       { $SiteDefs::ENSEMBL_DS_FARM_TIMEOUT       }
 sub memory_usage      { $SiteDefs::ENSEMBL_DS_MEMORY_USAGE      }
 sub analysis_capacity { $SiteDefs::ENSEMBL_DS_ANALYSIS_CAPACITY }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/FileChameleon.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/FileChameleon.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'FileChameleon'                           }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::FileChameleon' }
 sub queue_name        { $SiteDefs::ENSEMBL_FC_QUEUE               }
 sub is_farm           { !$SiteDefs::ENSEMBL_FC_RUN_LOCAL          }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_FC_LSF_TIMEOUT         }
+sub farm_timeout       { $SiteDefs::ENSEMBL_FC_FARM_TIMEOUT         }
 sub memory_usage      { $SiteDefs::ENSEMBL_FC_MEMORY_USAGE        }
 sub analysis_capacity { $SiteDefs::ENSEMBL_FC_ANALYSIS_CAPACITY   }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/FileChameleon.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/FileChameleon.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'FileChameleon'                           }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::FileChameleon' }
 sub queue_name        { $SiteDefs::ENSEMBL_FC_QUEUE               }
-sub is_lsf            { !$SiteDefs::ENSEMBL_FC_RUN_LOCAL          }
+sub is_farm           { !$SiteDefs::ENSEMBL_FC_RUN_LOCAL          }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_FC_LSF_TIMEOUT         }
 sub memory_usage      { $SiteDefs::ENSEMBL_FC_MEMORY_USAGE        }
 sub analysis_capacity { $SiteDefs::ENSEMBL_FC_ANALYSIS_CAPACITY   }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/IDMapper.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/IDMapper.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'IDMapper'                                }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::IDMapper'      }
 sub queue_name        { $SiteDefs::ENSEMBL_IDM_QUEUE              }
-sub is_lsf            { !$SiteDefs::ENSEMBL_IDM_RUN_LOCAL         }
+sub is_farm           { !$SiteDefs::ENSEMBL_IDM_RUN_LOCAL         }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_IDM_LSF_TIMEOUT        }
 sub memory_usage      { $SiteDefs::ENSEMBL_IDM_MEMORY_USAGE       }
 sub analysis_capacity { $SiteDefs::ENSEMBL_IDM_ANALYSIS_CAPACITY  }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/IDMapper.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/IDMapper.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'IDMapper'                                }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::IDMapper'      }
 sub queue_name        { $SiteDefs::ENSEMBL_IDM_QUEUE              }
 sub is_farm           { !$SiteDefs::ENSEMBL_IDM_RUN_LOCAL         }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_IDM_LSF_TIMEOUT        }
+sub farm_timeout       { $SiteDefs::ENSEMBL_IDM_FARM_TIMEOUT        }
 sub memory_usage      { $SiteDefs::ENSEMBL_IDM_MEMORY_USAGE       }
 sub analysis_capacity { $SiteDefs::ENSEMBL_IDM_ANALYSIS_CAPACITY  }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/LD.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/LD.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'LD'                                      }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::LD'            }
 sub queue_name        { $SiteDefs::ENSEMBL_LD_QUEUE               }
-sub is_lsf            { !$SiteDefs::ENSEMBL_LD_RUN_LOCAL          }
+sub is_farm           { !$SiteDefs::ENSEMBL_LD_RUN_LOCAL          }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_LD_LSF_TIMEOUT         }
 sub memory_usage      { $SiteDefs::ENSEMBL_LD_MEMORY_USAGE        }
 sub analysis_capacity { $SiteDefs::ENSEMBL_LD_ANALYSIS_CAPACITY   }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/LD.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/LD.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'LD'                                      }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::LD'            }
 sub queue_name        { $SiteDefs::ENSEMBL_LD_QUEUE               }
 sub is_farm           { !$SiteDefs::ENSEMBL_LD_RUN_LOCAL          }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_LD_LSF_TIMEOUT         }
+sub farm_timeout       { $SiteDefs::ENSEMBL_LD_FARM_TIMEOUT         }
 sub memory_usage      { $SiteDefs::ENSEMBL_LD_MEMORY_USAGE        }
 sub analysis_capacity { $SiteDefs::ENSEMBL_LD_ANALYSIS_CAPACITY   }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VEP.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VEP.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'VEP'                                     }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::VEP'           }
 sub queue_name        { $SiteDefs::ENSEMBL_VEP_QUEUE              }
 sub is_farm           { !$SiteDefs::ENSEMBL_VEP_RUN_LOCAL         }
-sub farm_timeout       { $SiteDefs::ENSEMBL_VEP_FARM_TIMEOUT        }
+sub farm_timeout      { $SiteDefs::ENSEMBL_VEP_FARM_TIMEOUT       }
 sub memory_usage      { $SiteDefs::ENSEMBL_VEP_MEMORY_USAGE       }
 sub analysis_capacity { $SiteDefs::ENSEMBL_VEP_ANALYSIS_CAPACITY  }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VEP.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VEP.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'VEP'                                     }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::VEP'           }
 sub queue_name        { $SiteDefs::ENSEMBL_VEP_QUEUE              }
 sub is_farm           { !$SiteDefs::ENSEMBL_VEP_RUN_LOCAL         }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_VEP_LSF_TIMEOUT        }
+sub farm_timeout       { $SiteDefs::ENSEMBL_VEP_FARM_TIMEOUT        }
 sub memory_usage      { $SiteDefs::ENSEMBL_VEP_MEMORY_USAGE       }
 sub analysis_capacity { $SiteDefs::ENSEMBL_VEP_ANALYSIS_CAPACITY  }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VEP.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VEP.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'VEP'                                     }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::VEP'           }
 sub queue_name        { $SiteDefs::ENSEMBL_VEP_QUEUE              }
-sub is_lsf            { !$SiteDefs::ENSEMBL_VEP_RUN_LOCAL         }
+sub is_farm           { !$SiteDefs::ENSEMBL_VEP_RUN_LOCAL         }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_VEP_LSF_TIMEOUT        }
 sub memory_usage      { $SiteDefs::ENSEMBL_VEP_MEMORY_USAGE       }
 sub analysis_capacity { $SiteDefs::ENSEMBL_VEP_ANALYSIS_CAPACITY  }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VR.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VR.pm
@@ -27,7 +27,7 @@ sub logic_name        { 'VR'                                      }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::VR'           }
 sub queue_name        { $SiteDefs::ENSEMBL_VR_QUEUE              }
 sub is_farm           { !$SiteDefs::ENSEMBL_VR_RUN_LOCAL         }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_VR_LSF_TIMEOUT        }
+sub farm_timeout       { $SiteDefs::ENSEMBL_VR_FARM_TIMEOUT        }
 sub memory_usage      { $SiteDefs::ENSEMBL_VR_MEMORY_USAGE       }
 sub analysis_capacity { $SiteDefs::ENSEMBL_VR_ANALYSIS_CAPACITY  }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VR.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VR.pm
@@ -26,7 +26,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'VR'                                      }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::VR'           }
 sub queue_name        { $SiteDefs::ENSEMBL_VR_QUEUE              }
-sub is_lsf            { !$SiteDefs::ENSEMBL_VR_RUN_LOCAL         }
+sub is_farm           { !$SiteDefs::ENSEMBL_VR_RUN_LOCAL         }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_VR_LSF_TIMEOUT        }
 sub memory_usage      { $SiteDefs::ENSEMBL_VR_MEMORY_USAGE       }
 sub analysis_capacity { $SiteDefs::ENSEMBL_VR_ANALYSIS_CAPACITY  }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VariationPattern.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VariationPattern.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'VariationPattern'                            }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::VariationPattern'  }
 sub queue_name        { $SiteDefs::ENSEMBL_VPF_QUEUE                  }
 sub is_farm           { !$SiteDefs::ENSEMBL_VPF_RUN_LOCAL             }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_VPF_LSF_TIMEOUT            }
+sub farm_timeout       { $SiteDefs::ENSEMBL_VPF_FARM_TIMEOUT            }
 sub memory_usage      { $SiteDefs::ENSEMBL_VPF_MEMORY_USAGE           }
 sub analysis_capacity { $SiteDefs::ENSEMBL_VPF_ANALYSIS_CAPACITY      }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VariationPattern.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VariationPattern.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'VariationPattern'                            }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::VariationPattern'  }
 sub queue_name        { $SiteDefs::ENSEMBL_VPF_QUEUE                  }
-sub is_lsf            { !$SiteDefs::ENSEMBL_VPF_RUN_LOCAL             }
+sub is_farm           { !$SiteDefs::ENSEMBL_VPF_RUN_LOCAL             }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_VPF_LSF_TIMEOUT            }
 sub memory_usage      { $SiteDefs::ENSEMBL_VPF_MEMORY_USAGE           }
 sub analysis_capacity { $SiteDefs::ENSEMBL_VPF_ANALYSIS_CAPACITY      }

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VcftoPed.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VcftoPed.pm
@@ -30,7 +30,7 @@ sub logic_name        { 'VcftoPed'                              }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::VcftoPed'    }
 sub queue_name        { $SiteDefs::ENSEMBL_VP_QUEUE             }
 sub is_farm           { !$SiteDefs::ENSEMBL_VP_RUN_LOCAL        }
-sub lsf_timeout       { $SiteDefs::ENSEMBL_VP_LSF_TIMEOUT       }
+sub farm_timeout       { $SiteDefs::ENSEMBL_VP_FARM_TIMEOUT       }
 sub memory_usage      { $SiteDefs::ENSEMBL_VP_MEMORY_USAGE      }
 sub analysis_capacity { $SiteDefs::ENSEMBL_VP_ANALYSIS_CAPACITY }
 

--- a/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VcftoPed.pm
+++ b/tools_hive/modules/EnsEMBL/Web/ToolsPipeConfig/VcftoPed.pm
@@ -29,7 +29,7 @@ use parent qw(EnsEMBL::Web::ToolsPipeConfig);
 sub logic_name        { 'VcftoPed'                              }
 sub runnable          { 'EnsEMBL::Web::RunnableDB::VcftoPed'    }
 sub queue_name        { $SiteDefs::ENSEMBL_VP_QUEUE             }
-sub is_lsf            { !$SiteDefs::ENSEMBL_VP_RUN_LOCAL        }
+sub is_farm           { !$SiteDefs::ENSEMBL_VP_RUN_LOCAL        }
 sub lsf_timeout       { $SiteDefs::ENSEMBL_VP_LSF_TIMEOUT       }
 sub memory_usage      { $SiteDefs::ENSEMBL_VP_MEMORY_USAGE      }
 sub analysis_capacity { $SiteDefs::ENSEMBL_VP_ANALYSIS_CAPACITY }


### PR DESCRIPTION
The changes in this PR are part of switching `ensembl-hive` from version 2.2 to version 2.7, and of migration from LSF to Slurm. They include:

- Updates to `beekeeper_manager.pl` to stop it from passing arbitrary command-line options to `beekeeper.pl` (beekeeper.pl in ensembl-hive, which is the script that is eventually called, no longer allows options outside of the ones that it expects).
- Updates to `beekeeper.pl` to fix a problem when it would call itself. You will notice that the old version of `beekeeper.pl` has a `do` command, with which it calls `beekeeper.pl` in `ensembl-hive`. For some reason that remains a mystery, after we switched ensembl-hive to version 2.7, our `beekeeper.pl` (i.e. the one in the public-plugins repo) started calling itself at the `do` line instead of calling `beekeeper.pl` in `ensembl-hive`. I have updated the file to use `fork` instead of `do`.
- Updates to `ToolsPipeConfig.pm` and its subclasses to update the definition of jobs for SLURM