### PR TITLE
Various compara documentation fixes

### DIFF
--- a/ensembl/htdocs/info/genome/compara/analyses.html
+++ b/ensembl/htdocs/info/genome/compara/analyses.html
@@ -13,11 +13,11 @@
 
 <p>Pairwise whole genome alignments can be used to determine conservation or differences between pairs of species, or to match up regions between species, so as to study the same genomic region in multiple species.</p>
 
-<p><a href="https://www.bx.psu.edu/~rsharris/lastz/">LastZ</a> and its predecessor <a href="https://europepmc.org/articles/PMC430961">Bla</a><a href="https://europepmc.org/articles/PMC208784">stZ</a> are used to align the genome sequences at the DNA level.</p>
+<p><a href="https://www.bx.psu.edu/~rsharris/lastz/">LastZ</a> is used to align the genome sequences at the DNA level.</p>
 
 <p>Genomes are compared to one another, for comparison between species, and to themselves, to identify paralogous regions. In self-alignment analyses, the trivial alignments (i.e. regions against themselves) are removed, such that only the paralogous regions remain.</p>
 
-<p>The actual whole-genome alignments are the results of post-processing the raw LastZ (or BlastZ) results. In the first step, original blocks are chained according to their location in both genomes. The netting process chooses for the reference species the best sub-chain in each region.</p>
+<p>The actual whole-genome alignments are the results of post-processing the raw LastZ results. In the first step, original blocks are chained according to their location in both genomes. The netting process chooses for the reference species the best sub-chain in each region.</p>
 
 <p>These alignments are used to calculate <a href="/info/genome/compara/synteny.html">synteny</a> and for <a href="/info/genome/compara/Ortholog_qc_manual.html">scoring orthologue quality</a>.</p>
 

--- a/ensembl/htdocs/info/genome/compara/ancestral_sequences.html
+++ b/ensembl/htdocs/info/genome/compara/ancestral_sequences.html
@@ -11,7 +11,7 @@
 
 <h1>Ancestral sequences</h1>
 
-<p><a href="https://europepmc.org/articles/PMC2577868">Ancestral sequences</a> are inferred from the <a href="/info/genome/compara/multiple_genome_alignments.html">EPO multiple alignments</a> using Ortheus. Ortheus is a probabilistic method for the inference of ancestor, a.k.a tree, alignments. The main contribution of Ortheus is the use of a phylogenetic model incorporating gaps to infer insertion and deletion events. Ancestral sequences are predicted for each node of the phylogenetic tree that relates the sequences. Each ancestral sequence is named according to the derived extant species. For example, a sequence named Hsap, Ptro, Mmul corresponds to the ancestor of the <i>Homo sapiens</i>, <i>Pan troglodytes</i>, and <i>Macaca mulatta</i> genomes.  </p>
+<p><a href="https://europepmc.org/articles/PMC2577868">Ancestral sequences</a> are inferred from the <a href="/info/genome/compara/multiple_genome_alignments.html">EPO multiple alignments</a> using Ortheus. Ortheus is a probabilistic method for the inference of ancestor, a.k.a tree, alignments. The main contribution of Ortheus is the use of a phylogenetic model incorporating gaps to infer insertion and deletion events. Ancestral sequences are predicted for each node of the phylogenetic tree that relates the sequences. Each ancestral sequence is named according to the derived extant species. For example, a sequence named "((homo_sapiens,pan_troglodytes),macaca_mulatta)" corresponds to the ancestor of the <i>Homo sapiens</i>, <i>Pan troglodytes</i>, and <i>Macaca mulatta</i> genomes.  </p>
 
 </body>
 </html>

--- a/ensembl/htdocs/info/genome/compara/conservation_and_constrained.html
+++ b/ensembl/htdocs/info/genome/compara/conservation_and_constrained.html
@@ -13,7 +13,7 @@
 
 <h1>Conservation scores and constrained elements</h1>
 
-<p>We use <a href="https://europepmc.org/article/pmc/2996323">GERP</a> to calculate conservation scores and call constrained elements on the amniota vertebrate Pecan, mammals EPO_EXTENDED, fish EPO_EXTENDED and sauropsids EPO_EXTENDED <a href="/info/genome/compara/multiple_genome_alignments.html">multiple alignments</a>. Calculation of these scores for different species groups allows the determination of regions that are conserved in one taxon but not another.</p>
+<p>We use <a href="https://europepmc.org/article/pmc/2996323">GERP</a> to calculate conservation scores and call constrained elements on the amniota vertebrate Pecan, mammals EPO_EXTENDED, fish EPO_EXTENDED, sauropsids EPO_EXTENDED and pig breeds EPO_EXTENDED <a href="/info/genome/compara/multiple_genome_alignments.html">multiple alignments</a>. Calculation of these scores for different species groups allows the determination of regions that are conserved in one taxon but not another.</p>
 
 <h2 id="conservationscores">Conservation scores</h2>
 


### PR DESCRIPTION
Some compara doc fixes:
- "Ancestral sequences" page updated with current Vertebrates ancestral-sequence name example.
- "Conservation scores" page updated to include pig breeds EPO_EXTENDED in list of multiple alignments.
- "Analyses" page updated to reflect the fact that BlastZ is no longer used in practice.

Related tickets:
- ENSCOMPARASW-8492
- ENSCOMPARASW-8487
- ENSCOMPARASW-8485