### PR TITLE
Update Vertebrates "Protein trees" and "Homology types" pages

### DIFF
--- a/ensembl/htdocs/info/genome/compara/homology_method.html
+++ b/ensembl/htdocs/info/genome/compara/homology_method.html
@@ -13,7 +13,7 @@
 
 <h1>Protein trees</h1>
   
-<p>Gene trees aim to represent the evolutionary history of gene families, which evolved from a common ancestor. Reconciliation of the gene tree against the species trees allow us to distinguish duplication and speciation events, thus inferring <a href="/info/genome/compara/homology_types.html">orthologues and paralogues</a>. </p>
+<p>Gene trees aim to represent the evolutionary history of gene families, which evolved from a common ancestor. Reconciliation of the gene tree against the species trees allows us to distinguish duplication and speciation events, thus inferring <a href="/info/genome/compara/homology_types.html">orthologues and paralogues</a>. </p>
 
 
 <p>
@@ -26,6 +26,10 @@ Fly/Mammal or Worm/Mammal orthologous gene predictions. Using this
 approach, we are also able to "time" duplication events which produce
 paralogues by identifying the most recent common ancestor (i.e. taxonomy level) for a
 given internal node of the tree.
+</p>
+
+<p>
+Please note that, primarily due to storage limitations, between-species paralogy relationships are not stored in the Compara databases or listed on the website (except in some special cases described in the "Between-species paralogues" section of the <a href="/info/genome/compara/homology_types.html">homology types documentation</a>). However, these relationships can be identified by examining the gene trees, which are annotated with duplication events.
 </p>
 
 
@@ -48,15 +52,15 @@ given internal node of the tree.
 <ol>
 <li>run NCBI Blast+ <a href="#fn1">[1]</a> (refined with SmithWaterman) on every orphaned gene against every other (both self and non-self species). We use the version 2.2.28, with the parameters: <code>-seg no -max_hsps_per_subject 1 -use_sw_tback -num_threads 1</code>.</li>
 
-<li>Build a sparse graph of gene relations based on Blast e-values and generate clusters using hcluster_sg <a href="#fn2">[2]</a>. Hcluster_sg has a little insight about the phylogeny of the species (namely: a list of outgroup species), which helps defining pertinent clusters for the ingroup species. We use yeast (Saccharomyces cerevisiae) as an outgroup (via the -C option) and the following command line arguments: <code>-m 750 -w 0 -s 0.34 -O</code>. See below for more details.</li>
+<li>Build a sparse graph of gene relations based on Blast e-values and generate clusters using hcluster_sg <a href="#fn2">[2]</a>. Hcluster_sg has a little insight about the phylogeny of the species (namely: a list of outgroup species), which helps define pertinent clusters for the ingroup species. We use yeast (Saccharomyces cerevisiae) as an outgroup (via the -C option) and the following command line arguments: <code>-m 750 -w 0 -s 0.34 -O</code>. See below for more details.</li>
 </ol>
 </li>
 
 <li>Large families that would be too complex to analyse are broken down with QuickTree <a href="#fn7">[7]</a> to limit them to 1,500 genes.</li>
 
-<li>For each cluster (family), build a multiple alignment based on the protein sequences using either a combination of multiple aligners, consensified by M-Coffee <a href="#fn3">[3]</a> or Mafft <a href="#fn4">[4]</a> when the cluster is too large, or MCoffee is too long. We use the version 9.03.r1318 of M-Coffee, with the aligner set: mafftgins_msa, muscle_msa, kalign_msa, t_coffee_msa, and the Mafft version 7.113 with the command line options: <code>--auto</code>.</li>
+<li>For each cluster (family), build a multiple alignment based on the protein sequences using either a combination of multiple aligners, consensified by M-Coffee <a href="#fn3">[3]</a> or Mafft <a href="#fn4">[4]</a> when the cluster is too large, or running MCoffee takes too long. We use the version 9.03.r1318 of M-Coffee, with the aligner set: mafftgins_msa, muscle_msa, kalign_msa, t_coffee_msa, and the Mafft version 7.113 with the command line options: <code>--auto</code>.</li>
 
-<li>For each aligned cluster, build a phylogenetic tree using TreeBeST <a href="#fn5">[5]</a> using the CDS back-translation of the protein multiple alignment from the original DNA sequences. A rooted tree with internal duplication tags is obtained at this stage, reconciling it against a species tree inferred from the <a href="https://www.ncbi.nlm.nih.gov/taxonomy">NCBI taxonomy</a>. See below for more details.</li>
+<li>For each aligned cluster, build a phylogenetic tree using TreeBeST <a href="#fn5">[5]</a> using the CDS back-translation of the protein multiple alignment from the original DNA sequences. A rooted tree with internal duplication tags is obtained at this stage, reconciling it against a species tree inferred from the <a href="https://www.ncbi.nlm.nih.gov/taxonomy">NCBI taxonomy</a> in general, or by our <a href="https://github.com/Ensembl/ensembl-compara/tree/main/pipelines/SpeciesTreeFromBusco">in-house species-tree pipeline</a> for the Vertebrates division. See below for more details.</li>
 
 <li>From each gene tree, infer gene pairwise relations of orthology and paralogy types.</li>
 
