### PR TITLE
Replace larger images with placeholder in species tree view

### DIFF
--- a/ensembl/conf/SiteDefs.pm
+++ b/ensembl/conf/SiteDefs.pm
@@ -39,6 +39,9 @@ sub update_conf {
   $SiteDefs::HAS_ANNOTATION             = 1;
   $SiteDefs::HAS_VIRTUAL_MACHINE        = 1;
 
+  # Max number of characters for base64-encoded images in species tree view.
+  $SiteDefs::BASE64_MAX_SIZE            = 1_000_000;
+
   $SiteDefs::ENSEMBL_TAXONOMY_DIVISION_FILE  = $SiteDefs::ENSEMBL_SERVERROOT.'/public-plugins/ensembl/conf/taxon_tree.json';
 
 ## This array is used to configure the species available in this

--- a/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
+++ b/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
@@ -88,6 +88,7 @@ sub render {
   $tree_details->{'default_tree'} = $mlss->has_tag('default_tree') ? $mlss->get_value_for_tag('default_tree') : (keys %{$tree_details->{'trees'}})[0];
  
   # Go through all the nodes of all the trees and get the tooltip info
+  my $default_image;
   my $lookup = $hub->species_defs->prodnames_to_urls_lookup;
   foreach my $tree (@$all_trees) {
    my %ref_genome_2_internal_info;
@@ -114,6 +115,21 @@ sub render {
           my $content = read_file($sp_icon);
           if ($content) {
             $sp->{icon} = 'data:image/png;base64,'.encode_base64($content);
+          }
+
+          if (length($sp->{icon}) > 1_000_000) {  # We assume one million characters is sufficient for a species-tree species image.
+            if (defined $default_image) {
+              $sp->{icon} = $default_image;
+            } else {
+              my $default_icon = $species_defs->ENSEMBL_WEBROOT . '/../public-plugins/docs/htdocs/img/e_bang.png';
+              if (file_exists($default_icon, {'no_exception' => 1})) {
+                my $default_content = read_file($default_icon);
+                if ($default_content) {
+                  $default_image = 'data:image/png;base64,'.encode_base64($default_content);
+                }
+              }
+              $sp->{icon} = $default_image;
+            }
           }
         }
         else {

--- a/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
+++ b/widgets/modules/EnsEMBL/Web/Document/HTML/Compara/SpeciesTree.pm
@@ -117,7 +117,7 @@ sub render {
             $sp->{icon} = 'data:image/png;base64,'.encode_base64($content);
           }
 
-          if (length($sp->{icon}) > 1_000_000) {  # We assume one million characters is sufficient for a species-tree species image.
+          if ($species_defs->BASE64_MAX_SIZE && length($sp->{icon}) > $species_defs->BASE64_MAX_SIZE) {
             if (defined $default_image) {
               $sp->{icon} = $default_image;
             } else {


### PR DESCRIPTION
This PR would replace larger images with a placeholder in the species tree view, ensuring memory usage would be kept within reasonable limits.

Example: [sandbox](http://wp-np2-35.ebi.ac.uk:5092/info/about/speciestree.html) vs [live site](https://www.ensembl.org/info/about/speciestree.html)