### PR TITLE
Add chicken rjf CADD config

### DIFF
--- a/ensembl/conf/json/gallus_gallus_gca000002315v5_vcf.json
+++ b/ensembl/conf/json/gallus_gallus_gca000002315v5_vcf.json
@@ -1,0 +1,12 @@
+{
+  "collections": [
+        {
+            "id": "CADD_GRCg6a_whole_genome_SNVs",
+            "species": "gallus_gallus_gca000002315v5",
+            "assembly": "GRCg6a",
+            "type": "local",
+            "filename_template": "/gallus_gallus_gca000002315v5/GRCg6a/variation_annotation/chCADD_updated.tsv.gz",
+            "annotation_type": "cadd"
+        }
+  ]
+}

--- a/tools/modules/EnsEMBL/Web/Job/VEP.pm
+++ b/tools/modules/EnsEMBL/Web/Job/VEP.pm
@@ -226,14 +226,22 @@ sub _configure_plugins {
         if ($pl_key eq 'CADD'){
           my $file_selected = $job_data->{'plugin_CADD_file_type'};
 
-          # check if species is pig and only add pig SNV file if that is the case
+          # check if species is pig and only add SNV file if that is the case
           if($file_selected eq 'snv' && $job_data->{'species'} eq "Sus_scrofa"){
             next unless $param_clone =~ /^snv_pig=/;
 
             my $param_aux = $param_clone;
             $param_aux =~ s/snv_pig=//;
             $param_clone = 'snv=' . $param_aux;
-          } 
+          }
+          # check if species is chicken rjf and only add SNV file if that is the case
+          elsif($file_selected eq 'snv' && $job_data->{'species'} eq "Gallus_gallus_GCA_000002315.5"){
+            next unless $param_clone =~ /^snv_chicken_rjf=/;
+
+            my $param_aux = $param_clone;
+            $param_aux =~ s/snv_chicken_rjf=//;
+            $param_clone = 'snv=' . $param_aux;
+          }
           # Only add appropriate files based on selected option otherwise
           elsif ($file_selected eq 'snv') {
             next unless $param_clone =~ /^snv=/;

--- a/tools_hive/conf/vep_plugins_hive_config.txt
+++ b/tools_hive/conf/vep_plugins_hive_config.txt
@@ -38,6 +38,7 @@
       "snv=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD_GRCh38_1.7_whole_genome_SNVs.tsv.gz",
       "indels=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD_GRCh38_1.7_InDels.tsv.gz",
       "snv_pig=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/ALL_pCADD-PHRED-scores.tsv.gz",
+      "snv_chicken_rjf=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/chCADD_updated.tsv.gz",
       "sv=[[ENSEMBL_VEP_PLUGIN_DATA_DIR]]/CADD_prescored_variants.tsv.gz"
     ]
   },


### PR DESCRIPTION
[ENSVAR-6855](https://embl.atlassian.net/browse/ENSVAR-6855)

- Add CADD config for chicken red jungle fowl.
- In VEP job param formation catch if the job is for chicken and add appropriate file 

sandbox url - 
VEP job - http://wp-np2-35.ebi.ac.uk:7070/Gallus_gallus_GCA_000002315.5/Tools/VEP/Results?tl=vb8LZH0BCrGLIu8A-147
Variation page - http://wp-np2-35.ebi.ac.uk:7070/Gallus_gallus_GCA_000002315.5/Variation/Explore?r=15:5480544-5481544;v=rs731438019;vdb=variation;vf=3700804