### PR TITLE
fix: swap dead cache FTP path for working one

### DIFF
--- a/docs/htdocs/info/docs/tools/vep/script/vep_download.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_download.html
@@ -1618,7 +1618,7 @@ docker run -t -i -v $HOME/vep_data:/data ensemblorg/ensembl-vep INSTALL.pl -a c
 
 # Or install the cache manually
 cd $HOME/vep_data
-curl -O [[SPECIESDEFS::ENSEMBL_FTP_URL]]/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/vep/homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz
+curl -O [[SPECIESDEFS::ENSEMBL_FTP_URL]]/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/indexed_vep_cache/homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz
 tar xzf homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz</pre>
   </li>
 </ol>
@@ -1686,7 +1686,7 @@ singularity exec vep.sif INSTALL.pl -c $HOME/vep_data -a c
 
 # Or install the cache manually
 cd $HOME/vep_data
-curl -O [[SPECIESDEFS::ENSEMBL_FTP_URL]]/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/vep/homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz
+curl -O [[SPECIESDEFS::ENSEMBL_FTP_URL]]/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/indexed_vep_cache/homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz
 tar xzf homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz</pre>
   </li>
 </ol>

--- a/docs/htdocs/info/docs/tools/vep/script/vep_tutorial.html
+++ b/docs/htdocs/info/docs/tools/vep/script/vep_tutorial.html
@@ -101,7 +101,7 @@ The following species/files are available; which do you want (can specify multip
     [species]</a>. </p>
     
     <pre class="code sh_sh">? 42
- - downloading [[SPECIESDEFS::ENSEMBL_FTP_URL]]/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/vep/homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz
+ - downloading [[SPECIESDEFS::ENSEMBL_FTP_URL]]/release-[[SPECIESDEFS::ENSEMBL_VERSION]]/variation/indexed_vep_cache/homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz
  - unpacking homo_sapiens_vep_[[SPECIESDEFS::ENSEMBL_VERSION]]_GRCh38.tar.gz
 
 Success</pre>


### PR DESCRIPTION
Arising from issue https://github.com/Ensembl/ensembl-vep/issues/2024

A user highlighted that the VEP cache download commands on [this page](https://www.ensembl.org/info/docs/tools/vep/script/vep_download.html) point to the wrong FTP path.

Points to https://ftp.ensembl.org/pub/release-116/variation/vep/homo_sapiens_vep_116_GRCh38.tar.gz, but should be https://ftp.ensembl.org/pub/release-116/variation/indexed_vep_cache/homo_sapiens_vep_116_GRCh38.tar.gz, this PR makes this correction.

<img width="861" height="179" alt="Screenshot 2026-07-07 at 16 03 32" src="https://github.com/user-attachments/assets/b18ad335-374c-4a8e-8d81-0da59578bb0a" />

