### PR TITLE
Change links for Expression Atlas build to pin its version

### DIFF
--- a/widgets/modules/EnsEMBL/Web/Document/Element/BodyJavascript.pm
+++ b/widgets/modules/EnsEMBL/Web/Document/Element/BodyJavascript.pm
@@ -35,8 +35,11 @@ sub content {
     # adding js only for gxa view and do not add them if their site is down
     # don't forget to remove their jquery lib as this will cause conflict with our one which is the latest one
     $main_js .=  qq{
-      <script language="JavaScript" type="text/javascript" src="$SiteDefs::GXA_EBI_URL/js-bundles/vendorCommons.bundle.js"></script>
-      <script language="JavaScript" type="text/javascript" src="$SiteDefs::GXA_EBI_URL/js-bundles/expressionAtlasHeatmapHighcharts.bundle.js"></script>
+      <script language="JavaScript" type="text/javascript" src="https://github.com/ebi-gene-expression-group/
+atlas-heatmap/releases/download/v5.7.1/vendorCommons.bundle.js"></script>
+      <script language="JavaScript" type="text/javascript" src="https://github.com/
+ebi-gene-expression-group/atlas-heatmap/releases/download/v5.7.1/
+expressionAtlasHeatmapHighcharts.bundle.js"></script>
     };
   }
   


### PR DESCRIPTION
Expression Atlas widget is currently broken. Something changed about its data requirements.

Example page on the plants site: https://plants.ensembl.org/Oryza_sativa/Gene/ExpressionAtlas?g=Os01g0100900;r=1:35623-41136;t=Os01t0100900-01

<img width="1512" height="903" alt="image" src="https://github.com/user-attachments/assets/7c596e6d-38b7-4ba0-8535-616e8eadba0a" />

The proposed solution is to pin the build to the version that used to work. See [discussion on Slack](https://genomes-ebi.slack.com/archives/C0F90TQ1X/p1752151834057189)

Same page on the staging site after the changes have been made:

https://staging-plants.ensembl.org/Oryza_sativa/Gene/ExpressionAtlas?g=Os01g0100900;r=1:35623-41136;t=Os01t0100900-01

<img width="4077" height="3573" alt="staging-plants ensembl org_Oryza_sativa_Gene_ExpressionAtlas_g=Os01g0100900;r=1_35623-41136;t=Os01t0100900-01" src="https://github.com/user-attachments/assets/61cb2a1f-4b97-49aa-abcb-8cad8d354367" />

_(Notice though that two image buttons to the left of the plant outline fail to load their images)_