### PR TITLE
Add gnomAD and Clinical SV custom annotation for web VEP - 115

### DIFF
--- a/tools/conf/vep_custom_web_config.json
+++ b/tools/conf/vep_custom_web_config.json
@@ -108,6 +108,36 @@
        }
     },
     {
+      "id": "custom_homo_sapiens_nstd102_somatic",
+      "species": "homo_sapiens",
+      "assembly": "GRCh38",
+      "type": "local",
+      "label": "Clinical Significance (somatic SV)",
+      "description": "Report clinical significance data from dbVar Clinical Structural Variants study (nstd102) for somatic types",
+      "section": "Phenotype data and citations",
+      "params": {
+            "file": "/homo_sapiens/GRCh38/variation_annotation/nstd102.GRCh38.variant_call.somatic.vcf.gz",
+            "format": "vcf",
+            "short_name": "nstd102_somatic",
+            "helptips": [
+                "Clinical significance reported in ClinVar",
+                "Accessions and version numbers assigned by ClinVar",
+                "Source of clinical significance",
+                "The parent variant region accession(s)",
+                "Origin of allele, if known; should be one of (biparental, de novo, germline, inherited, maternal, not applicable, not provided, not-reported, paternal, tested-inconclusive, uniparental, unknown)."
+            ],
+            "fields": [
+                "CLNSIG",
+                "CLNACC",
+                "clinical_source",
+                "REGIONID",
+                "ORIGIN"
+            ],
+            "type": "exact",
+            "coord": 0
+       }
+    },
+    {
       "id": "custom_gallus_gallus_PRJEB44919",
       "species": "gallus_gallus",
       "assembly": "bGalGal1.mat.broiler.GRCg7b",

--- a/tools/conf/vep_custom_web_config.json
+++ b/tools/conf/vep_custom_web_config.json
@@ -1,5 +1,46 @@
 [
     {
+      "id": "custom_homo_sapiens_gnomAD_SV",
+      "species": "homo_sapiens",
+      "assembly": "GRCh38",
+      "type": "local",
+      "description": "Report allele frequencies from the gnomAD SV dataset of unrelated genomes",
+      "section": "Variants and frequency data",
+      "params": {
+            "file": "/homo_sapiens/GRCh38/variation_genotype/gnomad/v4.1/SV/gnomad.v4.1.sv.sites.vcf.gz",
+            "format": "vcf",
+            "short_name": "gnomAD_SV",
+            "helptips": [
+                "Frequency across all samples",
+		"Frequency from African/African American population",
+		"Frequency from Amish population",
+		"Frequency from Admixed American population",
+		"Frequwncy from Ashkenazi Jewish population",
+		"Frequency from East Asian population",
+		"Frequency from Finish population",
+		"Frequency from Middle Eastern population",
+		"Frequency from Non-Finnish European population",
+		"Frequency from Remaining Individuals",
+		"Frequency from South Asian population"
+            ],
+            "fields": [
+		"AF",
+		"AF_afr",
+		"AF_ami",
+		"AF_amr",
+		"AF_asj",
+		"AF_eas",
+		"AF_fin",
+		"AF_mid",
+		"AF_nfe",
+		"AF_rmi",
+		"AF_sas"
+            ],
+            "type": "exact",
+            "coord": 0
+       }
+    },
+    {
       "id": "custom_homo_sapiens_AllOfUs",
       "species": "homo_sapiens",
       "assembly": "GRCh38",
@@ -32,6 +73,36 @@
 		"gvs_oth_af",
 		"gvs_sas_af"
 	    ],
+            "type": "exact",
+            "coord": 0
+       }
+    },
+    {
+      "id": "custom_homo_sapiens_nstd102",
+      "species": "homo_sapiens",
+      "assembly": "GRCh38",
+      "type": "local",
+      "label": "Clinical Significance (SV)",
+      "description": "Report clinical significance data from dbVar Clinical Structural Variants study (nstd102)",
+      "section": "Phenotype data and citations",
+      "params": {
+            "file": "/homo_sapiens/GRCh38/variation_annotation/nstd102.GRCh38.variant_call.vcf.gz",
+            "format": "vcf",
+            "short_name": "nstd102",
+            "helptips": [
+		"Clinical significance reported in ClinVar",
+		"Accessions and version numbers assigned by ClinVar",
+		"Source of clinical significance",
+		"The parent variant region accession(s)",
+		"Origin of allele, if known; should be one of (biparental, de novo, germline, inherited, maternal, not applicable, not provided, not-reported, paternal, tested-inconclusive, uniparental, unknown)."
+            ],
+            "fields": [
+		"CLNSIG",
+		"CLNACC",
+		"clinical_source",
+		"REGIONID",
+		"ORIGIN"
+            ],
             "type": "exact",
             "coord": 0
        }

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -1165,7 +1165,7 @@ sub _add_customs {
       'type'        => 'checkbox',
       'helptip'     => $custom->{description},
       'name'        => 'custom_'.$custom_id,
-      'label'       => ($custom->{params}->{short_name} || $custom_id),
+      'label'       => ($custom->{label} || $custom->{params}->{short_name} || $custom_id),
       'value'       => 'custom_'.$custom_id,
       'checked'     => 0,
     });

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -276,7 +276,7 @@ sub content {
     my $consequence = $row->{'Consequence'};
     my $location    = $row->{'Location'};
 
-    # linkify content
+    # linkify and/or beautify content
     foreach my $header (@$headers) {
       $row->{$header} = $self->linkify($header, $row->{$header}, $species, $job_data);
       if ($row->{$header} && $row->{$header} ne '' && $row->{$header} ne '-') {
@@ -288,6 +288,15 @@ sub content {
         }
         elsif ($header eq 'Mastermind_MMID3'){
           $row->{$header} = $self->get_items_in_list($row_id, 'mastermind_mmid3', 'Mastermind URL', $row->{$header}, $species);
+        }
+	elsif ($header eq 'nstd102_CLNACC'){
+	  $row->{$header} = $self->get_items_in_list($row_id, 'nstd102_CLNACC', 'ClinVar accession for SV', $row->{$header}, $species);
+	}
+	elsif ($header eq 'nstd102_CLNSIG'){
+          $row->{$header} = $self->get_items_in_list($row_id, 'nstd102_CLNSIG', 'ClinVar clinical significance for SV', $row->{$header}, $species);
+        }
+	elsif ($header eq 'nstd102_ORIGIN' || $header eq 'nstd102_clinical_source'){
+          $row->{$header} =~ s/"//g;
         }
         elsif ($header eq 'VAR_SYNONYMS'){
           $row->{$header} = $self->get_items_in_list($row_id, 'variant_synonyms', 'Variant synonyms', $row->{$header}, $species);
@@ -1345,6 +1354,16 @@ sub get_items_in_list {
       }
       elsif ($type eq 'mastermind_mmid3') {
         $item_url = $hub->get_ExtURL_link($item, 'MASTERMIND', $item);
+      }
+      elsif ($type eq 'nstd102_CLNACC') {
+	$item_url = $item =~ /^RCV/ ? 
+		$hub->get_ExtURL_link($item, 'CLINVAR', $item) :
+		$hub->get_ExtURL_link($item, 'CLINVAR_VAR', $item);
+      }
+      elsif ($type eq 'nstd102_CLNSIG') {
+	$item =~ s/\"//g;
+	$item =~ s/%20/ /g;
+	$item_url = $item;
       }
       elsif ($type eq 'IntAct_interaction_ac') {
       	$item =~ s/^\s+|\s+$//;

--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/Results.pm
@@ -289,13 +289,13 @@ sub content {
         elsif ($header eq 'Mastermind_MMID3'){
           $row->{$header} = $self->get_items_in_list($row_id, 'mastermind_mmid3', 'Mastermind URL', $row->{$header}, $species);
         }
-	elsif ($header eq 'nstd102_CLNACC'){
-	  $row->{$header} = $self->get_items_in_list($row_id, 'nstd102_CLNACC', 'ClinVar accession for SV', $row->{$header}, $species);
+	elsif ($header =~ /nstd102(_somatic)?_CLNACC/){
+	  $row->{$header} = $self->get_items_in_list($row_id, $header, 'ClinVar accession for SV', $row->{$header}, $species);
 	}
-	elsif ($header eq 'nstd102_CLNSIG'){
-          $row->{$header} = $self->get_items_in_list($row_id, 'nstd102_CLNSIG', 'ClinVar clinical significance for SV', $row->{$header}, $species);
+	elsif ($header =~ /nstd102(_somatic)?_CLNSIG/){
+          $row->{$header} = $self->get_items_in_list($row_id, $header, 'ClinVar clinical significance for SV', $row->{$header}, $species);
         }
-	elsif ($header eq 'nstd102_ORIGIN' || $header eq 'nstd102_clinical_source'){
+	elsif ($header =~ /nstd102(_somatic)?_ORIGIN/ || $header =~ 'nstd102(_somatic)?_clinical_source'){
           $row->{$header} =~ s/"//g;
         }
         elsif ($header eq 'VAR_SYNONYMS'){
@@ -1355,12 +1355,12 @@ sub get_items_in_list {
       elsif ($type eq 'mastermind_mmid3') {
         $item_url = $hub->get_ExtURL_link($item, 'MASTERMIND', $item);
       }
-      elsif ($type eq 'nstd102_CLNACC') {
+      elsif ($type =~ /nstd102(_somatic)?_CLNACC/) {
 	$item_url = $item =~ /^RCV/ ? 
 		$hub->get_ExtURL_link($item, 'CLINVAR', $item) :
 		$hub->get_ExtURL_link($item, 'CLINVAR_VAR', $item);
       }
-      elsif ($type eq 'nstd102_CLNSIG') {
+      elsif ($type =~ /nstd102(_somatic)?_CLNSIG/) {
 	$item =~ s/\"//g;
 	$item =~ s/%20/ /g;
 	$item_url = $item;


### PR DESCRIPTION
## gnomAD SV data
example sandbox url: http://wp-np2-35.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?tl=LlPKWfcJ4D2ddHA4-46

- option name - "gnomAD_SV allele frequencies"
- the option is put under "Variants and frequency data" section


## Clinical SV data (nstd102)
example sandbox url: 
http://wp-np2-35.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?tl=JQxJ2Ojmo7SILXxd-57
(somatic) http://wp-np2-35.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?tl=Y5zvqYwNa2stuk0d-58

- option name - "Clinical Significance (SV)"  and "Clinical Significance (somatic SV)"
- the option is put under "Phenotype and citation data" section
- following fields are picked for display -
   - `CLNSIG` - clinical significance
   - `CLNACC` - accession number (from ClinVar)
   - `clinical_source` - source of clinsig
   -  `REGIONID` - dbVar parent region ID
   - `ORIGIN` - cell origin


## Other related improvements
- Allow to specify a label specifically in the vep_custom_web_config.json, so we can have separate label for a custom option other than short_name.
- Beautify and linkify SV clinical outputs.