### PR TITLE
Update strains/breeds in Solr config for e114

### DIFF
--- a/solr/conf/SiteDefs.pm
+++ b/solr/conf/SiteDefs.pm
@@ -146,21 +146,43 @@ sub update_conf {
       ],
 
       facets_sidebar_deps => {
-        strain => { "species" => ["Mouse", "Pig", "Dog", "Sheep", "Goat", "Chicken", "Rat",
-          "Atlantic cod", "Atlantic salmon", "Three-spined stickleback"] }
+        strain => { "species" => [
+          "Atlantic cod",
+          "Atlantic salmon",
+          "Chicken",
+          "Dog",
+          "Domestic cat",
+          "Domestic pig",
+          "Eastern European house mouse",
+          "Goat",
+          "House mouse",
+          "Japanese wild mouse",
+          "Norway rat",
+          "Pig",
+          "Sheep",
+          "Southeastern Asian house mouse",
+          "Three-spined stickleback",
+          "Western European house mouse"
+        ] }
       },
 
       strain_type  => {
-        "Mouse"   => "strain",
-        "Rat"     => "strain",
         "Atlantic cod" => "strain",
         "Atlantic salmon" => "strain",
-        "Three-spined stickleback" => "strain",
         "Chicken" => "breed",
-        "Pig"     => "breed",
         "Dog"     => "breed",
-        "Sheep"   => "breed",
+        "Domestic cat" => "breed",
+        "Domestic pig" => "breed",
+        "Eastern European house mouse" => "strain",
         "Goat"    => "breed",
+        "House mouse"   => "strain",
+        "Japanese wild mouse"   => "strain",
+        "Norway rat"     => "strain",
+        "Pig"     => "breed",
+        "Sheep"   => "breed",
+        "Southeastern Asian house mouse"   => "strain",
+        "Three-spined stickleback" => "strain",
+        "Western European house mouse"   => "strain"
       },
 
       #######################


### PR DESCRIPTION
As part of [ENSWEBREL-1033](https://www.ebi.ac.uk/panda/jira/browse/ENSWEBREL-1033), updated the list of strains/breeds for search.

Based on the output of the dumping script:

```
There are 346 species
Dumping xml files to input
Species canis_lupus_familiarisbasenji has strains, with parent of Dog
Species canis_lupus_familiarisboxer has strains, with parent of Dog
Species canis_lupus_familiarisgreatdane has strains, with parent of Dog
Species canis_lupus_familiarisgsd has strains, with parent of Dog
Species capra_hircus_blackbengal has strains, with parent of Goat
Species capra_hircus_gca015443085v1 has strains, with parent of Goat
Species capra_hircus_gca026652205v1 has strains, with parent of Goat
Species felis_catus_abyssinian has strains, with parent of Domestic cat
Species gadus_morhua_gca010882105v1 has strains, with parent of Atlantic cod
Species gallus_gallus_gca016700215v2 has strains, with parent of Chicken
Species gallus_gallus_gca000002315v5 has strains, with parent of Chicken
Species gasterosteus_aculeatus_gca006229185v1 has strains, with parent of Three-spined stickleback
Species gasterosteus_aculeatus_gca006232265v1 has strains, with parent of Three-spined stickleback
Species gasterosteus_aculeatus_gca006232285v1 has strains, with parent of Three-spined stickleback
Species mus_musculus_129s1svimj has strains, with parent of House mouse
Species mus_musculus_aj has strains, with parent of House mouse
Species mus_musculus_akrj has strains, with parent of House mouse
Species mus_musculus_balbcj has strains, with parent of House mouse
Species mus_musculus_c3hhej has strains, with parent of House mouse
Species mus_musculus_c57bl6nj has strains, with parent of House mouse
Species mus_musculus_casteij has strains, with parent of Southeastern Asian house mouse
Species mus_musculus_cbaj has strains, with parent of House mouse
Species mus_musculus_dba2j has strains, with parent of House mouse
Species mus_musculus_fvbnj has strains, with parent of House mouse
Species mus_musculus_lpj has strains, with parent of House mouse
Species mus_musculus_molossinusjf1msj has strains, with parent of Japanese wild mouse
Species mus_musculus_nodshiltj has strains, with parent of House mouse
Species mus_musculus_pwkphj has strains, with parent of Eastern European house mouse
Species mus_musculus_wsbeij has strains, with parent of Western European house mouse
Species ovis_aries has strains, with parent of Sheep
Species ovis_aries_gca011170295v1 has strains, with parent of Sheep
Species ovis_aries_gca018804185v1 has strains, with parent of Sheep
Species ovis_aries_gca022416685v1 has strains, with parent of Sheep
Species ovis_aries_gca022416695v1 has strains, with parent of Sheep
Species ovis_aries_gca022416755v1 has strains, with parent of Sheep
Species ovis_aries_gca022416915v1 has strains, with parent of Sheep
Species ovis_aries_gca022432825v1 has strains, with parent of Sheep
Species ovis_aries_gca022432835v1 has strains, with parent of Sheep
Species ovis_aries_gca024222175v1 has strains, with parent of Sheep
Species rattus_norvegicus_shrspbbbutx has strains, with parent of Norway rat
Species rattus_norvegicus_shrutx has strains, with parent of Norway rat
Species rattus_norvegicus_wkybbb has strains, with parent of Norway rat
Species salmo_salar_gca021399835v1 has strains, with parent of Atlantic salmon
Species salmo_salar_gca923944775v1 has strains, with parent of Atlantic salmon
Species salmo_salar_gca931346935v2 has strains, with parent of Atlantic salmon
Species sus_scrofa_gca007644095v1 has strains, with parent of Pig
Species sus_scrofa_gca015776825v1 has strains, with parent of Pig
Species sus_scrofa_gca017957985v1 has strains, with parent of Domestic pig
Species sus_scrofa_gca018555405v1 has strains, with parent of Pig
Species sus_scrofa_gca019290145v1 has strains, with parent of Pig
Species sus_scrofa_gca020567905v1 has strains, with parent of Domestic pig
Species sus_scrofa_gca021656055v1 has strains, with parent of Pig
Species sus_scrofa_gca024718415v1 has strains, with parent of Pig
Species sus_scrofa_bamei has strains, with parent of Pig
Species sus_scrofa_berkshire has strains, with parent of Pig
Species sus_scrofa_hampshire has strains, with parent of Pig
Species sus_scrofa_jinhua has strains, with parent of Pig
Species sus_scrofa_landrace has strains, with parent of Pig
Species sus_scrofa_largewhite has strains, with parent of Pig
Species sus_scrofa_meishan has strains, with parent of Pig
Species sus_scrofa_pietrain has strains, with parent of Pig
Species sus_scrofa_rongchang has strains, with parent of Pig
Species sus_scrofa_tibetan has strains, with parent of Pig
Species sus_scrofa_wuzhishan has strains, with parent of Pig
Species sus_scrofa_usmarc has strains, with parent of Pig
```

This reduces to 16 parent species' common names:

```
Atlantic cod 
Atlantic salmon
Chicken
Dog 
Domestic cat 
Domestic pig 
Eastern European house mouse
Goat
House mouse
Japanese wild mouse
Norway rat 
Pig 
Sheep
Southeastern Asian house mouse
Three-spined stickleback
Western European house mouse
```

Note that some of those common names refer to the same species (house mouse, Eastern European house mouse, Southeastern Asian house mouse, Western European house mouse are all the same); and some species have seen changes in their common names (mouse -> house mouse; rat -> Norway rat). I am not sure what consequences this will have for Solr; but we will see.