### PR TITLE
Add Gencode Primary Track to Region in Detail

### DIFF
--- a/genoverse/modules/EnsEMBL/Web/ImageConfig/Genoverse.pm
+++ b/genoverse/modules/EnsEMBL/Web/ImageConfig/Genoverse.pm
@@ -49,7 +49,7 @@ sub init_genoverse {
   $self->modify_configs([ map "${_}structural_variation", '', 'somatic_' ], { genoverse => { type   => 'StructuralVariation',                  threshold => 5e6   } });
   $self->modify_configs([ 'scalebar', 'ruler', 'draggable', 'info'       ], { genoverse => { remove => 1                                                          } });
   $self->modify_configs([ 'mane_select'                                  ], { display => 'off'                                                                      });
-  $self->modify_configs([ 'gencode'                                      ], { display => 'gene_label', genoverse => { type   => 'Gene'                                                     } });
+  $self->modify_configs([ 'gencode_primary'                                      ], { display => 'gene_label', genoverse => { type   => 'Gene'                                                     } });
 
   my $info = $self->get_node('information');
 


### PR DESCRIPTION
Add Gencode Primary track to Region in Detail and make it enabled by default. Users will still be able to switch/enable Gencode Basic track. I used #833 as reference when working on this.

**Release version:** 114

**Sandbox link:** http://wp-np2-1e.ebi.ac.uk:8310/Homo_sapiens/Location/View?db=core;g=ENSG00000139618;r=13:32315086-32400268

**Related PR:** https://github.com/Ensembl/ensembl-webcode/pull/1060