### PR TITLE
Add Ensembl REST API to list of ways to access Compara data

### DIFF
--- a/ensembl/htdocs/info/genome/compara/accessing_compara.html
+++ b/ensembl/htdocs/info/genome/compara/accessing_compara.html
@@ -27,6 +27,8 @@
 <li>Homologues are available in <a href="/info/data/biomart/index.html">BioMart (Ensembl Gene database)</a>.</li>
 
 <li>Perl APIs, including the <a href="/info/docs/api/compara/index.html">Compara API</a>.</li>
+
+<li>The <a href="https://rest.ensembl.org/">Ensembl REST API</a>.</li>
 </ul>
 
 </body>


### PR DESCRIPTION
This PR would add the Ensembl REST API to the list of ways to access Compara data.