### PR TITLE
Inline with feedback from our SAB we are clarifying our mission

### DIFF
--- a/ensembl/htdocs/index.html
+++ b/ensembl/htdocs/index.html
@@ -34,13 +34,11 @@
     </div>
     <div class="grid-col-2">
       <div class="plain-box unbordered whats-new">      		
-        <p>Ensembl is a genome browser for vertebrate genomes that
-           supports research in comparative genomics, evolution,
-           sequence variation and transcriptional regulation. Ensembl
-           annotate genes, computes multiple alignments, predicts
-           regulatory function and collects disease data. Ensembl tools
-           include BLAST, BLAT, BioMart and the Ensembl Variant Effect
-           Predictor (VEP) for all supported species.</p>
+        <p>Ensembl is a public and open project providing access to genomes, 
+          annotations, tools and methods. Its goal is to enable genomic 
+          science by providing high-quality, integrated and consistent 
+          annotation on all cellular genomes within a harmonious, scalable 
+          and accessible infrastructure.</p>
         [[SCRIPT::EnsEMBL::Web::Document::HTML::WhatsNew]]
       </div>
     </div>

--- a/ensembl/htdocs/info/index.html
+++ b/ensembl/htdocs/info/index.html
@@ -72,13 +72,6 @@ other command-line scripts</li>
 </td>
 
 </tr>
-<tr>
-<td colspan="2">
-<h2 class="first"><a href="/info/about/">About us</a></h2>
-<p>Ensembl is a project to develop a software system which produces and maintains automatic annotation on selected eukaryotic genomes.</p>
-<p style="text-align:right;padding-right:2em;"><a href="/info/about/">More...</a></p>
-</td>
-</tr>
 </table>
 
 </body>


### PR DESCRIPTION
- Replacing home page text about Ensembl with the agreed text
- Removal of additional descriptions of mission instead relying on the about page to convey this