### PR TITLE
AllOfUs webVEP: remove fields and disable GRCh37 option

### DIFF
--- a/tools/conf/vep_custom_web_config.json
+++ b/tools/conf/vep_custom_web_config.json
@@ -13,7 +13,6 @@
             "helptips": [
 		"Alternate allele frequency across all available samples in the WGS joint callset", 
 		"Max subpopulation frequency",
-		"Max subpopulation ancestry",
 		"Alternate allele frequency across samples in the African subpopulation",
 		"Alternate allele frequency across samples in the Latino/Ad Mixed American subpopulation",
 		"Alternate allele frequency across samples in the East Asian subpopulation",
@@ -25,7 +24,6 @@
             "fields": [
 		"gvs_all_af",
 		"gvs_max_af",
-		"gvs_max_subpop",
 		"gvs_afr_af",
 		"gvs_amr_af",
 		"gvs_eas_af",

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -440,6 +440,7 @@ sub _build_variants_frequency_data {
 
   my $hub       = $self->hub;
   my $object    = $self->object;
+  my $sd        = $hub->species_defs;
   my $species   = $object->species_list;
   my $fd        = $object->get_form_details;
 
@@ -486,6 +487,9 @@ sub _build_variants_frequency_data {
     my $frequency_species_data = {};
     my $human_frequency_from_custom = [];
     foreach (@custom_frequencies) {
+      # for human the name is same for GRCh38 and GRCh37; so check assembly too
+      next if lc $_->{species} eq "homo_sapiens" && $sd->ASSEMBLY_NAME !~ /^$_->{assembly}/;
+
       $frequency_species_data->{$_->{species}} = [] if !$frequency_species_data->{$_->{species}};
       my $value_ele = {
         'name'      => 'custom_'.$_->{id},

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -195,6 +195,11 @@ sub content {
   $skip_colums{'OpenTargets_geneId'} = 1; # gene ID added to Open Targets L2G column
   $skip_colums{'PARALOGUE_VARIANTS'} = 1; # info added to PARALOGUE_REGIONS column
 
+  # skip ID column for custom configs
+  foreach my $cc (@{ $custom_configs }){
+    $skip_colums{$cc->{params}->{short_name}} = 1;
+  }
+
   if (%skip_colums) {
     my @tmp_headers;
     foreach my $header (@$headers) {
@@ -382,9 +387,6 @@ sub content {
   # Force to hide some columns by default
   foreach my $col ('IMPACT','SYMBOL_SOURCE','INTRON','DISTANCE','FLAGS','HGNC_ID','PHENO') {
     $display_column{$col} = 0;
-  }
-  foreach my $cc (@{ $custom_configs }){
-    $display_column{$cc->{params}->{short_name}} = 0;
   }
 
   # extras


### PR DESCRIPTION
AllOfUs webVEP option
- Remove max_subpop option
- Disable option for GRCh37 website

Generic custom config improvement
- Remove identifier field that contains location which is duplicate info 

sandbox url - http://wp-np2-35.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?tl=t1raqNqIYFGZdjhJ-36