### PR TITLE
Fix display of gencode primary and gencode basic transcripts in Genoverse

### DIFF
--- a/genoverse/modules/EnsEMBL/Web/Controller/Genoverse.pm
+++ b/genoverse/modules/EnsEMBL/Web/Controller/Genoverse.pm
@@ -238,7 +238,11 @@ sub fetch_features_generic {
   return \@features;
 }
 
-sub fetch_gencode {
+sub fetch_gencode_basic {
+  return shift->fetch_transcript(@_);
+}
+
+sub fetch_gencode_primary {
   return shift->fetch_transcript(@_);
 }
 


### PR DESCRIPTION
This PR fixes the bug that was introduced in https://github.com/Ensembl/ensembl-webcode/pull/1060, during the modifications to support the GENCODE Primary transcript set.

**PROBLEM:** Transcripts within the Gencode Basic and Gencode Primary tracks started showing up in red (compare on screenshot below with transcripts from the Gencode Comprehensive track):

![image](https://github.com/user-attachments/assets/88bed52c-1706-41d2-a635-d8fb7b4211ae)

**CAUSE:** 
- In https://github.com/Ensembl/ensembl-webcode/pull/1060, the `_gencode.pm` module was renamed and split into `_gencode_basic.pm` and `_gencode_primary.pm`. The url of the network requests to fetch data for these tracks has also changed from `https://www.ensembl.org/Homo_sapiens/Genoverse/fetch_features/_gencode?config=contigviewtop&id=gencode&renderer=gene_label&db=core&r=17:62384780-65515519` to `http://wp-np2-33.ebi.ac.uk:8410/Homo_sapiens/Genoverse/fetch_features/_gencode_primary?config=contigviewtop&id=gencode_primary&renderer=gene_label&db=core&r=17:62222390-65515519`
- As a result of the renaming, this line  https://github.com/Ensembl/public-plugins/blob/release/113/genoverse/modules/EnsEMBL/Web/Controller/Genoverse.pm#L59 could no longer find the appropriately named subroutines (`fetch$function` would expand to `fetch_gencode_primary`, which did not exist), and defaulted to using the `fetch_features_generic` subroutine to fetch transcript data. This subroutine returned features without any specified colour; and so the colour [defaulted](https://github.com/Ensembl/ensembl-webcode/blob/release/113/modules/EnsEMBL/Draw/Utils/ColourMap.pm#L73) to red.

**AFTER FIX:**

Gencode primary track renders correctly coloured transcripts:

![image](https://github.com/user-attachments/assets/dabcdc50-35b9-4f94-8d84-3f84ba369b5e)


**Sandbox:** http://wp-np2-33.ebi.ac.uk:8410/Homo_sapiens/Location/View?r=17:63992802-64038237&debug=js