### PR TITLE
Update whatsnew.html

### DIFF
--- a/ensembl/htdocs/ssi/whatsnew.html
+++ b/ensembl/htdocs/ssi/whatsnew.html
@@ -1,6 +1,6 @@
 <ul>
-<li>Many new fish genomes have been added to Ensembl</li>
-<li>Population frequency data is available for chicken, dog, goat and sheep through VEP</li>
-<li>Update to our current regulation annotation. The promoters now align with the 5’ ends of known transcripts</li>
-<li>VEP will be updated to use the dbNSFP commercial data release</li>
+<li>The GENCODE Primary tag is now the default gene display in human and mouse</li>
+<li>MANE has been updated to release v1.4</li>
+<li>Rat reference genome updated from mRatBN7.2 to GRCr8</li>
+<li>New variation data from EVA release 6 is available for many species</li>
 </ul>


### PR DESCRIPTION
Hi web,

I have updated the headlines for 114:

Regulation view available for GENE-SWiTCH and AQUA-FAANG species (pig, chicken and fish) MANE has been updated to release v1.4
Rat reference genome updated from mRatBN7.2 to GRCr8 New variation data from EVA release 6 is available for many species