### PR TITLE
Avoid hive param_substitute in VEP custom config (114)

### DIFF
--- a/tools/conf/vep_custom_web_config.json
+++ b/tools/conf/vep_custom_web_config.json
@@ -7,7 +7,7 @@
       "description": "Report allele frequencies from the NIH AllOfUs study",
       "section": "Variants and frequency data",
       "params": {
-            "file": "/homo_sapiens/GRCh38/variation_genotype/AllOfUs/AllOfUs_chr###CHR###.vcf.gz",
+            "file": "/homo_sapiens/GRCh38/variation_genotype/AllOfUs/AllOfUs_chr\\#\\#\\#CHR\\#\\#\\#.vcf.gz",
             "format": "vcf",
             "short_name": "AllOfUs",
             "helptips": [

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -153,7 +153,7 @@
   },
   Paralogues => {
     "params" => [
-      "matches=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/Paralogues/Paralogues.pm_homo_sapiens_113_ClinVar_20240819.tsv.gz",
+      "matches=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/Paralogues/Paralogues.pm_homo_sapiens_114_ClinVar_20241230.tsv.gz",
       "fields=identifier:alleles:clinical_significance:chromosome:start",
       "@*"
     ]

--- a/tools_hive/modules/EnsEMBL/Web/RunnableDB/VEP.pm
+++ b/tools_hive/modules/EnsEMBL/Web/RunnableDB/VEP.pm
@@ -47,6 +47,12 @@ sub run {
   my $options         = $self->param('script_options') || {};
   my $log_file        = "$work_dir/farm_log.txt";
 
+  # custom config can have double backlash around CHR to avoid hive param_substitute
+  # we get double backlash because perl JSON cannot decode escaped backlash as double backlash
+  if ($config->{'custom'}) {
+    s/\\#\\#\\#CHR\\#\\#\\#/###CHR###/ for @{ $config->{'custom'} }
+  }
+
   # path for VEP_plugins (gets pushed to INC by VEP::Runner)
   if (my $plugins_path = $self->param('plugins_path')) {
     $options->{'dir_plugins'} = $plugins_path =~ /^\// ? $plugins_path : sprintf('%s/%s', $self->param('code_root'), $plugins_path);


### PR DESCRIPTION
We use ###CHR### placeholder in VEP custom annotation to allow annotating from multiple file. But as web VEP job submission happen via eHive and eHive has a logic to param replacement with anything #TOKEN# it is creating failure.

The solution tried here is to escape # in the ###CHR### in the custom config with double backlash and replace them back again before submitting the VEP job.

Need for using double backlash -
- The config JSON is read by using Perl JSON module and it cannot parse a single backlash in the config.
Need for replacing the backlash again
- VEP can support ###CHR### or an escaped version with single backlash \#\#\#CHR\#\#\# but perl JSON module converts \\ --> \\ (not single backlash). That's we need to replace them back again.

sandbox test url - http://wp-np2-35.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?tl=nqITqTx9D5mEJyI8-17

**Paralogue plugin**:
Update Paralogue plugin file name to match the latest data.