### PR TITLE
Add back max subpop column for AllOfUs in web VEP - 115

### DIFF
--- a/tools/conf/vep_custom_web_config.json
+++ b/tools/conf/vep_custom_web_config.json
@@ -13,6 +13,7 @@
             "helptips": [
 		"Alternate allele frequency across all available samples in the WGS joint callset", 
 		"Max subpopulation frequency",
+		"Max subpopulation ancestry",
 		"Alternate allele frequency across samples in the African subpopulation",
 		"Alternate allele frequency across samples in the Latino/Admixed American subpopulation",
 		"Alternate allele frequency across samples in the East Asian subpopulation",
@@ -24,6 +25,7 @@
             "fields": [
 		"gvs_all_af",
 		"gvs_max_af",
+		"gvs_max_subpop",
 		"gvs_afr_af",
 		"gvs_amr_af",
 		"gvs_eas_af",


### PR DESCRIPTION
We had to remove the `max_subpop` field for AllOfUs option in web VEP because they were missing from the data in this PR - https://github.com/Ensembl/public-plugins/pull/868

With the addition of this data we are adding back the field.

sandbox url for test - 
http://wp-np2-35.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?tl=nStkHAdk33R9mNrs-62