### PR TITLE
Enhancement/ajax calls

### DIFF
--- a/tools/htdocs/components/10_Masthead_Tools.js
+++ b/tools/htdocs/components/10_Masthead_Tools.js
@@ -19,6 +19,14 @@
 
 Ensembl.Panel.Masthead = Ensembl.Panel.Masthead.extend({
 
+  toolsJobStateKey: 'ensembl.hasToolsJobs',
+
+  constructor: function (id) {
+    this.base(id);
+
+    Ensembl.EventManager.register('toolsRefreshMasthead', this, this.refreshToolsTab);
+  },
+
   init: function () {
     this.base();
 
@@ -28,11 +36,53 @@ Ensembl.Panel.Masthead = Ensembl.Panel.Masthead.extend({
     this.recentJobs = $.makeArray(this.elLk.toolsDropdown.find('li a').map(function(i, el) { return (el.href.match(/tl\=([a-z0-9_\-]+)/i) || []).pop() || null; }));
     this.fetchURL   ='/' + (Ensembl.species || 'Multi') + '/Ajax/tools_tab';
 
-    if (this.elLk.toolsTabs.length) {
+    if (this.elLk.toolsTabs.length && this.shouldFetchToolsTab()) {
       this.fetchToolsTab();
     }
   },
+
+  shouldFetchToolsTab: function() {
+    return this.hasToolsJobState() || this.hasRecentJobs() || this.hasCurrentToolsPage() || !!(Ensembl.coreParams && Ensembl.coreParams['tl']);
+  },
+
+  hasRecentJobs: function() {
+    return this.recentJobs && this.recentJobs.length;
+  },
+
+  hasCurrentToolsPage: function() {
+    return this.elLk.toolsTabs.filter('.final').length;
+  },
+
+  hasToolsJobState: function() {
+    try {
+      return window.localStorage && window.localStorage.getItem(this.toolsJobStateKey) === '1';
+    } catch(e) {
+      return false;
+    }
+  },
+
+  setToolsJobState: function(flag) {
+    try {
+      if (window.localStorage) {
+        if (flag) {
+          window.localStorage.setItem(this.toolsJobStateKey, '1');
+        } else {
+          window.localStorage.removeItem(this.toolsJobStateKey);
+        }
+      }
+    } catch(e) {}
+  },
   
+  refreshToolsTab: function(force, hasJobs) {
+    if (typeof hasJobs === 'boolean') {
+      this.setToolsJobState(hasJobs);
+    }
+
+    if (this.elLk.toolsTabs.length && (force || this.shouldFetchToolsTab())) {
+      this.fetchToolsTab();
+    }
+  },
+
   fetchToolsTab: function() {
     var panel = this;
 
@@ -51,10 +101,12 @@ Ensembl.Panel.Masthead = Ensembl.Panel.Masthead.extend({
   populateToolsTab: function(response) {
 
     if (response.empty) {
+      this.setToolsJobState(false);
 
       this.elLk.toolsTabs.find('a:not(:first-child)').remove().end().find('.dropdown').removeClass('dropdown');
 
     } else {
+      this.setToolsJobState(true);
 
       this.elLk.toolsTabs.filter(':not(.final)').addClass('final').find('a:first-child').html(response.caption).attr('href', response.url);
       this.elLk.toolsDropdown.find('ul.recent').remove().end().find('h4').first().html('Recent jobs').after($('<ul>').append($.map(response.tools, function(details, tool) {

--- a/tools/htdocs/components/10_Masthead_Tools.js
+++ b/tools/htdocs/components/10_Masthead_Tools.js
@@ -42,6 +42,8 @@ Ensembl.Panel.Masthead = Ensembl.Panel.Masthead.extend({
   },
 
   shouldFetchToolsTab: function() {
+    // The species-scoped */Ajax/tools_tab request checks private ticket state in
+    // the tools DB, so only make it when this browser is likely to have jobs.
     return this.hasToolsJobState() || this.hasRecentJobs() || this.hasCurrentToolsPage() || !!(Ensembl.coreParams && Ensembl.coreParams['tl']);
   },
 
@@ -62,6 +64,8 @@ Ensembl.Panel.Masthead = Ensembl.Panel.Masthead.extend({
   },
 
   setToolsJobState: function(flag) {
+    // The ajax response confirms whether this browser still needs eager tools tab
+    // refreshes on non-Tools pages.
     try {
       if (window.localStorage) {
         if (flag) {

--- a/tools/htdocs/components/11_ContentTools.js
+++ b/tools/htdocs/components/11_ContentTools.js
@@ -106,6 +106,9 @@ Ensembl.Panel.ContentTools = Ensembl.Panel.Content.extend({
       if (methodName in this) {
         this[methodName].apply(this, json.panelMethod);
         json.panelMethod.unshift(methodName);
+        if (methodName === 'refresh') {
+          Ensembl.EventManager.trigger('toolsRefreshMasthead', true);
+        }
         return 'method_applied';
       }
 

--- a/tools/htdocs/components/11_ContentTools.js
+++ b/tools/htdocs/components/11_ContentTools.js
@@ -106,6 +106,8 @@ Ensembl.Panel.ContentTools = Ensembl.Panel.Content.extend({
       if (methodName in this) {
         this[methodName].apply(this, json.panelMethod);
         json.panelMethod.unshift(methodName);
+        // Save/delete responses use refresh(), so re-check the masthead job tab
+        // state after they change ticket ownership or remove jobs.
         if (methodName === 'refresh') {
           Ensembl.EventManager.trigger('toolsRefreshMasthead', true);
         }

--- a/tools/htdocs/components/15_ToolsForm.js
+++ b/tools/htdocs/components/15_ToolsForm.js
@@ -172,6 +172,8 @@ Ensembl.Panel.ToolsForm = Ensembl.Panel.ContentTools.extend({
   /*
    * Method called once ticket is successfully submitted via AJAX
    */
+    // Set the tools-tab hint immediately so later non-Tools pages can show Jobs
+    // without probing */Ajax/tools_tab for users who never submit jobs.
     Ensembl.EventManager.trigger('toolsRefreshMasthead', true, true);
     Ensembl.EventManager.trigger('toolsRefreshActivitySummary', true, true, false);
     this.toggleForm(false, true);

--- a/tools/htdocs/components/15_ToolsForm.js
+++ b/tools/htdocs/components/15_ToolsForm.js
@@ -172,6 +172,7 @@ Ensembl.Panel.ToolsForm = Ensembl.Panel.ContentTools.extend({
   /*
    * Method called once ticket is successfully submitted via AJAX
    */
+    Ensembl.EventManager.trigger('toolsRefreshMasthead', true, true);
     Ensembl.EventManager.trigger('toolsRefreshActivitySummary', true, true, false);
     this.toggleForm(false, true);
   },

--- a/users/htdocs/components/10_Masthead_Users.js
+++ b/users/htdocs/components/10_Masthead_Users.js
@@ -108,6 +108,8 @@ Ensembl.Panel.Masthead = Ensembl.Panel.Masthead.extend({
       return;
     }
 
+    // Keep /Ajax/accounts_dropdown off the initial page load. Normal use fetches
+    // it on first open; force is reserved for account modal updates.
     this.cacheAccountsForm();
 
     if (!this.accountsRefreshURL) {

--- a/users/htdocs/components/10_Masthead_Users.js
+++ b/users/htdocs/components/10_Masthead_Users.js
@@ -27,71 +27,166 @@ Ensembl.Panel.Masthead = Ensembl.Panel.Masthead.extend({
   init: function () {
     this.base();
     
-    this.elLk.accountHolder   = this.el.find('div._account_holder');
+    this.elLk.accountHolder = this.el.find('div._account_holder');
 
-    this.accountsRefreshURL   = '';
-    this.accountsBookmarkData = '';
+    this.accountsRefreshURL        = '';
+    this.accountsBookmarkData      = '';
+    this.accountsDropdownLoaded    = false;
+    this.accountsDropdownLoading   = false;
+    this.accountsDropdownCallbacks = [];
     
-    this.refreshAccountsDropdown();
+    this.bindAccountsDropdown();
   },
   
-  refreshAccountsDropdown: function() {
-    var panel = this;
-    
-    if (this.elLk.accountHolder.length && !this.elLk.accountHolder.find('._accounts_no_user').length) {
-    
-      var hideDropdown = function(e) {
-        if (!e.which || e.which === 1) {
-          panel.toggleAccountsDropdown(false);
-          $(document).off('click', hideDropdown);
-        }
-      }
-      
-      if (!this.accountsRefreshURL) {
-        var form = this.elLk.accountHolder.find('form');
-        this.accountsRefreshURL   = form.attr('action');
-        this.accountsBookmarkData = form.serialize();
-      }
-      
-      $.ajax({
-        'url': this.accountsRefreshURL,
-        'context': this,
-        'data': this.accountsBookmarkData,
-        'type': 'POST',
-        'success': function(html) {
-          this.elLk.accountHolder.html(html);
-          this.elLk.accountLink = this.el.find('._accounts_link').on({
-            'click': function(event) {
-              event.preventDefault();
-              if (!$(this).hasClass('selected')) {
-                event.stopPropagation();
-                panel.toggleAccountsDropdown(true);
-                $(document).on('click', hideDropdown);
-              }
-            }
-          });
-          
-          this.elLk.accountDropdown = this.el.find('._accounts_dropdown').on({
-            'click': function(event) {
-              if (event.target.nodeName !== 'A' && event.target.parentNode.nodeName !== 'A') {
-                event.stopPropagation();
-              }
-            }
-          }).find('a').on('click', hideDropdown).end();
-          
-          this.elLk.accountHolder.find('._accounts_no_userdb').helptip().on({
-            'click': function(event) {
-              event.preventDefault();
-            }
-          });
-          
-        },
-        'dataType': 'html'
-      });
+  cacheAccountsForm: function() {
+    var form = this.elLk.accountHolder.find('form');
+
+    if (form.length) {
+      this.accountsRefreshURL   = form.attr('action');
+      this.accountsBookmarkData = form.serialize();
     }
   },
-  
+
+  bindAccountsDropdown: function() {
+    var panel = this;
+
+    if (!this.elLk.accountHolder.length) {
+      return;
+    }
+
+    this.cacheAccountsForm();
+
+    this.elLk.accountLink = this.elLk.accountHolder.find('._accounts_link').off('.accountsDropdown').on({
+      'click.accountsDropdown': function(event) {
+        event.preventDefault();
+
+        if (!$(this).hasClass('selected')) {
+          event.stopPropagation();
+          panel.showAccountsDropdown();
+        }
+      },
+      'focus.accountsDropdown': function() {
+        panel.loadAccountsDropdown();
+      }
+    });
+
+    this.elLk.accountDropdown = this.elLk.accountHolder.find('._accounts_dropdown').off('.accountsDropdown').on({
+      'click.accountsDropdown': function(event) {
+        if (event.target.nodeName !== 'A' && event.target.parentNode.nodeName !== 'A') {
+          event.stopPropagation();
+        }
+      }
+    }).find('a').off('.accountsDropdown').on('click.accountsDropdown', function(e) {
+      panel.hideAccountsDropdown(e);
+    }).end();
+
+    this.accountsDropdownLoaded = this.elLk.accountDropdown.length && $.trim(this.elLk.accountDropdown.html()).length ? true : false;
+
+    this.elLk.accountHolder.find('._accounts_no_userdb').helptip().off('.accountsDropdown').on({
+      'click.accountsDropdown': function(event) {
+        event.preventDefault();
+      }
+    });
+  },
+
+  loadAccountsDropdown: function(callback, force) {
+    if ($.isFunction(callback)) {
+      this.accountsDropdownCallbacks.push(callback);
+    }
+
+    if (!this.elLk.accountHolder.length || (!force && this.elLk.accountHolder.find('._accounts_no_user').length)) {
+      this.accountsDropdownCallbacks = [];
+      return;
+    }
+
+    if (this.accountsDropdownLoaded && !force) {
+      this.runAccountsDropdownCallbacks();
+      return;
+    }
+
+    if (this.accountsDropdownLoading) {
+      return;
+    }
+
+    this.cacheAccountsForm();
+
+    if (!this.accountsRefreshURL) {
+      this.accountsRefreshURL = '/Ajax/accounts_dropdown';
+    }
+
+    this.accountsDropdownLoading = true;
+
+    $.ajax({
+      'url': this.accountsRefreshURL,
+      'context': this,
+      'data': this.accountsBookmarkData,
+      'type': 'POST',
+      'success': function(html) {
+        var response = $('<div>').html(html);
+        var accountDropdown = response.find('._accounts_dropdown');
+
+        if (!force && accountDropdown.length && this.elLk.accountHolder.find('._accounts_link').length) {
+          this.elLk.accountHolder.find('._accounts_dropdown').replaceWith(accountDropdown);
+        } else {
+          this.elLk.accountHolder.html(html);
+          this.elLk.accountHolder.toggleClass('_logged_in', this.elLk.accountHolder.find('._accounts_link').length ? true : false);
+        }
+
+        this.bindAccountsDropdown();
+        this.runAccountsDropdownCallbacks();
+      },
+      'error': function() {
+        this.accountsDropdownCallbacks = [];
+      },
+      'complete': function() {
+        this.accountsDropdownLoading = false;
+      },
+      'dataType': 'html'
+    });
+  },
+
+  refreshAccountsDropdown: function(callback) {
+    this.loadAccountsDropdown($.isFunction(callback) ? callback : null, true);
+  },
+
+  runAccountsDropdownCallbacks: function() {
+    var callback;
+
+    while (this.accountsDropdownCallbacks.length) {
+      callback = this.accountsDropdownCallbacks.shift();
+      callback.call(this);
+    }
+  },
+
+  showAccountsDropdown: function() {
+    var panel = this;
+
+    if (!this.accountsDropdownLoaded) {
+      this.loadAccountsDropdown(function() {
+        panel.showAccountsDropdown();
+      });
+      return;
+    }
+
+    this.toggleAccountsDropdown(true);
+
+    $(document).off('click.accountsDropdown').on('click.accountsDropdown', function(e) {
+      panel.hideAccountsDropdown(e);
+    });
+  },
+
+  hideAccountsDropdown: function(e) {
+    if (!e || !e.which || e.which === 1) {
+      this.toggleAccountsDropdown(false);
+      $(document).off('click.accountsDropdown');
+    }
+  },
+
   toggleAccountsDropdown: function(flag) {
+    if (!this.elLk.accountLink.length || !this.elLk.accountDropdown.length) {
+      return;
+    }
+
     this.elLk.accountLink.toggleClass('selected', flag);
     this.elLk.accountDropdown.toggle(flag);
     if (flag && !this.elLk.accountDropdown.data('initiated')) {

--- a/users/modules/EnsEMBL/Web/Document/Element/AccountLinks.pm
+++ b/users/modules/EnsEMBL/Web/Document/Element/AccountLinks.pm
@@ -22,11 +22,12 @@ package EnsEMBL::Web::Document::Element::AccountLinks;
 use strict;
 
 ### TODO add shared bookmarks from group
-### TODO limit total number of bookmarks shown
 ### TODO show bookmarks from current site only
 ### TODO order bookmarks by priority
 
 use HTML::Entities qw(encode_entities);
+
+use constant ACCOUNT_DROPDOWN_BOOKMARK_LIMIT => 5;
 
 sub init {
   my ($self, $controller) = @_;
@@ -42,11 +43,12 @@ sub init {
 sub content {
   my $self  = shift;
   my $hub   = $self->hub;
+  my $user  = $hub->user;
+  my $html  = $user
+    ? sprintf('%s<div class="_accounts_dropdown accounts-dropdown"></div>', $self->_account_link($user))
+    : $self->_anonymous_link($hub->users_available);
 
-  return sprintf('<div class="_account_holder%s"><div class="account-loading">Loading&hellip;</div><form action="/Ajax/accounts_dropdown">%s</form></div>', $hub->user
-    ? (' _logged_in', join('', map sprintf('<input type="hidden" name="%s" value="%s" />', $_, encode_entities($self->{'_bookmark_data'}{$_})), keys %{$self->{'_bookmark_data'}}))
-    : ('', '')
-  );
+  return sprintf('<div class="_account_holder%s">%s%s</div>', $user ? ' _logged_in' : '', $html, $self->_bookmark_form);
 }
 
 sub content_ajax {
@@ -55,6 +57,8 @@ sub content_ajax {
   my $users_available = $hub->users_available;
   my $user            = $users_available ? $hub->user : undef;
   my $bookmarks       = $user ? $user->bookmarks : [];
+  my @display_bookmarks = @$bookmarks;
+  splice @display_bookmarks, ACCOUNT_DROPDOWN_BOOKMARK_LIMIT if @display_bookmarks > ACCOUNT_DROPDOWN_BOOKMARK_LIMIT;
 
   my $manage_link;
   my $site = $hub->species_defs->ENSEMBL_ACCOUNTS_SITE;
@@ -66,7 +70,7 @@ sub content_ajax {
   }
 
   return $user
-    ? sprintf('<a class="constant _accounts_link account-link" href="%s"><span class="acc-email">%s</span><span class="acc-arrow"><span>&#9660;</span><span class="selected">&#9650;</span></a>
+    ? sprintf('%s
         <div class="_accounts_dropdown accounts-dropdown">
           <h4>Bookmarks</h4>
           <div>%s</div>%s
@@ -76,14 +80,13 @@ sub content_ajax {
             <p><strong><a href="%s" class="constant">Logout</a></strong></p>
           </div>
         </div>',
-        $hub->PREFERENCES_PAGE,
-        $user->email,
+        $self->_account_link($user),
         join('', map {
           sprintf '<p><a href="%s" title="%s: %s" class="constant"><span>%2$s</span><span class="acc-bookmark-overflow">&#133;</span></a></p>',
             $hub->url({'type' => 'Account', 'action' => 'Bookmark', 'function' => 'Use', 'id' => $_->record_id, '__clear' => 1}),
             $_->name,
             $_->url
-        } @$bookmarks) || '<p><i>No bookmark added</i></p>',
+        } @display_bookmarks) || '<p><i>No bookmark added</i></p>',
         sprintf('
           <div>
             <p><a href="%s" class="modal_link constant">Bookmark this page</a></p>'. ( @$bookmarks ?
@@ -100,11 +103,35 @@ sub content_ajax {
         $manage_link,
         $hub->url({qw(type Account action Logout)})
       )
-    : sprintf('<a class="constant account-link _accounts_no_user%s" href="%s" title="%s">Login/Register</a>', $users_available
-      ? (' modal_link', $self->hub->url({qw(type Account action Login)}), 'Login/Register')
-      : (' _accounts_no_userdb', '#', 'User accounts are temporarily unavailable.')
-    )
+    : $self->_anonymous_link($users_available)
   ;
+}
+
+sub _account_link {
+  my ($self, $user) = @_;
+
+  return sprintf('<a class="constant _accounts_link account-link" href="%s"><span class="acc-email">%s</span><span class="acc-arrow"><span>&#9660;</span><span class="selected">&#9650;</span></span></a>',
+    $self->hub->PREFERENCES_PAGE,
+    encode_entities($user->email)
+  );
+}
+
+sub _anonymous_link {
+  my ($self, $users_available) = @_;
+
+  return sprintf('<a class="constant account-link _accounts_no_user%s" href="%s" title="%s">Login/Register</a>', $users_available
+    ? (' modal_link', $self->hub->url({qw(type Account action Login)}), 'Login/Register')
+    : (' _accounts_no_userdb', '#', 'User accounts are temporarily unavailable.')
+  );
+}
+
+sub _bookmark_form {
+  my $self          = shift;
+  my $bookmark_data = $self->{'_bookmark_data'} || {};
+
+  return sprintf('<form action="/Ajax/accounts_dropdown" style="display:none">%s</form>',
+    join('', map sprintf('<input type="hidden" name="%s" value="%s" />', $_, encode_entities($bookmark_data->{$_})), keys %$bookmark_data)
+  );
 }
 
 1;

--- a/users/modules/EnsEMBL/Web/Document/Element/AccountLinks.pm
+++ b/users/modules/EnsEMBL/Web/Document/Element/AccountLinks.pm
@@ -44,6 +44,9 @@ sub content {
   my $self  = shift;
   my $hub   = $self->hub;
   my $user  = $hub->user;
+
+  ## Avoid a /Ajax/accounts_dropdown request on every page view. Render the stable
+  ## account link now, and let the JS fetch user-specific dropdown contents lazily.
   my $html  = $user
     ? sprintf('%s<div class="_accounts_dropdown accounts-dropdown"></div>', $self->_account_link($user))
     : $self->_anonymous_link($hub->users_available);
@@ -57,6 +60,9 @@ sub content_ajax {
   my $users_available = $hub->users_available;
   my $user            = $users_available ? $hub->user : undef;
   my $bookmarks       = $user ? $user->bookmarks : [];
+
+  ## The masthead only needs a short preview; the full list remains available from
+  ## the account page, and limiting it keeps the lazy endpoint cheap.
   my @display_bookmarks = @$bookmarks;
   splice @display_bookmarks, ACCOUNT_DROPDOWN_BOOKMARK_LIMIT if @display_bookmarks > ACCOUNT_DROPDOWN_BOOKMARK_LIMIT;
 


### PR DESCRIPTION
## Summary

This PR reduces unnecessary masthead AJAX traffic by lazy-loading account dropdown content and only refreshing the tools Jobs tab when the browser is likely to have tools activity.

## Changes

- Lazily load `/Ajax/accounts_dropdown` when the account dropdown is first opened or focused, instead of requesting it on every page load.
- Render the stable account/login link server-side so the masthead remains usable before dropdown content is fetched.
- Add account dropdown loading/caching state, callback handling, namespaced event bindings, and forced refresh support for account modal updates.
- Limit the masthead bookmark preview to 5 entries while keeping full bookmark management available from the account page.
- Avoid eager `*/Ajax/tools_tab` requests unless there are recent/current tools jobs, a `tl` parameter, or a persisted browser hint.
- Store a lightweight `ensembl.hasToolsJobs` localStorage hint so later non-Tools pages can show Jobs without probing users who have never submitted jobs.
- Refresh the tools masthead after ticket submission and after tools save/delete refresh responses.

## Testing

Manual testing recommended:

- Confirm logged-out users see the Login/Register link without an initial accounts dropdown AJAX request.
- Confirm logged-in users see the account link immediately and dropdown content loads on first open/focus.
- Confirm account dropdown links still work for bookmarks, account details, manage bookmarks, and logout.
- Confirm submitting a tools job updates the Jobs tab and persists the tools-job hint.
- Confirm deleting/saving tools jobs refreshes the masthead state correctly.
- Confirm users with no tools jobs do not trigger unnecessary tools-tab AJAX calls on unrelated pages.
