### PR TITLE
VEP: Add gff type for gencode_promoter config - 115

### DIFF
--- a/tools/conf/vep_custom_web_config.json
+++ b/tools/conf/vep_custom_web_config.json
@@ -58,7 +58,8 @@
                   "format": "gff",
                   "short_name": "GENCODE_promoter",
                   "type": "overlap",
-                  "coord": 0
+                  "coord": 0,
+                  "gff_type": "gencode_promoter"
             }
       },
       {


### PR DESCRIPTION
Add the missing parameter in gencode promoter config -
`"gff_type": "gencode_promoter"`

test in sandbox - http://wp-np2-35.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?tl=d4gU9JpBEAVSRMOw-151