@@ -77,13 +81,13 @@ hcluster_sg <a href="#fn2">[2]</a> performs hierarchical clustering under mean d
 </ol>
 
 <p>
-Hcluster_sg also introduces an additional edge breaking rule: removes an edge between cluster A and B if the number of edges between A and B is smaller than <code>|A|*|B|/10</code>. This heuristic rule removes weak relations which are quite unlikely to be joined at a later step.
+Hcluster_sg also introduces an additional edge-breaking rule: removes an edge between cluster A and B if the number of edges between A and B is smaller than <code>|A|*|B|/10</code>. This heuristic rule removes weak relations which are quite unlikely to be joined at a later step.
 </p>
 
 <p>
-As the pipeline has to complete in time for the Ensembl releases, we limit the size of the clusters to 1,500 genes.
+As the pipeline has to be completed in time for the Ensembl releases, we limit the size of the clusters to 1,500 genes.
 For larger clusters, we run Mafft <a href="#fn4">[4]</a> and QuickTree <a href="#fn7">[7]</a>.
-QuickTree is a very fast and efficient to build an unrooted phylogenetic tree. We then find the branch that best splits the cluster into two halves.
+QuickTree is a very fast and efficient way to build an unrooted phylogenetic tree. We then find the branch that best splits the cluster into two halves.
 We recursively follow this approach until each sub-cluster is smaller than 1,500 genes.
 </p>
 
@@ -93,7 +97,7 @@ We recursively follow this approach until each sub-cluster is smaller than 1,500
 back-translated protein alignment (i.e., codon alignment) is used to
 build five different trees (within TreeBeST <a href="#fn5">[5]</a>):</p>
 <ol class="lc-roman">
-<li>a maximum likelihood (ML) tree built, based on the protein alignment with the WAG model, which takes into the account the species tree</li>
+<li>a maximum likelihood (ML) tree built, based on the protein alignment with the WAG model, which takes into account the species tree</li>
 <li>a ML tree built using phyml, based on the codon alignment with the Hasegawa-Kishino-Yano (HKY) model, also taking into account the species tree</li>
 <li>a neighbour-joining (NJ) tree using p-distance, based on the codon alignment</li>
 <li>a NJ tree using dN distance, based on the codon alignment</li>

--- a/ensembl/htdocs/info/genome/compara/homology_types.html
+++ b/ensembl/htdocs/info/genome/compara/homology_types.html
@@ -29,14 +29,14 @@
 <li>between-species paralogues – only as exceptions</li>
 </ul>
 
-<p>Genes in different species and related by a speciation event are defined as <strong>orthologues</strong>. Depending on the number of genes found in each species, we differentiate among 1:1, 1:many and many:many relationships. Please, refer to the figure where there are examples of the three kinds.</p>
+<p>Genes in different species related by a speciation event are defined as <strong>orthologues</strong>. Depending on the number of genes found in each species, we differentiate among 1:1, 1:many and many:many relationships. Please refer to the figure, where there are examples of the three kinds.</p>
 
 <h2 id="homoeologues">Homoeologues</h2>
 
 <p>Homologues which diverged by a speciation event but end up in the same genome through hybridisation (e.g. polyploid plant genomes). They can have the same types as orthologues (see above), but importantly, the types refer to the number of genes in the sub-genomes.</p>
 
 <p>
-Let's take wheat (<em>Triticum aestivum</em>) as an example. It is an hybrid of three sub-genomes named A, B, and D.
+Let's take wheat (<em>Triticum aestivum</em>) as an example. It is a hybrid of three sub-genomes named A, B, and D.
 If a gene is found in one copy in every sub-genome, the three A-B, A-D, and B-D homoeologues are all labelled as 1:1 homoeologues.
 If the gene has a second copy in the sub-genome D, the A-B pair is labelled as 1:1, while the A-D and B-D pairs are labelled as 1:many.
 </p>
@@ -60,27 +60,27 @@ If wheat's A sub-genome also has two copies of the gene, its orthology pairs wit
 <li>fragments of the same ‐predicted‐ gene (gene_split)</li>
 </ul>
 
-<p>Genes of the same species and related by a duplication event are defined as <strong>paralogues</strong>. In the previous figure, Hsap2 and Hsap2', and Mmus2 and Mmus2' are two examples of within species paralogues. The duplication event relating the paralogues does not need to affect this species only. For example, Mmus2' and Mmus3' are also within species paralogues but the duplication event has occurred in the common ancestor between species Hsap (human) and species Mmus (mouse). The taxonomy level "times" the duplication event to the ancestor of Euarchontoglires.</p>
+<p>Genes of the same species and related by a duplication event are defined as <strong>paralogues</strong>. In the previous figure, Hsap2 and Hsap2', and Mmus2 and Mmus2' are two examples of within-species paralogues. The duplication event relating the paralogues does not need to affect this species only. For example, Mmus2' and Mmus3' are also within-species paralogues but the duplication event has occurred in the common ancestor between species Hsap (human) and species Mmus (mouse). The taxonomy level "times" the duplication event to the ancestor of Euarchontoglires.</p>
 
 <h3 id="confidencescores">Confidence scores</h3>
 
