### PR TITLE
Updating the number of Mus musculus strains

### DIFF
--- a/ensembl/htdocs/Mus_musculus_strains.inc
+++ b/ensembl/htdocs/Mus_musculus_strains.inc
@@ -12,7 +12,7 @@
     <div class="column-right">
 <h2>Comparative analysis</h2>
 
-<p>Using our EPO pipeline, we generated a multiple genome alignment of 16 of the
+<p>Using our EPO pipeline, we generated a multiple genome alignment of 17 of the
    reference-quality genomes from the The Mouse Genomes Project with <i>Mus
    musculus</i>, <i>Rattus norvegicus</i> and an additional three <i>Mus</i>
    species&colon; <i>Mus caroli</i>, <i>Mus pahari</i> and <i>Mus


### PR DESCRIPTION
I have updated the total number of strains in the Mus_musculus_strains.inc document, in light of the Murinae EPO update for release 115.