### PR TITLE
Add new VEP option clinvar_somatic_classification (release 115)

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1523,6 +1523,16 @@ host          useastdb.ensembl.org</pre>
       <td>CLIN_SIG</td>
       <td>&nbsp;</td>
     </tr>
+    <tr id="opt_clinvar_somatic">
+      <td><pre>--clinvar_somatic_classification [1|0]</pre></td>
+      <td>&nbsp;</td>
+      <td>
+        Return the somatic classification of a variant as reported by ClinVar.
+        <i>Not used by default</i>
+      </td>
+      <td>SOMATIC_CLASSIFICATION</td>
+      <td>&nbsp;</td>
+    </tr>
     <tr id="opt_exclude_null_alleles">
       <td><pre>--exclude_null_alleles</pre></td>
       <td>&nbsp;</td>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_options.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_options.html
@@ -1524,7 +1524,7 @@ host          useastdb.ensembl.org</pre>
       <td>&nbsp;</td>
     </tr>
     <tr id="opt_clinvar_somatic">
-      <td><pre>--clinvar_somatic_classification [1|0]</pre></td>
+      <td><pre>--clinvar_somatic_classification</pre></td>
       <td>&nbsp;</td>
       <td>
         Return the somatic classification of a variant as reported by ClinVar.


### PR DESCRIPTION
Document new VEP option `--clinvar_somatic_classification` for release 115.
Sandbox: http://wp-np2-33.ebi.ac.uk:7040/info/docs/tools/vep/script/vep_options.html#existing