-<p>We compute a <strong>duplication confidence score</strong> for each duplication node. This is the <a href="https://en.wikipedia.org/wiki/Jaccard_index">Jaccard index</a> of the sets of species under the two sub-trees. The score is sometimes refered as "species intersection score". </p>
+<p>We compute a <strong>duplication confidence score</strong> for each duplication node. This is the <a href="https://en.wikipedia.org/wiki/Jaccard_index">Jaccard index</a> of the sets of species under the two sub-trees. The score is sometimes referred to as "species intersection score". </p>
 
 <p><img src="/info/genome/compara/duplication_confidence_score.merged.41.png" alt="Duplication confidence scores" title="Duplication confidence scores" /></p>
 
-<h3 id="betweenspeciesparalogues">Between species paralogues</h3>
+<h3 id="betweenspeciesparalogues">Between-species paralogues</h3>
 
-<p>A between species paralogue corresponds to a relation between genes of different species where the ancestor node has been labelled as a duplication node e.g. Mmus1:Hsap2 or Mmus1:Hsap3. Currently, we only annotate between species paralogue when there is no better match for any of the genes, and the duplication is weakly-supported (duplication confidence score ≤ 0.25).</p>
+<p>A between-species paralogue corresponds to a relation between genes of different species where the ancestor node has been labelled as a duplication node e.g. Mmus1:Hsap2 or Mmus1:Hsap3. Currently, we only annotate between-species paralogues when there is no better match for any of the genes, and the duplication is weakly supported (duplication confidence score &lt; 0.25).</p>
 
-<p>Such cases can be the results of real duplications followed by gene losses (as shown in the picture below), but most of the times occur as the result of a wrong gene tree topology with a spurious duplication node. Often assembly errors are behind these problems. It is not clear whether these genes are real orthologues or not, but they are the best available candidates (given the data), and we bend the definition of orthology to tag them as orthologues. They are flagged as "non-compliant with the gene tree". People interested in phylogenetic analysis mixing the orthologies and the trees should probably use the set of tree-compliant orthologies. </p>
+<p>Such cases can be the result of real duplications followed by gene losses (as shown in the picture below), but most of the time occur as the result of a wrong gene tree topology with a spurious duplication node. Often assembly errors are behind these problems. It is not clear whether these genes are real orthologues or not, but they are the best available candidates (given the data), and we bend the definition of orthology to tag them as orthologues. They are flagged as "non-compliant with the gene tree". People interested in phylogenetic analysis mixing the orthologies and the trees should probably use the set of tree-compliant orthologies. </p>
 
 <p><img src="/info/genome/compara/tree_example2.png" alt="Between species paralogues" title="Between species paralogues" /></p>
 
 <h3 id="genesplits">Gene splits</h3>
 
-<p>A paralogue labelled as a gene_split occurs when a gene appears to be broken in two. In the <a href="/info/genome/compara/homology_method.html">gene tree building process</a> they will each align to one end of the other orthologues of the gene, so will be clustered and placed in the tree alongside the other homologues. They are commonly related to fragmented genome assemblies or a gene prediction that is poor in supporting evidence, resulting in two fragmented genes where there should be one large one.</p>
+<p>A paralogue labelled as a gene_split occurs when a gene appears to be broken in two. In the <a href="/info/genome/compara/homology_method.html">gene tree building process</a> they will each align to one end of the other orthologues of the gene, so they will be clustered and placed in the tree alongside the other homologues. They are commonly related to fragmented genome assemblies or a gene prediction that is poor in supporting evidence, resulting in two fragmented genes where there should be one large one.</p>
 
-<p>Right after building the multiple alignment, we detect pairs pairs of genes that lie close to each other (< 1 MB) in the same sequence region and the same strand (see GeneA1/GeneA2 below). They are forced to be paired in the gene trees under gene_split events, and represent our most confident set. When there is no (or little) overlap between the gene fragments in the same species and they lie in different sequence regions in the assembly (see GeneB1/GeneB2 in the image below), we let TreeBeST5 decide their best position in the tree. They are linked by duplication nodes, and have a lower confidence index. </p>
+<p>Right after building the multiple alignment, we detect pairs of genes that lie close to each other (< 1 MB) in the same sequence region and the same strand (see GeneA1/GeneA2 below). They are forced to be paired in the gene trees under gene_split events, and represent our most confident set. When there is no (or little) overlap between the gene fragments in the same species and they lie in different sequence regions in the assembly (see GeneB1/GeneB2 in the image below), we let TreeBeST5 decide their best position in the tree. They are linked by duplication nodes, and have a lower confidence index. </p>
   
 
 <p><img src="/info/genome/compara/gene_split.png" alt="Gene split" title="Gene split" /></p>


### PR DESCRIPTION
This PR updates the "Protein trees" and "Homology types" pages:

- Emphasizes in "Protein trees" that between-species paralogies are not stored.
- Correct the duplications score thresholding in "Homology types".
- Applies small language fixes throughut.

Related ticket: ENSCOMPARASW-8498